### PR TITLE
docs: slim README landing page, move details into docs/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & run
+
+```bash
+# Configure and build (both backends)
+cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_MGR="dpdk rdma"
+cmake --build build -j
+cmake --install build --prefix /opt/daqiri
+
+# Container build (compiles patched DPDK from source)
+BASE_TARGET=dpdk DAQIRI_MGR="dpdk rdma" scripts/build-container.sh
+```
+
+CMake options (see `docs/getting-started.md` for the full table):
+- `DAQIRI_MGR` — space-separated backend list. Valid values: `dpdk`, `rdma`.
+- `DAQIRI_BUILD_PYTHON` — builds `pybind11` bindings from `python/`.
+- `DAQIRI_BUILD_EXAMPLES` — builds the two benchmark executables.
+
+CUDA architectures are hardcoded to `80;90` (A100, H100) in `src/CMakeLists.txt:25`. Change this when targeting other GPUs.
+
+## Benchmarks (the "tests")
+
+There is no unit test suite. Verification is done via the benchmark executables in `examples/`, driven by YAML configs:
+
+```bash
+./build/examples/daqiri_bench_default examples/daqiri_bench_default_tx_rx.yaml
+./build/examples/daqiri_bench_rdma    examples/daqiri_bench_rdma_tx_rx.yaml
+```
+
+Example YAML files contain `<angle-bracket>` placeholders (PCIe addresses, CPU cores, IPs) that **must** be replaced for your system. `daqiri_bench_default_sw_loopback.yaml` requires no physical link and is the fastest way to smoke-test a build.
+
+## Formatting
+
+`clang-format` is required for contributions (CONTRIBUTING.md):
+
+```bash
+git-clang-format --style file              # format staged changes
+clang-format -style=file -i -fallback-style=none <files>
+```
+
+## Architecture
+
+**Single C++/CUDA shared library** (`libdaqiri.so`) exposing a C++ API declared in `src/common.h`. The public surface is intentionally flat free-function helpers (`get_rx_burst`, `get_packet_ptr`, `set_udp_header`, …) that all operate on an opaque `BurstParams*`. Applications never touch backend types directly.
+
+### Manager abstraction
+`src/manager.h` defines `daqiri::Manager` — an (almost) ABC with ~50 virtual methods covering init, RX/TX burst dequeue/enqueue, header-fill helpers, buffer free, and RDMA connection setup. Backends live in `src/managers/<name>/` and are selected at CMake configure time via `DAQIRI_MGR`. Each backend produces its own static library (`daqiri_dpdk`, `daqiri_rdma`) linked into `daqiri_common`, and each adds a `DAQIRI_MGR_<NAME>=1` compile definition.
+
+`ManagerFactory` (also in `manager.h`) is a singleton that instantiates the active backend. `daqiri_init(...)` resolves which backend to use from the `NetworkConfig` and then delegates everything through the `Manager` vtable. There is only ever **one** active `Manager` per process.
+
+### Zero-copy / BurstParams
+All packet data flows through `BurstParams`, a batch of packets. Only pointers are passed between NIC, DAQIRI internals, and the application — the caller reads directly from the buffers the NIC DMA'd into. **The caller must explicitly free bursts**; a missed free drains the pool and produces `NO_FREE_BURST_BUFFERS` / `NO_FREE_PACKET_BUFFERS` errors and NIC drops. See `docs/api-guide.md`.
+
+### Segments & HDS
+A single packet can span multiple **segments** (contiguous memory regions), each in CPU or GPU memory. The header-data split (HDS) mode puts headers in segment 0 (CPU) and payload in segment 1 (GPU), enabling GPUDirect zero-copy payload paths. Batched-GPU and CPU-only modes use a single segment.
+
+### DPDK is load-bearing for the common library
+`src/manager.h` and `src/common.cpp` use `rte_ring` / `rte_mbuf` directly, so **DPDK is a build dependency of `daqiri_common` even when building only the RDMA backend**. The container build uses patched DPDK from `dpdk_patches/` (`dmabuf.patch`, `dpdk.nvidia.patch`) — the `dmabuf` patch removes the peermem kernel-module requirement for GPUDirect.
+
+### Third-party dependencies
+Vendored under `third_party/` as submodules (`.gitmodules`): `yaml-cpp` (config parser) and `spdlog` (logging). CMake prefers these over system copies. Missing them is a fatal error.
+
+### Current limitations
+- Only UDP fill mode is supported for TX (see README).
+- No CI yet — contributors and reviewers verify manually (CONTRIBUTING.md).
+
+## Contribution rules
+
+From `CONTRIBUTING.md`:
+- **DCO sign-off required** — every commit must have `Signed-off-by:` (use `git commit -s`). Unsigned commits will be rejected.
+- Commit titles in imperative mood, prefixed with the GitHub issue number: `#<Issue Number> - <Title>`.
+- An issue must exist and be approved before coding.
+- Prefer toggling features via new CMake options (with backward-compatible defaults) rather than wrapping entire files in `#if` guards. Use `#if` only for minor in-file changes.
+- Keep PRs narrowly scoped — one concern per PR, dependencies noted in the description.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,40 @@
 # DAQIRI networking library
 
+**From wire to GPU at line rate.** DAQIRI bypasses the Linux kernel to move raw sensor data directly into GPU memory at hundreds of gigabits per second.
+
 > [!WARNING]
 > The library is undergoing large improvements as we aim to better support it as an NVIDIA product.
 > API breakages might be more frequent until we reach version 1.0.
-> [!TIP]
-> Review the [High Performance Networking tutorial](/tutorials/high_performance_networking/README.md) for guided
-> instructions to configure your system and test the DAQIRI library.
 
-The DAQIRI library provides a way for users to achieve the highest throughput and lowest latency
-for transmitting and receiving Ethernet frames. Direct access to the NIC hardware
-is available in userspace, thus bypassing the kernel's networking stack entirely.
+DAQIRI provides direct NIC hardware access in userspace, bypassing the Linux kernel
+network stack to achieve the highest possible throughput and lowest latency for Ethernet
+frame transmission and reception. It targets NVIDIA ConnectX-6 Dx and later NICs and
+supports GPU direct memory access (GPUDirect) for zero-copy data paths between the NIC
+and GPU.
 
-## Build quickstart
+## Features
+
+- **High Throughput** — Hundreds of gigabits per second with proper hardware and tuning.
+- **Low Latency** — Direct access to NIC ring buffers; most latency is PCIe transit only.
+- **GPUDirect** — Receive data directly into GPU memory via two modes:
+  - *Header-data split*: Headers to CPU, payload to GPU (recommended for most workloads).
+  - *Batched GPU*: Entire packets to GPU memory (maximum bandwidth, GPU-side parsing required).
+- **Flow Steering** — Configure the NIC's hardware flow engine to route packets by UDP
+  source/destination port.
+- **RDMA** — InfiniBand RDMA operations (READ, WRITE, SEND) via the RDMA backend.
+
+### Backends
+
+| Backend | Config value | Description |
+|---------|-------------|-------------|
+| DPDK | `dpdk` (default) | Userspace packet processing with DPDK mbufs and rings. |
+| RDMA | `rdma` | InfiniBand RDMA via libibverbs (client/server model). |
+
+### Limitations
+
+- Only UDP fill mode is currently supported.
+
+## Quick Start
 
 ```bash
 cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_MGR="dpdk rdma"
@@ -19,536 +42,24 @@ cmake --build build -j
 cmake --install build --prefix /opt/daqiri
 ```
 
-Container build helper:
+Container build:
 
 ```bash
 BASE_TARGET=dpdk DAQIRI_MGR="dpdk rdma" scripts/build-container.sh
 ```
 
-## Requirements
+See [Getting Started](docs/getting-started.md) for requirements, CMake options, and
+running the benchmarks.
 
-- Linux
-- An NVIDIA NIC with a ConnectX6-Dx or later chip
-- System tuning as described in the [High Performance Networking tutorial](/tutorials/high_performance_networking/README.md)
-- For DPDK, Rivermax: MLNX5/IB drivers with peermem support - either through:
-  - Inbox (i.e. standard) drivers on Ubuntu kernel versions >= 5.4 and [< 6.8](https://discourse.ubuntu.com/t/nvidia-gpudirect-over-infiniband-migration-paths/44425), or
-  - NVIDIA optimized kernels (IGX OS, DGX BaseOS), or
-  - OFED drivers from [DOCA-Host](https://developer.nvidia.com/doca-archive) 2.8 or later (install the `mlnx-ofed-kernel-dkms` package or the `doca-ofed` meta-package for extra tooling), or
-  - _(deprecated)_ OFED drivers from [MOFED](https://network.nvidia.com/products/infiniband-drivers/linux/mlnx_ofed/) 23.10 or later (`sudo ./mlnxofedinstall --kernel-only`).
-- For GPUNetIO:
-  - The [GDRCopy `gdrdrv` kernel module](https://docs.nvidia.com/doca/sdk/doca-gpunetio/index.html#src-4410845379_id-.DOCAGPUNetIOv3.2.0LC-GDRCopyInstallation) must be loaded on the bare-metal system.
-  - DOCA-OFED drivers from [DOCA-Host](https://developer.nvidia.com/doca-archive) 3.2.1 or later (install the `doca-ofed` package).
+## Documentation
 
-> User-space libraries are included in the [Dockerfile](./Dockerfile) for each networking backend. Inspect this file if you wish to know what is needed to build and run on baremetal instead.
+| Document | Description |
+|----------|-------------|
+| [Getting Started](docs/getting-started.md) | Build, install, system requirements, benchmarks |
+| [Configuration Reference](docs/configuration.md) | Full YAML config reference for all backends |
+| [API Guide](docs/api-guide.md) | BurstParams, RX/TX workflows, buffer lifecycle, status codes |
+| [Contributing](CONTRIBUTING.md) | Contribution guidelines, coding standards, DCO sign-off |
 
-## Features
+## License
 
-- **High Throughput**: Hundreds of gigabits per second is possible with the proper hardware
-- **Low Latency**: With direct access to the NIC's ring buffers, most latency incurred is only PCIe latency
-  - Since the kernel's networking stack is bypassed, the user is responsible for defining the protocols used
-  over the network. In most cases Ethernet, IP, and UDP are ideal for this type of processing because of their
-  simplicity, but any type of protocol can be implemented or used. The DAQIRI library
-  gives the option to use several primitives to remove the need for filling out these headers for basic packet types,
-  but raw headers can also be constructed.
-- **GPUDirect**: Optionally send data directly from the NIC to GPU, or directly from the GPU to NIC. GPUDirect has two modes:
-  - Header-data split: Split the header portion of the packet to the CPU and the rest (payload) to the GPU. The split point is
-    configurable by the user. This option should be the preferred method in most cases since it's easy to use and still
-    gives near peak performance.
-  - Batched GPU: Receive batches of whole packets directly into the GPU memory. This option requires the GPU kernel to inspect
-    and determine how to handle packets. While performance may increase slightly over header-data split, this method
-    requires more effort and should only be used for advanced users.
-- **GPUComms**: Optionally control the send or receive communications from the GPU through the GPUDirect Async Kernel-Initiated network technology (enabled with the [DOCA GPUNetIO](https://docs.nvidia.com/doca/sdk/doca+gpunetio/index.html) backend only).
-- **Flow Configuration**: Configure the NIC's hardware flow engine for configurable patterns. Currently only UDP source
-    and destination are supported.
-
-### Limitations
-
-The limitations below will be removed in a future release.
-
-- Only UDP fill mode is supported
-
-### Managers
-
-Internally the DAQIRI library is implemented by different backends, each offering different features.
-
-It is specified with the `manager` parameter, passed to the `daqiri::daqiri_init` function before starting an application, along with all of the NIC parameters. This step allocates all packet buffers, initializes the queues on the NIC, and starts the appropriate number of internal threads to take packets off or put packets onto the NIC as fast as possible, using the backend-specific implementation.
-
-Developers can then use the rest of the DAQIRI API to send and receive packets, and do any
-additional processing needed (e.g. aggregate, reorder, etc.), as described in the [API Structures](#api-structures) section.
-
-> [!NOTE]
-> To achieve zero copy throughout the whole pipeline only pointers are passed between each entity above. When the user
-> receives the packets from the network library it's using the same buffers that the NIC wrote to either CPU or GPU
-> memory. This architecture also implies that the user must explicitly decide when to free any buffers it's owning.
-> Failure to free buffers will result in errors in the DAQIRI library not being able to allocate buffers.
-
-#### DPDK
-
-DPDK is an open-source userspace packet processing library supported across platforms and vendors.
-
-It is the default manager, and can be set with the values `dpdk` or `default`.
-
-Use the `examples/daqiri_bench_*.yaml` configs to build and run the sample applications with DPDK (default).
-
-#### Configuration Parameters
-
-##### Common Configuration
-
-These common configurations are used by both TX and RX:
-
-- **`version`**: Version of the config. Only 1 is valid currently.
-  - type: `integer`
-- **`master_core`**: Master core used to fork and join network threads. This core is not used for packet processing and can be
-bound to a non-isolated core. Should differ from isolated cores in queues below.
-  - type: `integer`
-- **`manager`**: Backend networking library. default: `dpdk`. Other: `doca` (GPUNet IO), `rivermax`
-  - type: `string`
-- **`log_level`**: Backend log level. default: `warn`. Other: `trace` , `debug`, `info`, `error`, `critical`, `off`
-  - type: `string`
-- **`tx_meta_buffers`**: Metadata buffers for transmit. One buffer is used for each burst of packets (default: 4096)
-  - type: `integer`
-- **`rx_meta_buffers`**: Metadata buffers for receive. One buffer is used for each burst of packets (default: 4096)
-  - type: `integer`
-
-##### Memory regions
-
-`memory_regions:` List of regions where buffers are stored.
-
-- **`name`**: Memory Region name
-  - type: `string`
-- **`kind`**: Location. Best options are `device` (GPU), or `huge` (pages - CPU). Not recommended: `host` (CPU), `host_pinned` (CPU).
-  - type: `string`
-- **`affinity`**: GPU ID for GPU memory, NUMA Node ID for CPU memory
-  - type: `integer`
-- **`access`**: Permissions to the rdma memory region ( `local` or `rmda_read` or `rdma_write`)
-  - type: `string`
-- **`num_bufs`**: Higher value means more time to process, but less space on GPU BAR1.
-Too low means risk of dropped packets from NIC having nowhere to write (Rx) or higher latency from buffering (Tx). Good rule of 👍 : 3x batch_size
-  - type: `integer`
-- **`buf_size`**: Size of buffer, equal to packet size or less if breaking down packets (ex: header data split)
-  - type: `integer`
-
-##### Interfaces
-
-- **`interfaces`**:  List and configure ethernet interfaces
- full path: `cfg\interfaces\`
-  - **`name`**: Name of the interfaca
-    - type: `string`
-  - **`address`**: PCIe BDF address (lspci) or linux interface name for DPDK/GPUNetIO/RiverMax or IP address for RDMA
-    - type: `string`
-  - **`rx|tx`** category of queues below
- full path: `cfg\interfaces\[rx|tx]`
-
-##### Receive Configuration (rx)
-
-- **`queues`**: List of queues on NIC
- type: `list`
- full path: `cfg\interfaces\rx\queues`
-  - **`name`**: Name of queue
-  - type: `string`
-  - **`id`**: Integer ID used for flow connection or lookup in operator compute method
-  - type: `integer`
-  - **`cpu_core`**: CPU core ID. Should be isolated when CPU polls the NIC for best performance.. **Not in use for Doca GPUNetIO**
-  Rivermax manager can accept coma separated list of CPU IDs
-  - type: `string`
-  - **`batch_size`**: Number of packets in a batch passed from the NIC to the downstream operator. A
- larger number increases throughput but reduces end-to-end latency, as it takes longer to populate a single
- buffer. A smaller number reduces end-to-end latency but can also reduce throughput.
-  - type: `integer`
-  - **`memory_regions`**: List of memory regions where buffers are stored. memory regions names are configured in the [Memory Regions](#memory-regions) section
-  type: `list`
-  - **`timeout_us`**: Timeout value that a batch will be sent on even if not enough packets to fill a batch were received
-  - type: `integer`
-- **`flex_items`**: Flexible parser flow items
- type: `list`
- full path: `cfg\interfaces\rx\flex_items`
-  - **`name`**: Name of flow item
-  - type: `string`
-  - **`id`**: ID of the flow item
-  - type: `integer`
-  - **`offset`**: Offset in bytes of where to match after the UDP header. Must be a multiple of 4 and < 28
-  - type: `integer`
-  - **`udp_dst_port`**: UDP destination port for flex item match
-  - type: `integer`
-
-- **`flows`**: List of flows - rules to apply to packets, mostly to divert to the right queue. (**Not in use for Rivermax manager**)
-  type: `list`
-  full path: `cfg\interfaces\[rx|tx]\flows`
-  - **`name`**: Name of the flow
-    - type: `string`
-  - **`id`**: ID of the flow
-    - type: `integer`
-  - **`action`**: Action section of flow (what happens. Currently only supports steering to a given queue)
-    - type: `sequence`
-      - **`type`**: Type of action. Only `queue` is supported currently.
-    - type: `string`
-      - **`id`**: ID of queue to steer to
-        - type: `integer`
-  - **`match`**: Match section of flow
-    - type: `sequence`
-      - **`udp_src`**: UDP source port or a range of ports (eg 1000-1010)
-    - type: `integer`
-      - **`udp_dst`**: UDP destination port or a range of ports (eg 1000-1010)
-    - type: `integer`
-      - **`ipv4_len`**: IPv4 payload length
-    - type: `integer`
-      - **`flex_item_id`**: Flex item ID from RX section. Flex items cannot be applied if UDP or IP matching above are used
-    - type: `integer`
-      - **`val`**: 32b value to match on
-    - type: `integer`
-      - **`mask`**: 32b mask to apply before the match
-    - type: `integer`
-
-##### Extended Receive Configuration for Rivermax manager
-
-- **`rivermax_rx_settings`**: Extended RX settings for Rivermax Manager. Rivermax Manager supports receiving the same stream from multiple redundant paths (IPO - Inline Packet Ordering).
- Each path is a combination of a source IP address, a destination IP address, a destination port, and a local IP address of the receiver device.
-  type: `list`
-  full path: `cfg\interfaces\rx\queues\rivermax_rx_settings`
-  - **`memory_registration`**: Flag, when enabled, reduces the number of memory keys in use by registering all the memory in a single pass on the application side.
-  **Can be used only together with HDS enabled**
-  - type: `boolean`
-  - default:`false`
-  - **`max_path_diff_us`**: Sets the maximum number of microseconds that receiver waits for the same packet to arrive from a different stream (if IPO is enabled)
-    - type: `integer`
-    - default:`0`
-  - **`ext_seq_num`**: The RTP sequence number is used by the hardware to determine the location of arriving packets in the receive buffer.
-  The application supports two sequence number parsing modes: 16-bit RTP sequence number (default) and 32-bit extended sequence number,
-  consisting of 16 low order RTP sequence number bits and 16 high order bits from the start of RTP payload. When set to `true` 32-bit ext. sequence number will be used
-  - type: `boolean`
-  - default:`true`
-  - **`sleep_between_operations_us`**: Specifies the duration, in microseconds, that the receiver will pause or sleep between two consecutive receive (RX) operations.
-  - type: `integer`
-  - default:`0`
-  - **`local_ip_addresses`**: List of Local NIC IP Addresses (one address per receiving path)
-    - type: `sequence`
-  - **`source_ip_addresses`**: List of Sender IP Addresses (one address per receiving path)
-    - type: `sequence`
-  - **`destination_ip_addresses`**: List of Destination IP Addresses (one address per receiving path), can be multicast
-    - type: `sequence`
-  - **`destination_ports`**: List of Destination IP ports (one port per receiving path)
-    - type: `sequence`
-  - **`stats_report_interval_ms`**: Specifies the duration, in milliseconds, that the receiver will display statistics in the log. Set `0` to disable statistics logging feature
-  - type: `integer`
-  - default:`0`
-  - **`send_packet_ext_info`**: Enables the transmission of extended metadata for each received packet
-  - type: `boolean`
-  - default:`true`
-
-- Example of the Rivermax queue configuration for redundant stream using HDS and GPU
-  This example demonstrates receiving a redundant stream sent from a sender with source addresses 192.168.100.4 and 192.168.100.3.
-  The stream is received via NIC which have local IP (same) 192.168.100.5 (listed twice, once per stream).
-  The multicast addresses and UDP ports on which the stream is being received are 224.1.1.1:5001 and 224.1.1.2:5001
- The incoming packets are of size 1152 bytes. The initial 20 bytes are stripped from the payload as an  application header and placed in buffers allocated in RAM.
- The remaining 1132 bytes are placed in dedicated payload buffers.  In this case, the payload buffers are allocated in GPU 0 memory.
-
-```YAML
-    memory_regions:
-    - name: "Data_RX_CPU"
-      kind: "huge"
-      affinity: 0
-      access:
-        - local
-      num_bufs: 43200
-      buf_size: 20
-    - name: "Data_RX_GPU"
-      kind: "device"
-      affinity: 0
-      access:
-        - local
-      num_bufs: 43200
-      buf_size: 1132
-    interfaces:
-    - address: 0005:03:00.0
-      name: data1
-      rx:
-        queues:
-        - name: Data1
-          id: 0
-          cpu_core: '11'
-          batch_size: 4320
-          rivermax_rx_settings:
-            settings_type: "ipo_receiver"
-            memory_registration: true
-            max_path_diff_us: 10000
-            ext_seq_num: true
-            sleep_between_operations_us: 0
-            memory_regions:
-            - "Data_RX_CPU"
-            - "Data_RX_GPU"
-            local_ip_addresses:
-            - 192.168.100.5
-            - 192.168.100.5
-            source_ip_addresses:
-            - 192.168.100.4
-            - 192.168.100.4
-            destination_ip_addresses:
-            - 224.1.1.1
-            - 224.1.1.2
-            destination_ports:
-            - 50001
-            - 50001
-            stats_report_interval_ms: 3000
-            send_packet_ext_info: true
-
-```
-
-##### Transmit Configuration (tx)
-
-- **`queues`**: List of queues on NIC
- type: `list`
- full path: `cfg\interfaces\tx\queues`
-  - **`name`**: Name of queue
-  - type: `string`
-  - **`id`**: Integer ID used for flow connection or lookup in operator compute method
-  - type: `integer`
-  - **`cpu_core`**: CPU core ID. Should be isolated when CPU polls the NIC for best performance.. **Not in use for Doca GPUNetIO**
-  Rivermax manager can accept coma separated list of CPU IDs
-  - type: `string`
-  - **`batch_size`**: Number of packets in a batch that the NIC needs to receive from the upstream operator before
- sending them over the network. A larger number increases throughput but reduces end-to-end latency.
- A smaller number reduces end-to-end latency but can also reduce throughput.
-  - type: `integer`
-  - **`memory_regions`**: List of memory regions where buffers are stored. memory regions names are configured in the [Memory Regions](#memory-regions) section
-  type: `list`
-  - **`accurate_send`**: Accurate TX sending enabled for sending packets at a specific PTP timestamp
-  - type: `boolean`
-
-##### Transmit Configuration (tx) - Queues
-
-- **`queues`**: List of queues on NIC
-  **Type**: `list`
-  **Full Path**: `cfg\interfaces\tx\queues`
-
-  - **`name`**: Name of the queue
-    - **Type**: `string`
-
-  - **`id`**: Integer ID used for flow connection or lookup in operator compute method
-    - **Type**: `integer`
-
-  - **`cpu_core`**: CPU core ID. Should be isolated when CPU polls the NIC for best performance. **Not in use for DOCA GPUNetIO**. Rivermax Manager can accept comma-separated list of CPU IDs.
-    - **Type**: `string`
-
-  - **`batch_size`**: Number of packets in batch passed between operators. Larger values increase throughput at cost of latency.
-    - **Type**: `integer`
-
-  - **`memory_regions`**: List of memory regions where buffers are stored (configured in Memory Regions section)
-    - **Type**: `list`
-
-##### Extended Transmit Configuration for Rivermax manager
-
-The Rivermax TX configuration enables hardware-assisted SMPTE 2110-20 compliant video streaming with:
-
-- Precision timestamping via PCIe PTP clock synchronization
-- Jitter-free packetization of rasterized video frames
-- Automatic UDP checksum offload
-- Traffic shaping for constant bitrate delivery
-
-  - **`rivermax_tx_settings`**: Extended TX settings for SMPTE 2110-20 media streaming
-    **Type**: `sequence`
-    **Full Path**: `cfg\interfaces\tx\queues\rivermax_tx_settings`
-
-    - **`settings_type`**: Transmission mode. Must be `media_sender` for video
-      - **Type**: `string`
-      - **Required**: Yes
-      - **Valid Values**: `media_sender`
-
-    - **`memory_registration`**: Enables bulk registration of GPU/CPU memory regions with NIC for zero-copy transfers. Recommended for high-throughput scenarios.
-      - **Type**: `boolean`
-      - **Default**: `true`
-
-    - **`memory_allocation`**:  I\O Memory allocated by application
-      - **Type**: `boolean`
-      - **Default**: `true`
-
-    - **`memory_pool_location`**: Buffer memory type (`device/huge_pages/host_pinned/host`)
-      - **Type**: `string`
-      - **Required**: Yes
-
-    - **`local_ip_address`**: Source IP address bound to transmitting network interface.
-      - **Type**: `string`
-      - **Required**: Yes
-
-    - **`destination_ip_address`**: Unicast/Multicast group address for media stream distribution.
-      - **Type**: `string`
-      - **Required**: Yes
-
-    - **`destination_port`**: UDP port number for media stream transmission
-      - **Type**: `integer`
-      - **Range**: 1024-65535
-      - **Required**: Yes
-
-    - **`video_format`**: Defines pixel sampling structure per SMPTE ST 2110-20
-      - **Type**: `string`
-      - **Required**: Yes
-      - **Valid Values**: `YCbCr-4:2:2`, `YCbCr-4:4:4`,`YCbCr-4:2:0`, `RGB`
-
-    - **`bit_depth`**: Color component quantization precision
-      - **Type**: `integer`
-      - **Required**: Yes
-      - **Valid Values**: `8`, `10`, `12`
-
-    - **`frame_width`**: Horizontal resolution in pixels
-      - **Type**: `integer`
-      - **Required**: Yes
-      - **Valid Values**: `1920` for HD, `3840` for 4K UHD
-
-    - **`frame_height`**: The vertical resolution of the video in pixels
-      - **Type**: `integer`
-      - **Required**: Yes
-      - **Valid Values**: `1080` for HD, `2160` for 4K UHD
-
-    - **`frame_rate`**: Frame rate in fps
-      - **Type**: `integer`
-      - **Required**: Yes
-      - **Valid Values**:  `24`, `25`, `30`, `50`, and `60`
-
-    - **`dummy_sender`**: Test mode without NIC transmission
-      - **Type**: `boolean`
-      - **Default**: `false`
-
-    - **`stats_report_interval_ms`**: Transmission stats logging interval (0=disable)
-      - **Type**: `integer`
-      - **Default**: `0`
-
-    - **`verbose`**: Enable detailed transmission logging
-      - **Type**: `boolean`
-      - **Default**: `false`
-
-    - **`sleep_between_operations`**: Add inter-burst delays for timing sync
-      - **Type**: `boolean`
-      - **Default**: `false`
-
-#### Example Configuration
-
-```YAML
-    memory_regions:
-    - name: "Data_TX_CPU"
-      kind: "huge"
-      affinity: 0
-      num_bufs: 43200
-      buf_size: 20
-    - name: "Data_TX_GPU"
-      kind: "device"
-      affinity: 0
-      num_bufs: 43200
-      buf_size: 1200
-
-    interfaces:
-    - name: "tx_port"
-      address: cc:00.1
-      tx:
-        queues:
-        - name: "tx_q_1"
-          id: 0
-          cpu_core:  "13"
-          batch_size: 4320
-          output_port: "bench_tx_out_1"
-          memory_regions:
-          - "Data_TX_CPU"
-          - "Data_TX_GPU"
-          rivermax_tx_settings:
-            settings_type: "media_sender"
-            memory_registration: true
-            memory_allocation: true
-            memory_pool_location: "host_pinned"
-            #allocator_type: "huge_page_2mb"
-            verbose: true
-            sleep_between_operations: false
-            local_ip_address: 2.1.0.12
-            destination_ip_address: 224.1.1.2
-            destination_port: 50001
-            stats_report_interval_ms: 1000
-            send_packet_ext_info: true
-            video_format: YCbCr-4:2:2
-            bit_depth: 10
-            frame_width: 1920
-            frame_height: 1080
-            frame_rate: 60
-            dummy_sender: false
-
-```
-
-#### API Structures
-
-The DAQIRI library uses a common structure named `BurstParams` to pass data to/from other operators. `BurstParams` provides pointers to packet memory locations (e.g., CPU or GPU) and contains metadata needed by any operator to track allocations. Interacting with `BurstParams` should only be done with the helper functions described below.
-
-#### Example API Usage
-
-For an entire list of API functions, please see the `daqiri/common.h` header file.
-
-##### Receive
-
-The section below describes a workflow using GPUDirect to receive packets using header-data split. The job of the user's operator(s)
-is to process and free the buffers as quickly as possible. This might be copying to interim buffers or freeing before the entire
-pipeline is done processing. This allows the networking piece to use relatively few buffers while still achieving very high rates.
-
-The first step in receiving from the NIC is to receive a `BurstParams` structure when a batch is complete:
-
-```cpp
-BurstParams *burst;
-int port_id_ = 0;
-int queue_id_ = 0;
-auto status = get_rx_burst(&burst, port_id_, queue_id_);
-```
-
-The packets arrive in scattered packet buffers. Depending on the application, you may need to iterate through the packets to
-aggregate them into a single buffer. Alternatively the operator handling the packet data can operate on a list of packet
-pointers rather than a contiguous buffer. Below is an example of aggregating separate GPU packet buffers into a single GPU
-buffer:
-
-```cpp
-  for (int p = 0; p < get_num_packets(burst); p++) {
-    h_dev_ptrs_[aggr_pkts_recv_ + p]   = get_cpu_packet_ptr(burst, p);
-    ttl_bytes_in_cur_batch_           += get_gpu_packet_length(burst, p) + sizeof(UDPPkt);
-  }
-
-  simple_packet_reorder(buffer, h_dev_ptrs, packet_len, burst->hdr.num_pkts);
-```
-
-For this example we are tossing the header portion (CPU), so we don't need to examine the packets. Since we launched a reorder
-kernel to aggregate the packets in GPU memory, we are also done with the GPU pointers. All buffers may be freed for the NIC to reuse at this point:
-
-```cpp
-free_all_burst_packets_and_burst(burst_bufs_[b]);
-```
-
-##### Transmit
-
-Transmitting packets works similar to the receive side, except the user is tasked with filling out the packets as much as it
-needs to. As mentioned above, helper functions are available to fill in most boilerplate header information if that doesn't
-change often.
-
-Before sending packets, the user's transmit operator must request a buffer from the NIC:
-
-```cpp
-auto burst = create_tx_burst_params();
-set_header(burst, port_id, queue_id, batch_size, num_segments);
-if ((ret = get_tx_packet_burst(burst)) != Status::SUCCESS) {
-  DAQIRI_LOG_ERROR("Error returned from get_tx_packet_burst: {}", static_cast<int>(ret));
-  return;
-}
-```
-
-The code above creates a shared `BurstParams`, and uses `get_tx_packet_burst` to populate the burst buffers with valid packet buffers. On success, the buffers inside the burst structure will be allocated and are ready to be filled in. Each packet must be filled in by the user. In this example we loop through each packet and populate a buffer:
-
-```cpp
-for (int num_pkt = 0; num_pkt < get_num_packets(burst); num_pkt++) {
-  void *payload_src = data_buf + num_pkt * payload_size;
-  if (set_udp_payload(burst, num_pkt, payload_src, payload_size) != Status::SUCCESS) {
-    DAQIRI_LOG_ERROR("Failed to create packet {}", num_pkt);
-  }
-}
-```
-
-The code iterates over the number of packets in the burst (defined above by the user) and passes a pointer
-to the payload and the packet size to `set_udp_payload`. In this example our configuration is using `fill_mode`
-"udp" on the transmitter, so `set_udp_payload` will populate the Ethernet, IP, and UDP headers. The payload
-pointer passed by the user is also copied into the buffer. Alternatively a user could use the packet buffers
-directly as output from a previous stage to avoid this extra copy.
-
-With the `BurstParams` populated, the burst can be sent off to the NIC:
-
-```cpp
-send_tx_burst(burst);
-```
+Apache 2.0 — see [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DAQIRI networking library
 
-**Connecting DAQ Frontends to GPU compute at line rate.** DAQIRI (Data Acquisition for Integrated Real-time Instruments) helps developers seamlessly connect their data acquisition systems to NVIDIA GPUs for real-time processing and AI, paving the way for autonomy of the next-generation of scintific and industrial instruments.
+**Send and receive Ethernet packets into CPU and GPU memory at hundreds of Gbps with a simple API.** DAQIRI (Data Acquisition for Integrated Real-time Instruments) connects data acquisition systems to NVIDIA GPUs for real-time processing and AI, paving the way for autonomy of the next generation of scientific and industrial instruments.
 
 > [!WARNING]
 > The library is undergoing large improvements as we aim to better support it as an NVIDIA product.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # DAQIRI networking library
 
-**From wire to GPU at line rate.** DAQIRI bypasses the Linux kernel to move raw sensor data directly into GPU memory at hundreds of gigabits per second.
+**Connecting DAQ Frontends to GPU compute at line rate.** DAQIRI (Data Acquisition for Integrated Real-time Instruments) helps developers seamlessly connect their data acquisition systems to NVIDIA GPUs for real-time processing and AI, paving the way for autonomy of the next-generation of scintific and industrial instruments.
 
 > [!WARNING]
 > The library is undergoing large improvements as we aim to better support it as an NVIDIA product.
 > API breakages might be more frequent until we reach version 1.0.
 
-DAQIRI provides direct NIC hardware access in userspace, bypassing the Linux kernel
-network stack to achieve the highest possible throughput and lowest latency for Ethernet
-frame transmission and reception. It targets NVIDIA ConnectX-6 Dx and later NICs and
-supports GPU direct memory access (GPUDirect) for zero-copy data paths between the NIC
-and GPU.
+DAQIRI provides direct NIC hardware access in userspace, bypassing the Linux kernel network stack to achieve the highest possible throughput and lowest latency for Ethernet frame transmission and reception. It targets NVIDIA ConnectX-6 Dx and later NICs and supports GPU direct memory access (GPUDirect) for zero-copy data paths between the NIC and GPU.
 
 ## Features
 

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -1,0 +1,243 @@
+# API Guide
+
+This guide covers the core DAQIRI API for receiving and transmitting packets. For the
+complete function list, see the [`daqiri/common.h`](/src/common.h) header file.
+
+## Key Concepts
+
+### BurstParams
+
+All packet data flows through the `BurstParams` structure. A burst is a batch of packets
+grouped together for efficient transfer between the NIC and the application.
+
+`BurstParams` provides:
+- Pointers to packet buffers (CPU or GPU memory)
+- Metadata: packet count, port/queue IDs, segment count, byte totals
+- Per-packet lengths and flow IDs
+
+Interact with `BurstParams` only through the helper functions described below — the
+internal layout is opaque.
+
+### Zero-Copy Design
+
+Only pointers are passed between the NIC, DAQIRI internals, and the application. When
+you receive packets, you are reading the same buffers the NIC DMA'd into — no copies
+are made.
+
+This means **you must explicitly free buffers** when done processing. Failure to free
+buffers will exhaust the memory pool, causing the NIC to drop packets and DAQIRI to
+return `NO_FREE_BURST_BUFFERS` or `NO_FREE_PACKET_BUFFERS` errors.
+
+### Segments
+
+A packet can span multiple memory segments. The most common case is header-data split
+(HDS), where:
+- Segment 0 = headers (CPU memory)
+- Segment 1 = payload (GPU memory)
+
+For CPU-only or batched-GPU modes, there is a single segment (segment 0).
+
+## Initialization
+
+```cpp
+#include "daqiri/common.h"
+
+// Initialize from a YAML config file
+auto status = daqiri::daqiri_init("path/to/config.yaml");
+
+// Or from a pre-parsed config struct
+daqiri::NetworkConfig config;
+daqiri::parse_network_config("path/to/config.yaml", config);
+auto status = daqiri::daqiri_init(config);
+```
+
+After `daqiri_init()` returns `Status::SUCCESS`, all memory regions are allocated, NIC
+queues are configured, and worker threads are running.
+
+## Receiving Packets
+
+### Step 1: Get a burst
+
+```cpp
+daqiri::BurstParams *burst;
+int port_id = 0;
+int queue_id = 0;
+auto status = daqiri::get_rx_burst(&burst, port_id, queue_id);
+```
+
+`get_rx_burst()` is non-blocking. It returns `Status::SUCCESS` when a complete batch is
+available, or `Status::NULL_PTR` when no burst is ready yet. There are also overloads
+that dequeue from any queue on a port, or from any queue on any port:
+
+```cpp
+// From any queue on port 0
+daqiri::get_rx_burst(&burst, 0);
+
+// From any queue on any port (round-robin)
+daqiri::get_rx_burst(&burst);
+```
+
+### Step 2: Access packet data
+
+For a single-segment configuration (CPU-only or batched GPU):
+
+```cpp
+for (int i = 0; i < daqiri::get_num_packets(burst); i++) {
+    void *pkt = daqiri::get_packet_ptr(burst, i);
+    uint32_t len = daqiri::get_packet_length(burst, i);
+    uint16_t flow = daqiri::get_packet_flow_id(burst, i);
+    // process packet...
+}
+```
+
+For header-data split (two segments):
+
+```cpp
+for (int i = 0; i < daqiri::get_num_packets(burst); i++) {
+    void *hdr = daqiri::get_segment_packet_ptr(burst, 0, i);  // CPU pointer
+    void *pay = daqiri::get_segment_packet_ptr(burst, 1, i);  // GPU pointer
+    uint32_t hdr_len = daqiri::get_segment_packet_length(burst, 0, i);
+    uint32_t pay_len = daqiri::get_segment_packet_length(burst, 1, i);
+}
+```
+
+### Step 3: Free buffers
+
+When you are done processing, free the burst to return buffers to the pool:
+
+```cpp
+// Free all packets and the burst metadata
+daqiri::free_all_packets_and_burst_rx(burst);
+```
+
+You can also free individual packets or segments if your pipeline releases buffers
+incrementally:
+
+```cpp
+// Free a single packet (all segments)
+daqiri::free_packet(burst, idx);
+
+// Free one segment of a packet
+daqiri::free_packet_segment(burst, seg, idx);
+
+// Free all packets for one segment, then the burst
+daqiri::free_all_segment_packets(burst, seg);
+daqiri::free_rx_burst(burst);
+```
+
+### GPU Packet Aggregation
+
+When using batched GPU mode, packets arrive in scattered buffers — each at an arbitrary
+GPU address. For workloads that need contiguous data, DAQIRI provides a CUDA reorder
+kernel (`simple_packet_reorder` in `src/kernels.cu`) that copies scattered packets into
+a flat output buffer:
+
+```cpp
+// Collect GPU pointers from the burst
+for (int p = 0; p < daqiri::get_num_packets(burst); p++) {
+    h_dev_ptrs[p] = daqiri::get_packet_ptr(burst, p);
+}
+
+// Reorder into a contiguous GPU buffer
+simple_packet_reorder(output_buffer, h_dev_ptrs, packet_len, num_packets);
+
+// Free once the kernel completes
+daqiri::free_all_packets_and_burst_rx(burst);
+```
+
+## Transmitting Packets
+
+### Step 1: Allocate a burst
+
+```cpp
+auto burst = daqiri::create_tx_burst_params();
+daqiri::set_header(burst, port_id, queue_id, batch_size, num_segments);
+
+auto status = daqiri::get_tx_packet_burst(burst);
+if (status != daqiri::Status::SUCCESS) {
+    // No buffers available — retry later
+}
+```
+
+You can check availability before allocating:
+
+```cpp
+if (daqiri::is_tx_burst_available(burst)) {
+    daqiri::get_tx_packet_burst(burst);
+}
+```
+
+### Step 2: Fill packets
+
+Use the header helpers for standard UDP packets:
+
+```cpp
+for (int i = 0; i < daqiri::get_num_packets(burst); i++) {
+    daqiri::set_eth_header(burst, i, dst_mac);
+    daqiri::set_ipv4_header(burst, i, ip_payload_len, IPPROTO_UDP, src_ip, dst_ip);
+    daqiri::set_udp_header(burst, i, udp_payload_len, src_port, dst_port);
+    daqiri::set_udp_payload(burst, i, payload_ptr, payload_size);
+    daqiri::set_packet_lengths(burst, i, {total_pkt_len});
+}
+```
+
+Or construct raw packets by writing directly into the packet buffer returned by
+`get_packet_ptr()`.
+
+### Step 3: Send
+
+```cpp
+daqiri::send_tx_burst(burst);
+```
+
+The burst is enqueued to the TX worker thread, which sends it to the NIC via DMA.
+
+### Timed Transmission
+
+For precise packet scheduling (requires ConnectX-7+):
+
+```cpp
+daqiri::set_packet_tx_time(burst, idx, ptp_timestamp);
+```
+
+## Utility Functions
+
+```cpp
+// Get MAC address of a port
+char mac[6];
+daqiri::get_mac_addr(port_id, mac);
+
+// Look up port ID by interface name or PCIe address
+int port = daqiri::get_port_id("rx_port");
+
+// Traffic control
+daqiri::drop_all_traffic(port_id);    // drop all incoming packets
+daqiri::allow_all_traffic(port_id);   // restore normal traffic
+
+// Drain stale packets from a queue
+daqiri::flush_port_queue(port_id, queue_id);
+
+// Print NIC statistics
+daqiri::print_stats();
+
+// Shutdown and cleanup
+daqiri::shutdown();
+```
+
+## Status Codes
+
+All functions that can fail return `daqiri::Status`:
+
+| Status | Meaning |
+|--------|---------|
+| `SUCCESS` | Operation completed successfully |
+| `NULL_PTR` | Burst or internal pointer not initialized / no data ready |
+| `NO_FREE_BURST_BUFFERS` | Metadata buffer pool exhausted (increase `tx/rx_meta_buffers`) |
+| `NO_FREE_PACKET_BUFFERS` | Packet buffer pool exhausted (free buffers faster or increase `num_bufs`) |
+| `NOT_READY` | System not yet initialized |
+| `INVALID_PARAMETER` | Invalid argument passed |
+| `NO_SPACE_AVAILABLE` | Ring or queue is full |
+| `NOT_SUPPORTED` | Operation not supported by the current backend |
+| `GENERIC_FAILURE` | Unspecified failure |
+| `CONNECT_FAILURE` | RDMA connection failed |
+| `INTERNAL_ERROR` | Internal error in the backend |

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -12,7 +12,7 @@ grouped together for efficient transfer between the NIC and the application.
 
 `BurstParams` provides:
 - Pointers to packet buffers (CPU or GPU memory)
-- Metadata: packet count, port/queue IDs, segment count, byte totals
+- Packet metadata: packet count, port/queue IDs, segment count, byte totals
 - Per-packet lengths and flow IDs
 
 Interact with `BurstParams` only through the helper functions described below — the
@@ -30,8 +30,11 @@ return `NO_FREE_BURST_BUFFERS` or `NO_FREE_PACKET_BUFFERS` errors.
 
 ### Segments
 
-A packet can span multiple memory segments. The most common case is header-data split
-(HDS), where:
+A **segment** is a contiguous memory region (in CPU or GPU memory) that holds part
+of a packet. A single packet can span multiple segments, which lets different parts
+of the packet live in different memory domains.
+
+The most common case is header-data split (HDS), where:
 - Segment 0 = headers (CPU memory)
 - Segment 1 = payload (GPU memory)
 
@@ -45,9 +48,9 @@ For CPU-only or batched-GPU modes, there is a single segment (segment 0).
 // Initialize from a YAML config file
 auto status = daqiri::daqiri_init("path/to/config.yaml");
 
-// Or from a pre-parsed config struct
+// Or build the configuration in code
 daqiri::NetworkConfig config;
-daqiri::parse_network_config("path/to/config.yaml", config);
+// Populate configuration struct
 auto status = daqiri::daqiri_init(config);
 ```
 
@@ -169,7 +172,7 @@ if (daqiri::is_tx_burst_available(burst)) {
 
 ### Step 2: Fill packets
 
-Use the header helpers for standard UDP packets:
+Use the header helper functions for standard UDP packets:
 
 ```cpp
 for (int i = 0; i < daqiri::get_num_packets(burst); i++) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,9 @@
 # Configuration Reference
 
-DAQIRI is configured through a YAML file that defines memory regions, NIC interfaces,
-TX/RX queues, and flow rules. The configuration is passed to `daqiri_init()` at startup.
+DAQIRI is configured through a YAML file or a `NetworkConfig` struct built in code.
+Either form defines memory regions, NIC interfaces, TX/RX queues, and flow rules, and
+is passed to `daqiri_init()` at startup. The struct form is useful for customers who
+want to interoperate with existing configuration code.
 
 See `examples/daqiri_bench_*.yaml` for complete working examples.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,332 @@
+# Configuration Reference
+
+DAQIRI is configured through a YAML file that defines memory regions, NIC interfaces,
+TX/RX queues, and flow rules. The configuration is passed to `daqiri_init()` at startup.
+
+See `examples/daqiri_bench_*.yaml` for complete working examples.
+
+## Common Configuration
+
+These settings apply globally to both TX and RX:
+
+- **`version`**: Config version. Only `1` is valid currently.
+  - type: `integer`
+- **`master_core`**: CPU core used to fork and join network threads. This core is not used
+  for packet processing and can be bound to a non-isolated core. Should differ from isolated
+  cores assigned to queues.
+  - type: `integer`
+- **`manager`**: Backend networking library.
+  - type: `string`
+  - values: `dpdk` (default), `rdma`
+- **`log_level`**: Backend log level.
+  - type: `string`
+  - values: `trace`, `debug`, `info`, `warn` (default), `error`, `critical`, `off`
+- **`loopback`**: Enable software loopback for testing without a physical link.
+  - type: `string`
+  - values: `""` (disabled, default), `"sw"` (software loopback)
+- **`tx_meta_buffers`**: Metadata buffers for transmit. One buffer is used for each burst
+  of packets.
+  - type: `integer`
+  - default: `256`
+- **`rx_meta_buffers`**: Metadata buffers for receive. One buffer is used for each burst
+  of packets.
+  - type: `integer`
+  - default: `256`
+
+## Memory Regions
+
+`memory_regions:` — List of regions where packet buffers are stored. The number of regions
+and their `kind` determines the receive mode (CPU-only, header-data split, or batched GPU).
+
+- **`name`**: Memory region name. Referenced by queue configurations.
+  - type: `string`
+- **`kind`**: Memory type.
+  - type: `string`
+  - values:
+    - `huge` — CPU hugepages (recommended for CPU buffers)
+    - `device` — GPU VRAM
+    - `host_pinned` — Pinned CPU pages (not recommended for high-throughput RX/TX)
+    - `host` — Regular CPU memory (not recommended)
+- **`affinity`**: GPU ID for `device` memory, or NUMA node ID for CPU memory.
+  - type: `integer`
+- **`access`**: Memory access permissions.
+  - type: `list`
+  - values: `local`, `rdma_read`, `rdma_write`
+- **`num_bufs`**: Number of buffers in this region. Higher values give more processing
+  headroom but consume more memory (GPU BAR1 for `device`). Too low risks dropped packets
+  on RX or higher latency on TX. Rule of thumb: at least 3x `batch_size`.
+  - type: `integer`
+- **`buf_size`**: Size of each buffer in bytes. Should match the expected packet size, or
+  the segment size when using header-data split.
+  - type: `integer`
+
+### Example: Header-Data Split
+
+Two regions — a small CPU region for headers and a GPU region for payload:
+
+```yaml
+memory_regions:
+- name: "RX_CPU"
+  kind: "huge"
+  affinity: 0
+  access:
+    - local
+  num_bufs: 51200
+  buf_size: 64        # ETH+IP+UDP headers (~42 bytes, padded)
+- name: "RX_GPU"
+  kind: "device"
+  affinity: 0
+  access:
+    - local
+  num_bufs: 51200
+  buf_size: 1000      # payload
+```
+
+## Interfaces
+
+`interfaces:` — List of NIC interfaces to configure.
+
+- **`name`**: Interface name. Used to look up port IDs at runtime via `get_port_id()`.
+  - type: `string`
+- **`address`**: PCIe BDF address (from `lspci`) or Linux interface name for DPDK, or IP
+  address for RDMA.
+  - type: `string`
+
+### RDMA Configuration
+
+When using the RDMA backend (`manager: rdma`), each interface requires an `rdma_config` block:
+
+- **`rdma_config`**:
+  - **`mode`**: Connection role.
+    - type: `string`
+    - values: `client`, `server`
+  - **`transport_mode`**: RDMA transport type.
+    - type: `string`
+    - values: `RC` (Reliable Connected), `UC` (Unreliable Connected)
+  - **`port`**: Listening port (server mode only).
+    - type: `integer`
+
+## Receive Configuration (rx)
+
+### Queues
+
+`rx.queues:` — List of receive queues on the interface.
+
+- **`name`**: Queue name.
+  - type: `string`
+- **`id`**: Integer ID used for flow steering and burst retrieval.
+  - type: `integer`
+- **`cpu_core`**: CPU core ID for the RX worker thread. Should be an isolated core for best
+  performance.
+  - type: `string`
+- **`batch_size`**: Number of packets per batch passed from the NIC to the application. Larger
+  values increase throughput; smaller values reduce latency.
+  - type: `integer`
+- **`memory_regions`**: List of memory region names (defined in [Memory Regions](#memory-regions)).
+  The order determines segment mapping: first region = segment 0, second = segment 1, etc.
+  A single region means all packet data lands in one place; two regions enables header-data
+  split.
+  - type: `list`
+- **`timeout_us`**: Timeout in microseconds. A partial batch is delivered if this time elapses
+  before `batch_size` packets are collected. Set to `0` to disable (wait for full batch only).
+  - type: `integer`
+  - default: `0`
+
+### Flex Items
+
+`rx.flex_items:` — Flexible parser items for custom flow matching beyond standard UDP fields.
+
+- **`name`**: Name of the flex item.
+  - type: `string`
+- **`id`**: ID of the flex item.
+  - type: `integer`
+- **`offset`**: Byte offset after the UDP header where matching begins. Must be a multiple
+  of 4 and less than 28.
+  - type: `integer`
+- **`udp_dst_port`**: UDP destination port for flex item activation.
+  - type: `integer`
+
+### Flows
+
+`rx.flows:` — Flow rules that steer packets to specific queues based on match criteria.
+
+- **`name`**: Flow name.
+  - type: `string`
+- **`id`**: Flow ID. Retrievable at runtime via `get_packet_flow_id()`.
+  - type: `integer`
+- **`action`**: What to do with matched packets.
+  - **`type`**: Action type. Only `queue` is currently supported.
+    - type: `string`
+  - **`id`**: Queue ID to steer matched packets to.
+    - type: `integer`
+- **`match`**: Criteria for matching packets.
+  - **`udp_src`**: UDP source port or port range (e.g., `1000-1010`).
+    - type: `integer` or `string`
+  - **`udp_dst`**: UDP destination port or port range.
+    - type: `integer` or `string`
+  - **`ipv4_len`**: IPv4 payload length.
+    - type: `integer`
+  - **`flex_item_id`**: Flex item ID (from `rx.flex_items`). Cannot be combined with UDP/IP
+    matching.
+    - type: `integer`
+  - **`val`**: 32-bit value to match (with flex items).
+    - type: `integer`
+  - **`mask`**: 32-bit mask applied before matching (with flex items).
+    - type: `integer`
+
+### Flow Isolation
+
+`rx.flow_isolation:` — When `true`, only packets matching an explicit flow rule are delivered.
+Unmatched packets are dropped. When `false`, unmatched packets go to a default queue.
+
+- type: `boolean`
+- default: `false`
+
+## Transmit Configuration (tx)
+
+### Queues
+
+`tx.queues:` — List of transmit queues on the interface.
+
+- **`name`**: Queue name.
+  - type: `string`
+- **`id`**: Integer ID used for burst submission.
+  - type: `integer`
+- **`cpu_core`**: CPU core ID for the TX worker thread. Should be an isolated core for best
+  performance.
+  - type: `string`
+- **`batch_size`**: Number of packets per batch sent to the NIC. Larger values increase
+  throughput; smaller values reduce latency.
+  - type: `integer`
+- **`memory_regions`**: List of memory region names. Same segment mapping rules as RX.
+  - type: `list`
+- **`offloads`**: List of hardware offloads to enable.
+  - type: `list`
+  - values: `tx_eth_src` (auto-fill source MAC address)
+
+### Accurate Send
+
+`tx.accurate_send:` — Enable hardware-timed packet transmission using PTP timestamps. When
+enabled, use `set_packet_tx_time()` to schedule packets. Requires ConnectX-7 or later.
+
+- type: `boolean`
+- default: `false`
+
+## Complete Example (DPDK, Header-Data Split)
+
+```yaml
+%YAML 1.2
+---
+daqiri:
+  cfg:
+    version: 1
+    manager: "dpdk"
+    master_core: 3
+    debug: false
+    log_level: "info"
+
+    memory_regions:
+    - name: "Data_TX_CPU"
+      kind: "huge"
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 64
+    - name: "Data_TX_GPU"
+      kind: "device"
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 1064
+    - name: "Data_RX_CPU"
+      kind: "huge"
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 64
+    - name: "Data_RX_GPU"
+      kind: "device"
+      affinity: 0
+      num_bufs: 51200
+      buf_size: 1000
+
+    interfaces:
+    - name: "tx_port"
+      address: <PCIe BDF>
+      tx:
+        queues:
+        - name: "tx_q_0"
+          id: 0
+          batch_size: 10240
+          cpu_core: 11
+          memory_regions:
+            - "Data_TX_CPU"
+            - "Data_TX_GPU"
+          offloads:
+            - "tx_eth_src"
+    - name: "rx_port"
+      address: <PCIe BDF>
+      rx:
+        flow_isolation: true
+        queues:
+        - name: "rx_q_0"
+          id: 0
+          cpu_core: 9
+          batch_size: 10240
+          memory_regions:
+            - "Data_RX_CPU"
+            - "Data_RX_GPU"
+        flows:
+        - name: "flow_0"
+          id: 0
+          action:
+            type: queue
+            id: 0
+          match:
+            udp_src: 4096
+            udp_dst: 4096
+            ipv4_len: 1050
+```
+
+## Complete Example (RDMA, Client/Server)
+
+```yaml
+%YAML 1.2
+---
+daqiri:
+  cfg:
+    version: 1
+    manager: "rdma"
+    master_core: 3
+    debug: false
+    log_level: "info"
+
+    memory_regions:
+    - name: "DATA_TX"
+      kind: "host_pinned"
+      affinity: 0
+      num_bufs: 20
+      buf_size: 9000000
+    - name: "DATA_RX"
+      kind: "host_pinned"
+      affinity: 0
+      num_bufs: 20
+      buf_size: 9000000
+
+    interfaces:
+    - name: my_server
+      rdma_config:
+        mode: server
+        transport_mode: RC
+        port: 4096
+      address: 10.100.3.1
+      rx:
+        queues:
+        - name: "Server_RX_Queue"
+          id: 0
+          cpu_core: 8
+          batch_size: 1
+      tx:
+        queues:
+        - name: "Server_TX_Queue"
+          id: 0
+          cpu_core: 8
+          batch_size: 1
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,9 @@
   - NVIDIA optimized kernels (IGX OS, DGX BaseOS)
   - OFED drivers from [DOCA-Host](https://developer.nvidia.com/doca-archive) 2.8 or later
     (install the `mlnx-ofed-kernel-dkms` package or the `doca-ofed` meta-package)
+
+  > **Note:** If you use the DPDK bundled in the DAQIRI container, it is patched with
+  > dmabuf support and **peermem is not required**.
 - **DPDK** (for the DPDK backend) — userspace libraries are included in the
   [Dockerfile](../Dockerfile). Inspect it if building on bare metal.
 - **libibverbs** and **librdmacm** (for the RDMA backend)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,91 @@
+# Getting Started
+
+## Requirements
+
+### Hardware
+
+- An NVIDIA NIC with a **ConnectX-6 Dx or later** chip
+
+### Software
+
+- **Linux** (kernel 5.4+)
+- **CUDA Toolkit**
+- **MLNX5/InfiniBand drivers** with peermem support, via one of:
+  - Inbox (standard) drivers on Ubuntu kernel versions >= 5.4 and [< 6.8](https://discourse.ubuntu.com/t/nvidia-gpudirect-over-infiniband-migration-paths/44425)
+  - NVIDIA optimized kernels (IGX OS, DGX BaseOS)
+  - OFED drivers from [DOCA-Host](https://developer.nvidia.com/doca-archive) 2.8 or later
+    (install the `mlnx-ofed-kernel-dkms` package or the `doca-ofed` meta-package)
+- **DPDK** (for the DPDK backend) — userspace libraries are included in the
+  [Dockerfile](../Dockerfile). Inspect it if building on bare metal.
+- **libibverbs** and **librdmacm** (for the RDMA backend)
+
+### System Tuning
+
+For best performance, the system must be tuned for high-performance networking (CPU
+isolation, hugepages, NUMA awareness, etc.).
+
+<!-- TODO: Port the high-performance networking tutorial to this repository -->
+> A system tuning guide will be available in a future update.
+
+The `python/tune_system.py` script can help diagnose common configuration issues.
+
+## Building from Source
+
+### CMake
+
+```bash
+cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_MGR="dpdk rdma"
+cmake --build build -j
+cmake --install build --prefix /opt/daqiri
+```
+
+### CMake Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `DAQIRI_MGR` | `"dpdk rdma"` | Space-separated list of backends to build. Valid values: `dpdk`, `rdma`. |
+| `DAQIRI_BUILD_PYTHON` | `OFF` | Build pybind11 Python bindings. |
+| `DAQIRI_BUILD_EXAMPLES` | `ON` | Build benchmark executables. |
+| `BUILD_SHARED_LIBS` | — | Build as shared library. |
+
+CUDA architectures are hardcoded to `80;90` (A100, H100) in `src/CMakeLists.txt`.
+
+### Container Build
+
+The repository includes a Dockerfile and build script that compiles DPDK from source:
+
+```bash
+BASE_TARGET=dpdk DAQIRI_MGR="dpdk rdma" scripts/build-container.sh
+```
+
+## Running the Benchmarks
+
+Two benchmark executables are built when `DAQIRI_BUILD_EXAMPLES=ON`:
+
+- **`daqiri_bench_default`** — DPDK TX/RX throughput and latency benchmark
+- **`daqiri_bench_rdma`** — RDMA-specific benchmark
+
+Both are config-driven. Example configs are in the `examples/` directory:
+
+| Config file | Description |
+|-------------|-------------|
+| `daqiri_bench_default_tx_rx.yaml` | DPDK TX/RX, CPU-only |
+| `daqiri_bench_default_tx_rx_hds.yaml` | DPDK TX/RX with header-data split (GPUDirect) |
+| `daqiri_bench_default_rx_multi_q.yaml` | DPDK multi-queue RX |
+| `daqiri_bench_default_sw_loopback.yaml` | DPDK software loopback (no physical link needed) |
+| `daqiri_bench_rdma_tx_rx.yaml` | RDMA client/server TX/RX |
+
+Edit the YAML files to match your system (PCIe addresses, CPU cores, IP addresses) before
+running. Fields marked with `<angle brackets>` are placeholders that must be replaced.
+
+## Formatting
+
+Run clang-format before committing:
+
+```bash
+# Format staged changes
+git-clang-format --style file
+
+# Format specific files
+clang-format -style=file -i -fallback-style=none <files>
+```


### PR DESCRIPTION
## Summary
- Replace the 555-line README with a concise landing page (~65 lines) focused on what DAQIRI is, key features, quickstart, and links to deeper docs.
- Move configuration reference, API guide, and getting-started details into `docs/` (`api-guide.md`, `configuration.md`, `getting-started.md`).
- Remove Rivermax and GPUNetIO/DOCA backend references — only DPDK and RDMA backends exist in the codebase. Fix `rdma_read` typo in config docs.
- Reframe the top-of-README pitch to emphasize connecting DAQ frontends to NVIDIA GPUs for real-time processing.

## Test plan
- [ ] Render README on GitHub and verify links to `docs/*.md` resolve
- [ ] Spot-check `docs/getting-started.md` build commands against current CMake options
- [ ] Confirm no remaining references to removed backends (Rivermax, GPUNetIO, DOCA) in README/docs
- [ ] Verify `docs/configuration.md` matches current config schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)