### PR TITLE
Add install rules for benchmark examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -27,3 +27,8 @@ target_link_libraries(daqiri_bench_rdma PRIVATE daqiri::daqiri ${DAQIRI_EXAMPLE_
 foreach(cfg IN LISTS DAQIRI_BENCH_CONFIGS)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${cfg} ${CMAKE_CURRENT_BINARY_DIR}/${cfg} COPYONLY)
 endforeach()
+
+install(TARGETS daqiri_bench_default daqiri_bench_rdma
+        RUNTIME DESTINATION bin)
+install(FILES ${DAQIRI_BENCH_CONFIGS}
+        DESTINATION bin)


### PR DESCRIPTION
Benchmark example executables were not previously viewable in the container runtime image. Add install() directives so cmake --install places daqiri_bench_default, daqiri_bench_rdma, and their YAML configs into the bin/ prefix directory. This makes the benchmarks available in the container runtime image.