### PR TITLE
Added data conversion kernels and options

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -75,6 +75,10 @@ Reorder batch sizing requirement (v1):
   supported for reorder in v1.
 - `reorder_type: "gpu"` requires `device` or `host_pinned` packet/output memory.
 - `reorder_type: "cpu"` requires `host`, `host_pinned`, or `huge` packet/output memory.
+- If a reorder config includes `data_types`, `payload_len` and `aggregate_len` describe the
+  converted output element size, not the on-wire byte count.
+- `data_types.endianness: "network"` interprets byte-multiple input types wider than 8 bits as
+  network byte order before conversion.
 
 Reordered RX bursts can be identified from `burst->hdr.hdr.burst_flags`:
 - `DAQIRI_BURST_FLAG_REORDERED` means the burst contains one aggregated reorder buffer.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,6 +220,15 @@ v1 batch-size requirement:
 - **`payload_byte_offset`**: Byte offset in each packet where copied payload starts. Bytes before
   this offset are skipped.
   - type: `integer`
+- **`data_types`**: Optional payload data type conversion for GPU reorder. If omitted, payload
+  bytes are copied as-is.
+  - `input_type`: On-wire input element type. Values: `int4`, `int8`, `int16`, `int32`
+  - `output_type`: Reordered output element type. Values: `fp16`, `bf16`, `fp32`, `fp64`, `int32`
+  - `endianness`: Optional input byte order. Values: `host`, `network`; default: `host`
+  - requirements: conversion is supported for `reorder_type: "gpu"`; the output memory region
+    buffer must hold the converted batch size
+  - notes: `int4` is interpreted as two signed 4-bit two's-complement values per byte, high
+    nibble first; `network` endianness swaps byte-multiple input types wider than 8 bits
 - **`flow_ids`**: List of RX flow IDs this reorder config applies to.
   - type: `list[integer]`
   - notes: flow IDs cannot overlap across reorder configs on the same interface
@@ -235,6 +244,15 @@ v1 batch-size requirement:
     - `sequence_number.bit_width` (1..32)
     - `packets_per_batch` (>0)
     - Constraint: `2^seq_bits % packets_per_batch == 0`
+
+Example conversion from packed signed 4-bit payload samples to FP16:
+
+```yaml
+data_types:
+  input_type: "int4"
+  output_type: "fp16"
+  endianness: "host"
+```
 
 After `daqiri_init()`, each GPU reorder config must be assigned a CUDA stream. CPU reorder
 configs do not use CUDA streams:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20)
 
 project(daqiri_bench_examples LANGUAGES CXX)
 
+find_package(CUDAToolkit REQUIRED)
+
 if(TARGET yaml-cpp::yaml-cpp)
   set(DAQIRI_EXAMPLE_YAML_TARGET yaml-cpp::yaml-cpp)
 else()
@@ -14,6 +16,7 @@ set(DAQIRI_BENCH_CONFIGS
   daqiri_bench_raw_tx_rx_reorder_seq_1024.yaml
   daqiri_bench_raw_tx_rx_reorder_seq_1024_cpu.yaml
   daqiri_bench_raw_sw_loopback_reorder_seq_1024.yaml
+  daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml
   daqiri_bench_raw_rx_reorder_seq_ppb.yaml
   daqiri_bench_raw_rx_reorder_seq_batch.yaml
   daqiri_bench_raw_rx_multi_q.yaml
@@ -47,6 +50,7 @@ endfunction()
 function(add_daqiri_raw_bench target source)
   add_executable(${target} ${source} raw_bench_common.cpp)
   link_daqiri_bench(${target})
+  target_link_libraries(${target} PRIVATE CUDA::cudart)
   set_target_properties(${target} PROPERTIES
     BUILD_RPATH "$ORIGIN/../src;$ORIGIN/../src/third_party/yaml-cpp"
   )
@@ -55,6 +59,7 @@ endfunction()
 add_daqiri_raw_bench(daqiri_bench_raw_hds raw_hds_bench.cpp)
 add_daqiri_raw_bench(daqiri_bench_raw_gpudirect raw_gpudirect_bench.cpp)
 add_daqiri_raw_bench(daqiri_bench_raw_reorder_seq raw_reorder_seq_bench.cpp)
+add_daqiri_raw_bench(daqiri_bench_raw_reorder_quantize raw_reorder_quantize_bench.cpp)
 
 add_executable(daqiri_bench_rdma rdma_bench.cpp)
 link_daqiri_bench(daqiri_bench_rdma)
@@ -73,6 +78,7 @@ install(TARGETS
         daqiri_bench_raw_hds
         daqiri_bench_raw_gpudirect
         daqiri_bench_raw_reorder_seq
+        daqiri_bench_raw_reorder_quantize
         daqiri_bench_rdma
         daqiri_bench_socket
         RUNTIME DESTINATION bin)

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ Standalone benchmark applications for testing performance of DAQIRI with various
 - `daqiri_bench_raw_gpudirect`: raw TX/RX with one device-memory packet segment
 - `daqiri_bench_raw_hds`: raw TX/RX with header-data split
 - `daqiri_bench_raw_reorder_seq`: raw RX sequence-number reorder benchmark
+- `daqiri_bench_raw_reorder_quantize`: raw RX sequence reorder with payload conversion
 - `daqiri_bench_rdma`: RDMA benchmark logic (former `rdma_bench.h`)
 - `daqiri_bench_socket`: TCP/UDP socket benchmark logic
 
@@ -21,6 +22,7 @@ Run:
 ./build/examples/daqiri_bench_raw_gpudirect ./build/examples/daqiri_bench_raw_tx_rx.yaml --seconds 10
 ./build/examples/daqiri_bench_raw_hds ./build/examples/daqiri_bench_raw_tx_rx_hds.yaml --seconds 10
 ./build/examples/daqiri_bench_raw_reorder_seq ./build/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024.yaml --seconds 10
+./build/examples/daqiri_bench_raw_reorder_quantize ./build/examples/daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml --seconds 10
 ./build/examples/daqiri_bench_rdma ./build/examples/daqiri_bench_rdma_tx_rx.yaml --seconds 10 --mode both
 ./build/examples/daqiri_bench_socket ./build/examples/daqiri_bench_socket_udp_tx_rx.yaml --seconds 10 --mode both
 ./build/examples/daqiri_bench_socket ./build/examples/daqiri_bench_socket_tcp_tx_rx.yaml --seconds 10 --mode both
@@ -39,6 +41,7 @@ Included configs:
 | `daqiri_bench_raw_sw_loopback_reorder_seq_1024.yaml` | `daqiri_bench_raw_reorder_seq` |
 | `daqiri_bench_raw_rx_reorder_seq_ppb.yaml` | `daqiri_bench_raw_reorder_seq` |
 | `daqiri_bench_raw_rx_reorder_seq_batch.yaml` | `daqiri_bench_raw_reorder_seq` |
+| `daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml` | `daqiri_bench_raw_reorder_quantize` |
 | `daqiri_bench_rdma_tx_rx.yaml` | `daqiri_bench_rdma` |
 | `daqiri_bench_socket_udp_tx_rx.yaml` | `daqiri_bench_socket` |
 | `daqiri_bench_socket_tcp_tx_rx.yaml` | `daqiri_bench_socket` |

--- a/examples/daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml
@@ -1,0 +1,112 @@
+%YAML 1.2
+---
+daqiri:
+  cfg:
+    version: 1
+    stream_type: "raw"
+    master_core: 3
+    debug: false
+    log_level: "info"
+    loopback: ""
+
+    memory_regions:
+    - name: "Data_TX_GPU"
+      kind: "device"
+      affinity: 0
+      num_bufs: 16384
+      buf_size: 2048
+    - name: "Data_RX_GPU"
+      kind: "device"
+      affinity: 0
+      num_bufs: 16384
+      buf_size: 2048
+    - name: "Reorder_RX_GPU"
+      kind: "device"
+      affinity: 0
+      num_bufs: 128
+      # Worst-case validated size uses the source MR slot: (2048 - 64) int4 bytes -> fp32
+      # for 256 packets per seq_batch_number batch: 1,984 * 2 * 4 * 256 = 4,063,232 bytes.
+      buf_size: 4063232
+
+    interfaces:
+    - name: "tx_port"
+      address: <0000:00:00.0>
+      tx:
+        queues:
+        - name: "tx_q_0"
+          id: 0
+          batch_size: 256
+          cpu_core: 11
+          memory_regions:
+            - "Data_TX_GPU"
+          offloads:
+            - "tx_eth_src"
+    - name: "rx_port"
+      address: <0000:00:00.1>
+      rx:
+        flow_isolation: true
+        queues:
+        - name: "rx_q_0"
+          id: 0
+          cpu_core: 9
+          batch_size: 256
+          timeout_us: 20000
+          memory_regions:
+            - "Data_RX_GPU"
+        flows:
+        - name: "flow_0"
+          id: 201
+          action:
+            type: queue
+            id: 0
+          match:
+            udp_src: 5000
+            udp_dst: 5000
+        reorder_configs:
+        - name: "rx_reorder_quantize_seq_batch"
+          reorder_type: "gpu"
+          memory_region: "Reorder_RX_GPU"
+          payload_byte_offset: 64
+          flow_ids:
+            - 201
+          data_types:
+            input_type: "int4"
+            output_type: "fp32"
+            endianness: "host"
+          method:
+            seq_batch_number:
+              sequence_number:
+                bit_offset: 128
+                bit_width: 10
+              batch_number:
+                bit_offset: 144
+                bit_width: 2
+
+bench_rx:
+  interface_name: "rx_port"
+  gpu_direct: true
+  split_boundary: false
+  batch_size: 256
+  max_packet_size: 2048
+  header_size: 64
+
+bench_tx:
+  interface_name: "tx_port"
+  gpu_direct: true
+  split_boundary: false
+  batch_size: 256
+  payload_size: 256
+  header_size: 64
+  eth_dst_addr: <00:00:00:00:00:00>
+  ip_src_addr: <1.2.3.4>
+  ip_dst_addr: <5.6.7.8>
+  udp_src_port: 5000
+  udp_dst_port: 5000
+
+bench_reorder_quantize:
+  input_type: "int4"
+  output_type: "fp32"
+  endianness: "host"
+  verify_batches: 3
+  verify_chunks: 6
+  chunk_elements: 16

--- a/examples/raw_bench_common.cpp
+++ b/examples/raw_bench_common.cpp
@@ -35,6 +35,49 @@ volatile std::sig_atomic_t g_stop_requested = 0;
 
 }  // namespace
 
+PinnedHostBuffer::PinnedHostBuffer(PinnedHostBuffer&& other) noexcept {
+  ptr_ = other.ptr_;
+  capacity_ = other.capacity_;
+  other.ptr_ = nullptr;
+  other.capacity_ = 0;
+}
+
+PinnedHostBuffer& PinnedHostBuffer::operator=(PinnedHostBuffer&& other) noexcept {
+  if (this != &other) {
+    reset();
+    ptr_ = other.ptr_;
+    capacity_ = other.capacity_;
+    other.ptr_ = nullptr;
+    other.capacity_ = 0;
+  }
+  return *this;
+}
+
+PinnedHostBuffer::~PinnedHostBuffer() { reset(); }
+
+bool PinnedHostBuffer::resize(size_t size) {
+  if (size <= capacity_) { return true; }
+  reset();
+  if (size == 0) { return true; }
+  if (cudaHostAlloc(&ptr_, size, cudaHostAllocDefault) != cudaSuccess) { return false; }
+  capacity_ = size;
+  return true;
+}
+
+void PinnedHostBuffer::reset() {
+  if (ptr_ != nullptr) {
+    cudaFreeHost(ptr_);
+    ptr_ = nullptr;
+    capacity_ = 0;
+  }
+}
+
+uint8_t* PinnedHostBuffer::data() { return static_cast<uint8_t*>(ptr_); }
+
+const uint8_t* PinnedHostBuffer::data() const { return static_cast<const uint8_t*>(ptr_); }
+
+size_t PinnedHostBuffer::capacity() const { return capacity_; }
+
 int parse_run_seconds(int argc, char** argv) {
   int run_seconds = 10;
   for (int i = 2; i + 1 < argc; i += 2) {
@@ -115,6 +158,20 @@ void populate_udp_ipv4_headers(uint8_t* pkt_data,
   pkt->udp.check = 0;
   pkt->udp.len = htons(
       static_cast<uint16_t>(payload_size + header_size - (sizeof(ethhdr) + sizeof(iphdr))));
+}
+
+cudaError_t memcpy_batch_async(const std::vector<void*>& dsts,
+                               const std::vector<const void*>& srcs,
+                               const std::vector<size_t>& sizes,
+                               cudaStream_t stream) {
+  if (dsts.empty()) { return cudaSuccess; }
+
+  cudaMemcpyAttributes attr{};
+  attr.srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+  attr.flags = cudaMemcpyFlagDefault;
+  size_t attr_idx = 0;
+  return cudaMemcpyBatchAsync(
+      dsts.data(), srcs.data(), sizes.data(), dsts.size(), &attr, &attr_idx, 1, stream);
 }
 
 void signal_handler(int signum) {

--- a/examples/raw_bench_common.h
+++ b/examples/raw_bench_common.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
 #include <yaml-cpp/yaml.h>
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -42,6 +44,28 @@ struct RawBenchRxConfig {
   std::string interface_name = "rx_port";
 };
 
+class PinnedHostBuffer {
+ public:
+  PinnedHostBuffer() = default;
+  PinnedHostBuffer(const PinnedHostBuffer&) = delete;
+  PinnedHostBuffer& operator=(const PinnedHostBuffer&) = delete;
+
+  PinnedHostBuffer(PinnedHostBuffer&& other) noexcept;
+  PinnedHostBuffer& operator=(PinnedHostBuffer&& other) noexcept;
+  ~PinnedHostBuffer();
+
+  bool resize(size_t size);
+  void reset();
+
+  uint8_t* data();
+  const uint8_t* data() const;
+  size_t capacity() const;
+
+ private:
+  void* ptr_ = nullptr;
+  size_t capacity_ = 0;
+};
+
 int parse_run_seconds(int argc, char** argv);
 bool has_bench_rx(const YAML::Node& root);
 bool has_bench_tx(const YAML::Node& root);
@@ -57,6 +81,11 @@ void populate_udp_ipv4_headers(uint8_t* pkt_data,
                                uint32_t ip_dst_host,
                                uint16_t src_port,
                                uint16_t dst_port);
+
+cudaError_t memcpy_batch_async(const std::vector<void*>& dsts,
+                               const std::vector<const void*>& srcs,
+                               const std::vector<size_t>& sizes,
+                               cudaStream_t stream);
 
 void signal_handler(int signum);
 void wait_for_stop(int run_seconds, std::atomic<bool>& stop);

--- a/examples/raw_reorder_quantize_bench.cpp
+++ b/examples/raw_reorder_quantize_bench.cpp
@@ -1,0 +1,849 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <arpa/inet.h>
+#include <cuda_runtime.h>
+#include <yaml-cpp/yaml.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <csignal>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "raw_bench_common.h"
+#include "src/common.h"
+
+namespace {
+
+volatile std::sig_atomic_t g_stop_requested = 0;
+
+void signal_handler(int signum) {
+  if (signum == SIGINT) { g_stop_requested = 1; }
+}
+
+enum class SampleType {
+  INT4,
+  INT8,
+  INT16,
+  INT32,
+  FP16,
+  BF16,
+  FP32,
+  FP64,
+  INVALID,
+};
+
+enum class Endianness {
+  HOST,
+  NETWORK,
+  INVALID,
+};
+
+struct BitField {
+  uint32_t bit_offset = 0;
+  uint8_t bit_width = 0;
+};
+
+struct ReorderPlanConfig {
+  std::string interface_name;
+  std::string reorder_name;
+  BitField sequence_number;
+  BitField batch_number;
+  uint32_t packets_per_batch = 0;
+  uint32_t payload_byte_offset = 0;
+  SampleType input_type = SampleType::INT32;
+  SampleType output_type = SampleType::INT32;
+  Endianness input_endianness = Endianness::HOST;
+  bool data_types_defined = false;
+};
+
+struct BenchConfig {
+  std::string interface_name = "loopback_ports";
+  uint32_t queue_id = 0;
+  uint32_t batch_size = 256;
+  uint32_t payload_size = 256;
+  uint32_t header_size = 64;
+  std::string eth_dst_addr = "00:00:00:00:00:00";
+  std::string ip_src_addr = "1.2.3.4";
+  std::string ip_dst_addr = "5.6.7.8";
+  uint16_t udp_src_port = 4096;
+  uint16_t udp_dst_port = 4096;
+  SampleType input_type = SampleType::INT4;
+  SampleType output_type = SampleType::FP32;
+  Endianness input_endianness = Endianness::HOST;
+  uint32_t verify_batches = 3;
+  uint32_t verify_chunks = 6;
+  uint32_t chunk_elements = 16;
+};
+
+struct SharedStats {
+  std::atomic<uint32_t> verified_batches{0};
+  std::atomic<uint32_t> verified_chunks{0};
+  std::atomic<uint32_t> failures{0};
+};
+
+SampleType sample_type_from_string(const std::string& value) {
+  if (value == "int4") { return SampleType::INT4; }
+  if (value == "int8") { return SampleType::INT8; }
+  if (value == "int16") { return SampleType::INT16; }
+  if (value == "int32") { return SampleType::INT32; }
+  if (value == "fp16") { return SampleType::FP16; }
+  if (value == "bf16") { return SampleType::BF16; }
+  if (value == "fp32") { return SampleType::FP32; }
+  if (value == "fp64") { return SampleType::FP64; }
+  return SampleType::INVALID;
+}
+
+std::string sample_type_to_string(SampleType type) {
+  switch (type) {
+    case SampleType::INT4:
+      return "int4";
+    case SampleType::INT8:
+      return "int8";
+    case SampleType::INT16:
+      return "int16";
+    case SampleType::INT32:
+      return "int32";
+    case SampleType::FP16:
+      return "fp16";
+    case SampleType::BF16:
+      return "bf16";
+    case SampleType::FP32:
+      return "fp32";
+    case SampleType::FP64:
+      return "fp64";
+    default:
+      return "invalid";
+  }
+}
+
+const char* endianness_to_string(Endianness endianness) {
+  switch (endianness) {
+    case Endianness::HOST:
+      return "host";
+    case Endianness::NETWORK:
+      return "network";
+    default:
+      return "invalid";
+  }
+}
+
+Endianness endianness_from_string(const std::string& value) {
+  if (value == "host") { return Endianness::HOST; }
+  if (value == "network") { return Endianness::NETWORK; }
+  return Endianness::INVALID;
+}
+
+uint32_t input_type_bits(SampleType type) {
+  switch (type) {
+    case SampleType::INT4:
+      return 4;
+    case SampleType::INT8:
+      return 8;
+    case SampleType::INT16:
+      return 16;
+    case SampleType::INT32:
+      return 32;
+    default:
+      return 0;
+  }
+}
+
+uint32_t output_type_bytes(SampleType type) {
+  switch (type) {
+    case SampleType::FP16:
+    case SampleType::BF16:
+      return 2;
+    case SampleType::FP32:
+    case SampleType::INT32:
+      return 4;
+    case SampleType::FP64:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+uint32_t element_count_for_payload(uint32_t payload_size, SampleType input_type) {
+  const uint32_t bits = input_type_bits(input_type);
+  if (bits == 0) { return 0; }
+  const uint64_t payload_bits = static_cast<uint64_t>(payload_size) * 8ULL;
+  if ((payload_bits % bits) != 0ULL) { return 0; }
+  return static_cast<uint32_t>(payload_bits / bits);
+}
+
+uint32_t bit_field_end_byte(const BitField& field) {
+  return (field.bit_offset + field.bit_width + 7U) / 8U;
+}
+
+uint32_t bit_field_value_mask(uint8_t bit_width) {
+  return bit_width >= 32U ? std::numeric_limits<uint32_t>::max() : ((1U << bit_width) - 1U);
+}
+
+void set_bits_be(uint8_t* data, uint32_t bit_offset, uint8_t bit_width, uint32_t value) {
+  for (uint8_t i = 0; i < bit_width; ++i) {
+    const uint32_t src_shift = static_cast<uint32_t>(bit_width - 1U - i);
+    const uint8_t bit = static_cast<uint8_t>((value >> src_shift) & 0x1U);
+    const uint32_t bit_idx = bit_offset + i;
+    const uint32_t byte_idx = bit_idx / 8U;
+    const uint8_t bit_pos = static_cast<uint8_t>(7U - (bit_idx % 8U));
+    const uint8_t mask = static_cast<uint8_t>(1U << bit_pos);
+    data[byte_idx] = static_cast<uint8_t>((data[byte_idx] & ~mask) | (bit << bit_pos));
+  }
+}
+
+int32_t expected_value(uint32_t slot_idx, uint32_t element_idx) {
+  const uint32_t raw = static_cast<uint32_t>((slot_idx * 3ULL + element_idx) % 15ULL);
+  return static_cast<int32_t>(raw) - 7;
+}
+
+void write_int16(uint8_t* dst, int32_t value, Endianness endianness) {
+  const auto raw = static_cast<uint16_t>(static_cast<int16_t>(value));
+  if (endianness == Endianness::NETWORK) {
+    dst[0] = static_cast<uint8_t>(raw >> 8U);
+    dst[1] = static_cast<uint8_t>(raw & 0xFFU);
+  } else {
+    dst[0] = static_cast<uint8_t>(raw & 0xFFU);
+    dst[1] = static_cast<uint8_t>(raw >> 8U);
+  }
+}
+
+void write_int32(uint8_t* dst, int32_t value, Endianness endianness) {
+  const auto raw = static_cast<uint32_t>(value);
+  if (endianness == Endianness::NETWORK) {
+    dst[0] = static_cast<uint8_t>((raw >> 24U) & 0xFFU);
+    dst[1] = static_cast<uint8_t>((raw >> 16U) & 0xFFU);
+    dst[2] = static_cast<uint8_t>((raw >> 8U) & 0xFFU);
+    dst[3] = static_cast<uint8_t>(raw & 0xFFU);
+  } else {
+    dst[0] = static_cast<uint8_t>(raw & 0xFFU);
+    dst[1] = static_cast<uint8_t>((raw >> 8U) & 0xFFU);
+    dst[2] = static_cast<uint8_t>((raw >> 16U) & 0xFFU);
+    dst[3] = static_cast<uint8_t>((raw >> 24U) & 0xFFU);
+  }
+}
+
+void fill_payload(uint8_t* payload,
+                  uint32_t payload_size,
+                  SampleType input_type,
+                  Endianness endianness,
+                  uint32_t slot_idx) {
+  const uint32_t element_count = element_count_for_payload(payload_size, input_type);
+  std::memset(payload, 0, payload_size);
+
+  switch (input_type) {
+    case SampleType::INT4:
+      for (uint32_t element_idx = 0; element_idx < element_count; element_idx += 2U) {
+        const uint8_t high = static_cast<uint8_t>(expected_value(slot_idx, element_idx)) & 0x0FU;
+        const uint8_t low = static_cast<uint8_t>(expected_value(slot_idx, element_idx + 1U)) & 0x0FU;
+        payload[element_idx / 2U] = static_cast<uint8_t>((high << 4U) | low);
+      }
+      break;
+    case SampleType::INT8:
+      for (uint32_t element_idx = 0; element_idx < element_count; ++element_idx) {
+        payload[element_idx] =
+            static_cast<uint8_t>(
+                static_cast<int8_t>(expected_value(slot_idx, element_idx)));
+      }
+      break;
+    case SampleType::INT16:
+      for (uint32_t element_idx = 0; element_idx < element_count; ++element_idx) {
+        write_int16(payload + (element_idx * 2U),
+                    expected_value(slot_idx, element_idx),
+                    endianness);
+      }
+      break;
+    case SampleType::INT32:
+      for (uint32_t element_idx = 0; element_idx < element_count; ++element_idx) {
+        write_int32(payload + (element_idx * 4U),
+                    expected_value(slot_idx, element_idx),
+                    endianness);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+float half_to_float(uint16_t half) {
+  const uint32_t sign = static_cast<uint32_t>(half & 0x8000U) << 16U;
+  uint32_t exp = (half >> 10U) & 0x1FU;
+  uint32_t mant = half & 0x03FFU;
+  uint32_t bits = 0;
+
+  if (exp == 0) {
+    if (mant == 0) {
+      bits = sign;
+    } else {
+      exp = 1;
+      while ((mant & 0x0400U) == 0U) {
+        mant <<= 1U;
+        --exp;
+      }
+      mant &= 0x03FFU;
+      bits = sign | ((exp + 127U - 15U) << 23U) | (mant << 13U);
+    }
+  } else if (exp == 0x1FU) {
+    bits = sign | 0x7F800000U | (mant << 13U);
+  } else {
+    bits = sign | ((exp + 127U - 15U) << 23U) | (mant << 13U);
+  }
+
+  float value = 0.0F;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+float bf16_to_float(uint16_t bf16) {
+  const uint32_t bits = static_cast<uint32_t>(bf16) << 16U;
+  float value = 0.0F;
+  std::memcpy(&value, &bits, sizeof(value));
+  return value;
+}
+
+double read_output_value(const uint8_t* data, SampleType output_type, uint32_t element_idx) {
+  switch (output_type) {
+    case SampleType::FP16: {
+      uint16_t bits = 0;
+      std::memcpy(&bits, data + (element_idx * 2U), sizeof(bits));
+      return static_cast<double>(half_to_float(bits));
+    }
+    case SampleType::BF16: {
+      uint16_t bits = 0;
+      std::memcpy(&bits, data + (element_idx * 2U), sizeof(bits));
+      return static_cast<double>(bf16_to_float(bits));
+    }
+    case SampleType::FP32: {
+      float value = 0.0F;
+      std::memcpy(&value, data + (element_idx * 4U), sizeof(value));
+      return static_cast<double>(value);
+    }
+    case SampleType::FP64: {
+      double value = 0.0;
+      std::memcpy(&value, data + (element_idx * 8U), sizeof(value));
+      return value;
+    }
+    case SampleType::INT32: {
+      int32_t value = 0;
+      std::memcpy(&value, data + (element_idx * 4U), sizeof(value));
+      return static_cast<double>(value);
+    }
+    default:
+      return std::numeric_limits<double>::quiet_NaN();
+  }
+}
+
+bool nearly_equal(double actual, double expected) {
+  return std::fabs(actual - expected) <= 0.001;
+}
+
+bool verify_reorder_output(const uint8_t* output,
+                           const daqiri::ReorderBurstInfo& info,
+                           const BenchConfig& cfg) {
+  const uint32_t element_count = element_count_for_payload(cfg.payload_size, cfg.input_type);
+  const uint32_t output_bytes = output_type_bytes(cfg.output_type);
+  if (element_count == 0 || output_bytes == 0 || info.payload_len != element_count * output_bytes) {
+    std::cerr << "Unexpected output payload length. got=" << info.payload_len
+              << " expected=" << (element_count * output_bytes) << "\n";
+    return false;
+  }
+
+  const uint32_t chunk_elements = std::min(cfg.chunk_elements, element_count);
+  const uint32_t span = element_count - chunk_elements + 1U;
+
+  for (uint32_t chunk_idx = 0; chunk_idx < cfg.verify_chunks; ++chunk_idx) {
+    const uint32_t slot_idx =
+        static_cast<uint32_t>((static_cast<uint64_t>(chunk_idx) * 37ULL) % info.packets_per_batch);
+    const uint32_t element_start =
+        static_cast<uint32_t>((static_cast<uint64_t>(chunk_idx) * 53ULL) % span);
+    const uint8_t* slot = output + (static_cast<size_t>(slot_idx) * info.payload_len);
+
+    for (uint32_t i = 0; i < chunk_elements; ++i) {
+      const uint32_t element_idx = element_start + i;
+      const double expected = static_cast<double>(expected_value(slot_idx, element_idx));
+      const double actual = read_output_value(slot, cfg.output_type, element_idx);
+      if (!nearly_equal(actual, expected)) {
+        std::cerr << "Verification mismatch batch_id=" << info.batch_id
+                  << " slot=" << slot_idx
+                  << " element=" << element_idx
+                  << " expected=" << expected
+                  << " actual=" << actual << "\n";
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+BitField parse_bit_field(const YAML::Node& node, const std::string& key) {
+  BitField field;
+  field.bit_offset = node[key]["bit_offset"].as<uint32_t>();
+  field.bit_width = node[key]["bit_width"].as<uint8_t>();
+  return field;
+}
+
+ReorderPlanConfig parse_reorder_plan(const YAML::Node& root) {
+  const auto interfaces = root["daqiri"]["cfg"]["interfaces"];
+  for (const auto& intf : interfaces) {
+    const auto rx = intf["rx"];
+    if (!rx || !rx["reorder_configs"]) { continue; }
+    for (const auto& reorder : rx["reorder_configs"]) {
+      if (reorder["reorder_type"].as<std::string>("") != "gpu") { continue; }
+      if (!reorder["method"] || !reorder["method"]["seq_batch_number"]) { continue; }
+      ReorderPlanConfig plan;
+      plan.interface_name = intf["name"].as<std::string>();
+      plan.reorder_name = reorder["name"].as<std::string>();
+      plan.payload_byte_offset = reorder["payload_byte_offset"].as<uint32_t>();
+      if (reorder["data_types"]) {
+        const auto data_types = reorder["data_types"];
+        const auto input_node =
+            data_types["input_type"] ? data_types["input_type"] : data_types["input"];
+        const auto output_node =
+            data_types["output_type"] ? data_types["output_type"] : data_types["output"];
+        if (!input_node || !output_node) {
+          throw std::runtime_error("Reorder data_types requires input_type and output_type");
+        }
+        plan.input_type = sample_type_from_string(input_node.as<std::string>());
+        plan.output_type = sample_type_from_string(output_node.as<std::string>());
+        const auto endianness_node =
+            data_types["endianness"] ? data_types["endianness"] : data_types["input_endianness"];
+        plan.input_endianness =
+            endianness_from_string(endianness_node.as<std::string>("host"));
+        plan.data_types_defined = true;
+      }
+      const auto seq_batch = reorder["method"]["seq_batch_number"];
+      plan.sequence_number = parse_bit_field(seq_batch, "sequence_number");
+      plan.batch_number = parse_bit_field(seq_batch, "batch_number");
+      plan.packets_per_batch =
+          (1U << plan.sequence_number.bit_width) / (1U << plan.batch_number.bit_width);
+      return plan;
+    }
+  }
+  throw std::runtime_error("No GPU seq_batch_number reorder config found");
+}
+
+BenchConfig parse_bench_config(const YAML::Node& root, const ReorderPlanConfig& plan) {
+  BenchConfig cfg;
+  const auto bench = root["bench_reorder_quantize"];
+  cfg.input_type = plan.input_type;
+  cfg.output_type = plan.output_type;
+  cfg.input_endianness = plan.input_endianness;
+
+  if (root["bench_tx"] && root["bench_tx"]["interface_name"]) {
+    cfg.interface_name = root["bench_tx"]["interface_name"].as<std::string>(cfg.interface_name);
+  } else {
+    cfg.interface_name = plan.interface_name;
+  }
+  if (root["bench_tx"]) {
+    const auto tx = root["bench_tx"];
+    cfg.batch_size = tx["batch_size"].as<uint32_t>(cfg.batch_size);
+    cfg.payload_size = tx["payload_size"].as<uint32_t>(cfg.payload_size);
+    cfg.header_size = tx["header_size"].as<uint32_t>(cfg.header_size);
+    cfg.eth_dst_addr = tx["eth_dst_addr"].as<std::string>(cfg.eth_dst_addr);
+    cfg.ip_src_addr = tx["ip_src_addr"].as<std::string>(cfg.ip_src_addr);
+    cfg.ip_dst_addr = tx["ip_dst_addr"].as<std::string>(cfg.ip_dst_addr);
+    cfg.udp_src_port = tx["udp_src_port"].as<uint16_t>(cfg.udp_src_port);
+    cfg.udp_dst_port = tx["udp_dst_port"].as<uint16_t>(cfg.udp_dst_port);
+  }
+
+  if (bench) {
+    const auto bench_input = sample_type_from_string(bench["input_type"].as<std::string>(
+        sample_type_to_string(cfg.input_type)));
+    const auto bench_output = sample_type_from_string(bench["output_type"].as<std::string>(
+        sample_type_to_string(cfg.output_type)));
+    const auto bench_endianness =
+        endianness_from_string(bench["endianness"].as<std::string>(
+            endianness_to_string(cfg.input_endianness)));
+    if (bench_input != cfg.input_type || bench_output != cfg.output_type
+        || bench_endianness != cfg.input_endianness) {
+      throw std::runtime_error("bench_reorder_quantize types must match reorder data_types");
+    }
+    cfg.verify_batches = bench["verify_batches"].as<uint32_t>(cfg.verify_batches);
+    cfg.verify_chunks = bench["verify_chunks"].as<uint32_t>(cfg.verify_chunks);
+    cfg.chunk_elements = bench["chunk_elements"].as<uint32_t>(cfg.chunk_elements);
+  }
+
+  if (cfg.input_type == SampleType::INVALID || input_type_bits(cfg.input_type) == 0) {
+    throw std::runtime_error("Invalid bench input_type");
+  }
+  if (cfg.output_type == SampleType::INVALID || output_type_bytes(cfg.output_type) == 0) {
+    throw std::runtime_error("Invalid bench output_type");
+  }
+  if (cfg.input_endianness == Endianness::INVALID) {
+    throw std::runtime_error("Invalid bench endianness");
+  }
+  if (!plan.data_types_defined) {
+    throw std::runtime_error("Reorder quantize example requires reorder data_types");
+  }
+  if (element_count_for_payload(cfg.payload_size, cfg.input_type) == 0) {
+    throw std::runtime_error("payload_size is not an integral number of input elements");
+  }
+  if (cfg.header_size > plan.payload_byte_offset) {
+    throw std::runtime_error("bench_tx header_size must not exceed reorder payload_byte_offset");
+  }
+  const auto packet_size =
+      static_cast<size_t>(std::max(cfg.header_size, plan.payload_byte_offset)) + cfg.payload_size;
+  const uint64_t packet_bits = static_cast<uint64_t>(packet_size) * 8ULL;
+  const uint64_t sequence_end_bit =
+      static_cast<uint64_t>(plan.sequence_number.bit_offset) + plan.sequence_number.bit_width;
+  const uint64_t batch_end_bit =
+      static_cast<uint64_t>(plan.batch_number.bit_offset) + plan.batch_number.bit_width;
+  if (plan.sequence_number.bit_width == 0 || plan.batch_number.bit_width == 0
+      || sequence_end_bit > packet_bits || batch_end_bit > packet_bits) {
+    throw std::runtime_error("Reorder sequence or batch field is outside the TX packet");
+  }
+  if (bit_field_end_byte(plan.sequence_number) > plan.payload_byte_offset
+      || bit_field_end_byte(plan.batch_number) > plan.payload_byte_offset) {
+    throw std::runtime_error(
+        "Fast quantize example requires sequence and batch fields before payload_byte_offset");
+  }
+  if (cfg.batch_size < plan.packets_per_batch) {
+    throw std::runtime_error("TX batch_size must be >= packets_per_batch");
+  }
+  return cfg;
+}
+
+void tx_worker(const BenchConfig& cfg,
+               const ReorderPlanConfig& plan,
+               std::atomic<bool>& stop,
+               SharedStats& stats) {
+  const int port_id = daqiri::get_port_id(cfg.interface_name);
+  if (port_id < 0) {
+    std::cerr << "Invalid TX interface_name: " << cfg.interface_name << "\n";
+    stats.failures.fetch_add(1);
+    stop.store(true);
+    return;
+  }
+
+  char eth_dst[6] = {0};
+  daqiri::format_eth_addr(eth_dst, cfg.eth_dst_addr);
+
+  uint32_t ip_src = 0;
+  uint32_t ip_dst = 0;
+  inet_pton(AF_INET, cfg.ip_src_addr.c_str(), &ip_src);
+  inet_pton(AF_INET, cfg.ip_dst_addr.c_str(), &ip_dst);
+  ip_src = ntohl(ip_src);
+  ip_dst = ntohl(ip_dst);
+
+  uint32_t current_batch_id = 0;
+  uint32_t packets_in_current_batch = 0;
+  uint32_t next_slot_assignment = 0;
+  const auto packet_size =
+      static_cast<size_t>(std::max(cfg.header_size, plan.payload_byte_offset)) + cfg.payload_size;
+  const auto wire_payload_size = static_cast<uint32_t>(packet_size - cfg.header_size);
+  daqiri::bench::PinnedHostBuffer packet_template;
+  daqiri::bench::PinnedHostBuffer tx_copy_staging;
+  if (!packet_template.resize(packet_size) ||
+      !tx_copy_staging.resize(packet_size * cfg.batch_size)) {
+    std::cerr << "Failed to allocate pinned TX staging buffers\n";
+    stats.failures.fetch_add(1);
+    stop.store(true);
+    return;
+  }
+  daqiri::bench::populate_udp_ipv4_headers(packet_template.data(),
+                                           cfg.header_size,
+                                           wire_payload_size,
+                                           eth_dst,
+                                           ip_src,
+                                           ip_dst,
+                                           cfg.udp_src_port,
+                                           cfg.udp_dst_port);
+
+  const uint32_t patch_start = std::min(plan.sequence_number.bit_offset / 8U,
+                                        plan.batch_number.bit_offset / 8U);
+  const uint32_t patch_end =
+      std::max(bit_field_end_byte(plan.sequence_number), bit_field_end_byte(plan.batch_number));
+  const size_t metadata_patch_size = patch_end - patch_start;
+  const uint32_t sequence_mask = bit_field_value_mask(plan.sequence_number.bit_width);
+  const uint32_t batch_mask = bit_field_value_mask(plan.batch_number.bit_width);
+  std::unordered_map<void*, uint32_t> tx_buffer_slots;
+  cudaStream_t tx_copy_stream = nullptr;
+  std::vector<void*> batch_copy_dsts;
+  std::vector<const void*> batch_copy_srcs;
+  std::vector<size_t> batch_copy_sizes;
+  if (cudaStreamCreateWithFlags(&tx_copy_stream, cudaStreamNonBlocking) != cudaSuccess) {
+    std::cerr << "Failed to create TX copy stream\n";
+    stats.failures.fetch_add(1);
+    stop.store(true);
+    return;
+  }
+  batch_copy_dsts.reserve(cfg.batch_size);
+  batch_copy_srcs.reserve(cfg.batch_size);
+  batch_copy_sizes.reserve(cfg.batch_size);
+
+  while (!stop.load()) {
+    auto* msg = daqiri::create_tx_burst_params();
+    daqiri::set_header(msg, static_cast<uint16_t>(port_id), cfg.queue_id, cfg.batch_size, 1);
+
+    if (!daqiri::is_tx_burst_available(msg)) {
+      daqiri::free_tx_metadata(msg);
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+      continue;
+    }
+    if (daqiri::get_tx_packet_burst(msg) != daqiri::Status::SUCCESS) {
+      daqiri::free_tx_metadata(msg);
+      continue;
+    }
+
+    bool failed = false;
+    const auto num_pkts = static_cast<int>(daqiri::get_num_packets(msg));
+    if (num_pkts > static_cast<int>(cfg.batch_size)) {
+      std::cerr << "TX burst packet count exceeds configured batch_size\n";
+      failed = true;
+    }
+    size_t staging_offset = 0;
+    batch_copy_dsts.clear();
+    batch_copy_srcs.clear();
+    batch_copy_sizes.clear();
+    for (int i = 0; i < num_pkts; ++i) {
+      if (failed) { break; }
+      const uint32_t batch_id = current_batch_id & batch_mask;
+
+      auto* gpu_pkt = static_cast<uint8_t*>(daqiri::get_segment_packet_ptr(msg, 0, i));
+      if (gpu_pkt == nullptr) {
+        failed = true;
+        break;
+      }
+
+      const auto [slot_it, inserted] = tx_buffer_slots.emplace(gpu_pkt, next_slot_assignment);
+      if (inserted) {
+        next_slot_assignment = (next_slot_assignment + 1U) % plan.packets_per_batch;
+      }
+
+      const uint32_t sequence =
+          ((batch_id * plan.packets_per_batch) + slot_it->second) & sequence_mask;
+      if (inserted) {
+        auto* packet_init = tx_copy_staging.data() + staging_offset;
+        staging_offset += packet_size;
+        std::memcpy(packet_init, packet_template.data(), packet_size);
+        fill_payload(packet_init + plan.payload_byte_offset,
+                     cfg.payload_size,
+                     cfg.input_type,
+                     cfg.input_endianness,
+                     slot_it->second);
+        set_bits_be(packet_init,
+                    plan.sequence_number.bit_offset,
+                    plan.sequence_number.bit_width,
+                    sequence);
+        set_bits_be(packet_init,
+                    plan.batch_number.bit_offset,
+                    plan.batch_number.bit_width,
+                    batch_id);
+        batch_copy_dsts.push_back(gpu_pkt);
+        batch_copy_srcs.push_back(packet_init);
+        batch_copy_sizes.push_back(packet_size);
+      } else {
+        auto* metadata_patch = tx_copy_staging.data() + staging_offset;
+        staging_offset += metadata_patch_size;
+        std::memcpy(metadata_patch, packet_template.data() + patch_start, metadata_patch_size);
+        set_bits_be(metadata_patch,
+                    plan.sequence_number.bit_offset - (patch_start * 8U),
+                    plan.sequence_number.bit_width,
+                    sequence);
+        set_bits_be(metadata_patch,
+                    plan.batch_number.bit_offset - (patch_start * 8U),
+                    plan.batch_number.bit_width,
+                    batch_id);
+        batch_copy_dsts.push_back(gpu_pkt + patch_start);
+        batch_copy_srcs.push_back(metadata_patch);
+        batch_copy_sizes.push_back(metadata_patch_size);
+      }
+      ++packets_in_current_batch;
+      if (packets_in_current_batch == plan.packets_per_batch) {
+        packets_in_current_batch = 0;
+        ++current_batch_id;
+      }
+    }
+
+    if (!failed && !batch_copy_dsts.empty()) {
+      const auto copy_status = daqiri::bench::memcpy_batch_async(
+          batch_copy_dsts, batch_copy_srcs, batch_copy_sizes, tx_copy_stream);
+      if (copy_status != cudaSuccess || cudaStreamSynchronize(tx_copy_stream) != cudaSuccess) {
+        std::cerr << "Batched TX packet copy failed: " << cudaGetErrorString(copy_status) << "\n";
+        failed = true;
+      }
+    }
+
+    if (!failed &&
+        daqiri::set_all_packet_lengths(msg, {static_cast<int>(packet_size)})
+            != daqiri::Status::SUCCESS) {
+      failed = true;
+    }
+
+    if (failed) {
+      stats.failures.fetch_add(1);
+      daqiri::free_all_packets_and_burst_tx(msg);
+      stop.store(true);
+      continue;
+    }
+    daqiri::send_tx_burst(msg);
+  }
+  if (tx_copy_stream != nullptr) { cudaStreamDestroy(tx_copy_stream); }
+}
+
+void rx_worker(const BenchConfig& cfg,
+               const ReorderPlanConfig& plan,
+               std::atomic<bool>& stop,
+               SharedStats& stats) {
+  const int port_id = daqiri::get_port_id(plan.interface_name);
+  if (port_id < 0) {
+    std::cerr << "Invalid RX interface_name: " << plan.interface_name << "\n";
+    stats.failures.fetch_add(1);
+    stop.store(true);
+    return;
+  }
+
+  daqiri::bench::PinnedHostBuffer output;
+  while (!stop.load()) {
+    daqiri::BurstParams* burst = nullptr;
+    if (daqiri::get_rx_burst(&burst, port_id, 0) != daqiri::Status::SUCCESS || burst == nullptr) {
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+      continue;
+    }
+
+    const bool reordered =
+        (burst->hdr.hdr.burst_flags & daqiri::DAQIRI_BURST_FLAG_REORDERED) != 0U;
+    if (!reordered) {
+      daqiri::free_all_packets_and_burst_rx(burst);
+      continue;
+    }
+
+    if (burst->event != nullptr) { cudaEventSynchronize(burst->event); }
+    daqiri::ReorderBurstInfo info{};
+    const auto info_status = daqiri::get_reorder_burst_info(burst, &info);
+    if (info_status != daqiri::Status::SUCCESS) {
+      std::cerr << "get_reorder_burst_info failed with status "
+                << static_cast<int>(info_status) << "\n";
+      stats.failures.fetch_add(1);
+      daqiri::free_all_packets_and_burst_rx(burst);
+      stop.store(true);
+      return;
+    }
+
+    const auto aggregate_len = daqiri::get_packet_length(burst, 0);
+    if (!output.resize(aggregate_len)) {
+      std::cerr << "Failed to allocate pinned verification output buffer\n";
+      stats.failures.fetch_add(1);
+      daqiri::free_all_packets_and_burst_rx(burst);
+      stop.store(true);
+      return;
+    }
+    if (cudaMemcpy(output.data(),
+                   daqiri::get_packet_ptr(burst, 0),
+                   aggregate_len,
+                   cudaMemcpyDeviceToHost)
+        != cudaSuccess) {
+      std::cerr << "Failed to copy reordered output to host\n";
+      stats.failures.fetch_add(1);
+      daqiri::free_all_packets_and_burst_rx(burst);
+      stop.store(true);
+      return;
+    }
+
+    const bool ok = verify_reorder_output(output.data(), info, cfg);
+    daqiri::free_all_packets_and_burst_rx(burst);
+    if (!ok) {
+      stats.failures.fetch_add(1);
+      stop.store(true);
+      return;
+    }
+
+    stats.verified_batches.fetch_add(1);
+    stats.verified_chunks.fetch_add(cfg.verify_chunks);
+    if (stats.verified_batches.load() >= cfg.verify_batches) {
+      stop.store(true);
+      return;
+    }
+  }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " <config.yaml> [--seconds N]\n";
+    return 1;
+  }
+
+  const int run_seconds = daqiri::bench::parse_run_seconds(argc, argv);
+
+  const auto root = YAML::LoadFile(argv[1]);
+  const auto plan = parse_reorder_plan(root);
+  const auto cfg = parse_bench_config(root, plan);
+
+  if (daqiri::daqiri_init(argv[1]) != daqiri::Status::SUCCESS) {
+    std::cerr << "daqiri_init failed\n";
+    return 1;
+  }
+
+  cudaStream_t reorder_stream = nullptr;
+  if (cudaStreamCreate(&reorder_stream) != cudaSuccess) {
+    std::cerr << "Failed to create CUDA stream\n";
+    daqiri::shutdown();
+    return 1;
+  }
+  const auto stream_status =
+      daqiri::set_reorder_cuda_stream(plan.interface_name, plan.reorder_name, reorder_stream);
+  if (stream_status != daqiri::Status::SUCCESS) {
+    std::cerr << "set_reorder_cuda_stream failed with status "
+              << static_cast<int>(stream_status) << "\n";
+    cudaStreamDestroy(reorder_stream);
+    daqiri::shutdown();
+    return 1;
+  }
+
+  std::atomic<bool> stop{false};
+  SharedStats stats;
+  std::thread rx_thread(rx_worker, cfg, plan, std::ref(stop), std::ref(stats));
+  std::thread tx_thread(tx_worker, cfg, plan, std::ref(stop), std::ref(stats));
+
+  std::signal(SIGINT, signal_handler);
+  const auto start = std::chrono::steady_clock::now();
+  while (!stop.load() && !g_stop_requested) {
+    const auto elapsed =
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start);
+    if (run_seconds > 0 && elapsed.count() >= run_seconds) { stop.store(true); }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  stop.store(true);
+
+  if (tx_thread.joinable()) { tx_thread.join(); }
+  if (rx_thread.joinable()) { rx_thread.join(); }
+
+  daqiri::print_stats();
+  cudaStreamDestroy(reorder_stream);
+  daqiri::shutdown();
+
+  std::cout << "Reorder quantize verify: input=" << sample_type_to_string(cfg.input_type)
+            << " output=" << sample_type_to_string(cfg.output_type)
+            << " verified_batches=" << stats.verified_batches.load()
+            << " verified_chunks=" << stats.verified_chunks.load()
+            << " failures=" << stats.failures.load() << "\n";
+
+  return stats.failures.load() == 0 && stats.verified_batches.load() >= cfg.verify_batches ? 0 : 2;
+}

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -219,6 +219,11 @@ Status set_packet_lengths(BurstParams* burst, int idx, const std::initializer_li
   return g_daqiri_mgr->set_packet_lengths(burst, idx, lens);
 }
 
+Status set_all_packet_lengths(BurstParams* burst, const std::initializer_list<int>& lens) {
+  ASSERT_DAQIRI_MGR_INITIALIZED();
+  return g_daqiri_mgr->set_all_packet_lengths(burst, lens);
+}
+
 Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t time) {
   ASSERT_DAQIRI_MGR_INITIALIZED();
   return g_daqiri_mgr->set_packet_tx_time(burst, idx, time);
@@ -738,6 +743,68 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_reorder_config(
                      reorder_config.reorder_type_,
                      reorder_config.name_);
     return false;
+  }
+
+  if (reorder_item["data_types"].IsDefined()) {
+    const auto& data_types_node = reorder_item["data_types"];
+    if (!data_types_node.IsMap()) {
+      DAQIRI_LOG_ERROR("Reorder config '{}' data_types must be a map", reorder_config.name_);
+      return false;
+    }
+
+    const auto input_node =
+        data_types_node["input_type"] ? data_types_node["input_type"] : data_types_node["input"];
+    const auto output_node =
+        data_types_node["output_type"] ? data_types_node["output_type"] : data_types_node["output"];
+    if (!input_node || !output_node) {
+      DAQIRI_LOG_ERROR(
+          "Reorder config '{}' data_types requires input_type and output_type",
+          reorder_config.name_);
+      return false;
+    }
+
+    try {
+      reorder_config.data_types_.input_type_ =
+          daqiri::reorder_data_type_from_string(input_node.as<std::string>());
+      reorder_config.data_types_.output_type_ =
+          daqiri::reorder_data_type_from_string(output_node.as<std::string>());
+      const auto endianness_node = data_types_node["endianness"]
+                                       ? data_types_node["endianness"]
+                                       : data_types_node["input_endianness"];
+      if (endianness_node) {
+        reorder_config.data_types_.input_endianness_ =
+            daqiri::reorder_endianness_from_string(endianness_node.as<std::string>());
+      }
+    } catch (const std::exception& e) {
+      DAQIRI_LOG_ERROR("Failed to parse data_types in reorder config '{}': {}",
+                       reorder_config.name_,
+                       e.what());
+      return false;
+    }
+
+    if (!daqiri::is_reorder_input_data_type(reorder_config.data_types_.input_type_)) {
+      DAQIRI_LOG_ERROR(
+          "Invalid reorder input_type '{}' in config '{}'. Valid values: int4, int8, int16, int32",
+          daqiri::reorder_data_type_to_string(reorder_config.data_types_.input_type_),
+          reorder_config.name_);
+      return false;
+    }
+    if (!daqiri::is_reorder_output_data_type(reorder_config.data_types_.output_type_)) {
+      DAQIRI_LOG_ERROR(
+          "Invalid reorder output_type '{}' in config '{}'. Valid values: fp16, bf16, fp32, fp64, int32",
+          daqiri::reorder_data_type_to_string(reorder_config.data_types_.output_type_),
+          reorder_config.name_);
+      return false;
+    }
+    if (reorder_config.data_types_.input_endianness_ == daqiri::ReorderEndianness::INVALID) {
+      DAQIRI_LOG_ERROR(
+          "Invalid reorder endianness '{}' in config '{}'. Valid values: host, network",
+          daqiri::reorder_endianness_to_string(reorder_config.data_types_.input_endianness_),
+          reorder_config.name_);
+      return false;
+    }
+
+    reorder_config.data_types_.enabled_ = true;
   }
 
   if (!reorder_item["method"] || !reorder_item["method"].IsMap()) {

--- a/src/common.h
+++ b/src/common.h
@@ -282,6 +282,19 @@ void free_all_packets_and_burst_tx(BurstParams* burst);
 Status set_packet_lengths(BurstParams* burst, int idx, const std::initializer_list<int>& lens);
 
 /**
+ * @brief Set the same packet lengths for every packet in a burst
+ *
+ * Sets metadata packet lengths for all packets in a burst. This is useful for benchmarks and
+ * fixed-size packet streams where all packets have the same segment lengths.
+ *
+ * @param burst Burst structure containing packet lists
+ * @param lens Lengths of each segment
+ * @return Status indicating status. Valid values are:
+ *    SUCCESS: Packet lengths populated successfully
+ */
+Status set_all_packet_lengths(BurstParams* burst, const std::initializer_list<int>& lens);
+
+/**
  * @brief Set packet TX time
  *
  * Sets the transmit time (in PTP time) to transmit the packet. Every packet transmitted

--- a/src/kernels.cu
+++ b/src/kernels.cu
@@ -18,6 +18,8 @@
 #include "src/kernels.h"
 #include <stdio.h>
 #include <assert.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
 
 /**
  * @brief Simple packet reorder kernel to demonstrate reordering a batch of packets into
@@ -75,6 +77,422 @@ __device__ static inline uint32_t extract_bits_be(const uint8_t* data,
   return value;
 }
 
+enum ReorderKernelDataType : uint8_t {
+  kReorderDataTypeSame = 0,
+  kReorderDataTypeInt4 = 1,
+  kReorderDataTypeInt8 = 2,
+  kReorderDataTypeInt16 = 3,
+  kReorderDataTypeInt32 = 4,
+  kReorderDataTypeFp16 = 5,
+  kReorderDataTypeBf16 = 6,
+  kReorderDataTypeFp32 = 7,
+  kReorderDataTypeFp64 = 8,
+};
+
+enum ReorderKernelEndianness : uint8_t {
+  kReorderEndiannessHost = 0,
+  kReorderEndiannessNetwork = 1,
+};
+
+__device__ static inline int32_t sign_extend_4(uint8_t value) {
+  const int32_t low = static_cast<int32_t>(value & 0x0FU);
+  return (low & 0x8) != 0 ? (low | ~0x0F) : low;
+}
+
+__device__ static inline bool is_network_endianness(uint8_t input_endianness) {
+  return input_endianness == kReorderEndiannessNetwork;
+}
+
+__device__ static inline uint16_t bswap16(uint16_t value) {
+  return static_cast<uint16_t>(__byte_perm(static_cast<uint32_t>(value), 0U, 0x4401U));
+}
+
+__device__ static inline uint32_t bswap32(uint32_t value) {
+  return __byte_perm(value, 0U, 0x0123U);
+}
+
+__device__ static inline uint32_t bswap16_lanes(uint32_t value) {
+  return __byte_perm(value, 0U, 0x2301U);
+}
+
+template <uint8_t InputType>
+struct ReorderInputReader;
+
+template <>
+struct ReorderInputReader<kReorderDataTypeInt4> {
+  static constexpr uint32_t kBits = 4;
+
+  __device__ static inline int32_t read(const uint8_t* src,
+                                        uint32_t element_idx,
+                                        uint8_t input_endianness) {
+    (void)input_endianness;
+    const uint8_t packed = src[element_idx >> 1U];
+    const uint8_t nibble =
+        (element_idx & 0x1U) == 0U ? static_cast<uint8_t>(packed >> 4U)
+                                   : static_cast<uint8_t>(packed & 0x0FU);
+    return sign_extend_4(nibble);
+  }
+};
+
+template <>
+struct ReorderInputReader<kReorderDataTypeInt8> {
+  static constexpr uint32_t kBits = 8;
+
+  __device__ static inline int32_t read(const uint8_t* src,
+                                        uint32_t element_idx,
+                                        uint8_t input_endianness) {
+    (void)input_endianness;
+    return static_cast<int32_t>(reinterpret_cast<const int8_t*>(src)[element_idx]);
+  }
+};
+
+template <>
+struct ReorderInputReader<kReorderDataTypeInt16> {
+  static constexpr uint32_t kBits = 16;
+
+  __device__ static inline int32_t read(const uint8_t* src,
+                                        uint32_t element_idx,
+                                        uint8_t input_endianness) {
+    const uint32_t byte_idx = element_idx * 2U;
+    uint16_t value =
+        static_cast<uint16_t>(src[byte_idx]) | (static_cast<uint16_t>(src[byte_idx + 1U]) << 8U);
+    if (is_network_endianness(input_endianness)) { value = bswap16(value); }
+    return static_cast<int32_t>(static_cast<int16_t>(value));
+  }
+};
+
+template <>
+struct ReorderInputReader<kReorderDataTypeInt32> {
+  static constexpr uint32_t kBits = 32;
+
+  __device__ static inline int32_t read(const uint8_t* src,
+                                        uint32_t element_idx,
+                                        uint8_t input_endianness) {
+    const uint32_t byte_idx = element_idx * 4U;
+    uint32_t value = static_cast<uint32_t>(src[byte_idx])
+                     | (static_cast<uint32_t>(src[byte_idx + 1U]) << 8U)
+                     | (static_cast<uint32_t>(src[byte_idx + 2U]) << 16U)
+                     | (static_cast<uint32_t>(src[byte_idx + 3U]) << 24U);
+    if (is_network_endianness(input_endianness)) { value = bswap32(value); }
+    return static_cast<int32_t>(value);
+  }
+};
+
+template <uint8_t OutputType>
+struct ReorderOutputWriter;
+
+template <>
+struct ReorderOutputWriter<kReorderDataTypeFp16> {
+  __device__ static inline void write(uint8_t* dst, uint32_t element_idx, int32_t value) {
+    reinterpret_cast<__half*>(dst)[element_idx] = __float2half_rn(static_cast<float>(value));
+  }
+};
+
+template <>
+struct ReorderOutputWriter<kReorderDataTypeBf16> {
+  __device__ static inline void write(uint8_t* dst, uint32_t element_idx, int32_t value) {
+    reinterpret_cast<__nv_bfloat16*>(dst)[element_idx] =
+        __float2bfloat16_rn(static_cast<float>(value));
+  }
+};
+
+template <>
+struct ReorderOutputWriter<kReorderDataTypeFp32> {
+  __device__ static inline void write(uint8_t* dst, uint32_t element_idx, int32_t value) {
+    reinterpret_cast<float*>(dst)[element_idx] = static_cast<float>(value);
+  }
+};
+
+template <>
+struct ReorderOutputWriter<kReorderDataTypeFp64> {
+  __device__ static inline void write(uint8_t* dst, uint32_t element_idx, int32_t value) {
+    reinterpret_cast<double*>(dst)[element_idx] = static_cast<double>(value);
+  }
+};
+
+template <>
+struct ReorderOutputWriter<kReorderDataTypeInt32> {
+  __device__ static inline void write(uint8_t* dst, uint32_t element_idx, int32_t value) {
+    reinterpret_cast<int32_t*>(dst)[element_idx] = value;
+  }
+};
+
+template <uint8_t InputType, uint8_t OutputType>
+__device__ static inline void convert_reorder_value(uint8_t* dst,
+                                                    const uint8_t* src,
+                                                    uint32_t element_idx,
+                                                    uint8_t input_endianness) {
+  const int32_t value = ReorderInputReader<InputType>::read(src, element_idx, input_endianness);
+  ReorderOutputWriter<OutputType>::write(dst, element_idx, value);
+}
+
+template <uint8_t InputAlignment>
+__device__ static inline uint32_t load_u32_aligned_or_bytes(const uint8_t* src,
+                                                            const uint8_t* read_floor,
+                                                            const uint8_t* read_end) {
+  if constexpr (InputAlignment == 0U) {
+    return *reinterpret_cast<const uint32_t*>(src);
+  }
+
+  const uintptr_t src_addr = reinterpret_cast<uintptr_t>(src);
+  const uintptr_t aligned_addr = src_addr & ~static_cast<uintptr_t>(0x3U);
+  const auto* aligned = reinterpret_cast<const uint8_t*>(aligned_addr);
+
+  if (aligned >= read_floor && aligned + 8 <= read_end) {
+    const uint32_t lower = *reinterpret_cast<const uint32_t*>(aligned);
+    const uint32_t upper = *reinterpret_cast<const uint32_t*>(aligned + 4);
+    if constexpr (InputAlignment == 1U) {
+      return __byte_perm(lower, upper, 0x4321U);
+    } else if constexpr (InputAlignment == 2U) {
+      return __byte_perm(lower, upper, 0x5432U);
+    } else {
+      return __byte_perm(lower, upper, 0x6543U);
+    }
+  }
+
+  return static_cast<uint32_t>(src[0]) | (static_cast<uint32_t>(src[1]) << 8U)
+         | (static_cast<uint32_t>(src[2]) << 16U) | (static_cast<uint32_t>(src[3]) << 24U);
+}
+
+template <uint8_t InputType, uint8_t OutputType, uint8_t InputAlignment>
+struct ReorderPayloadConverter;
+
+template <uint8_t OutputType, uint8_t InputAlignment>
+struct ReorderPayloadConverter<kReorderDataTypeInt4, OutputType, InputAlignment> {
+  __device__ static inline void convert(uint8_t* __restrict__ dst,
+                                        const uint8_t* __restrict__ src,
+                                        const uint8_t* __restrict__ read_floor,
+                                        const uint8_t* __restrict__ read_end,
+                                        uint8_t input_endianness,
+                                        uint32_t input_payload_len) {
+    (void)input_endianness;
+    const uint32_t word_count = input_payload_len / 4U;
+
+    for (uint32_t word_idx = static_cast<uint32_t>(threadIdx.x);
+         word_idx < word_count;
+         word_idx += blockDim.x) {
+      const uint32_t word =
+          load_u32_aligned_or_bytes<InputAlignment>(src + (word_idx * 4U), read_floor, read_end);
+      const uint32_t base_element_idx = word_idx * 8U;
+
+#pragma unroll
+      for (uint32_t byte_idx = 0; byte_idx < 4U; ++byte_idx) {
+        const uint8_t byte = static_cast<uint8_t>((word >> (byte_idx * 8U)) & 0xFFU);
+        const uint32_t element_idx = base_element_idx + (byte_idx * 2U);
+        ReorderOutputWriter<OutputType>::write(dst, element_idx, sign_extend_4(byte >> 4U));
+        ReorderOutputWriter<OutputType>::write(dst, element_idx + 1U, sign_extend_4(byte));
+      }
+    }
+
+    const uint32_t first_tail_element = word_count * 8U;
+    const uint32_t element_count = input_payload_len * 2U;
+    for (uint32_t element_idx = first_tail_element + static_cast<uint32_t>(threadIdx.x);
+         element_idx < element_count;
+         element_idx += blockDim.x) {
+      convert_reorder_value<kReorderDataTypeInt4, OutputType>(
+          dst, src, element_idx, input_endianness);
+    }
+  }
+};
+
+template <uint8_t OutputType, uint8_t InputAlignment>
+struct ReorderPayloadConverter<kReorderDataTypeInt8, OutputType, InputAlignment> {
+  __device__ static inline void convert(uint8_t* __restrict__ dst,
+                                        const uint8_t* __restrict__ src,
+                                        const uint8_t* __restrict__ read_floor,
+                                        const uint8_t* __restrict__ read_end,
+                                        uint8_t input_endianness,
+                                        uint32_t input_payload_len) {
+    (void)input_endianness;
+    const uint32_t word_count = input_payload_len / 4U;
+
+    for (uint32_t word_idx = static_cast<uint32_t>(threadIdx.x);
+         word_idx < word_count;
+         word_idx += blockDim.x) {
+      const uint32_t word =
+          load_u32_aligned_or_bytes<InputAlignment>(src + (word_idx * 4U), read_floor, read_end);
+      const uint32_t base_element_idx = word_idx * 4U;
+
+#pragma unroll
+      for (uint32_t byte_idx = 0; byte_idx < 4U; ++byte_idx) {
+        const int32_t value =
+            static_cast<int32_t>(static_cast<int8_t>((word >> (byte_idx * 8U)) & 0xFFU));
+        ReorderOutputWriter<OutputType>::write(dst, base_element_idx + byte_idx, value);
+      }
+    }
+
+    const uint32_t first_tail_element = word_count * 4U;
+    for (uint32_t element_idx = first_tail_element + static_cast<uint32_t>(threadIdx.x);
+         element_idx < input_payload_len;
+         element_idx += blockDim.x) {
+      convert_reorder_value<kReorderDataTypeInt8, OutputType>(
+          dst, src, element_idx, input_endianness);
+    }
+  }
+};
+
+template <uint8_t OutputType, uint8_t InputAlignment>
+struct ReorderPayloadConverter<kReorderDataTypeInt16, OutputType, InputAlignment> {
+  __device__ static inline void convert(uint8_t* __restrict__ dst,
+                                        const uint8_t* __restrict__ src,
+                                        const uint8_t* __restrict__ read_floor,
+                                        const uint8_t* __restrict__ read_end,
+                                        uint8_t input_endianness,
+                                        uint32_t input_payload_len) {
+    const uint32_t word_count = input_payload_len / 4U;
+
+    for (uint32_t word_idx = static_cast<uint32_t>(threadIdx.x);
+         word_idx < word_count;
+         word_idx += blockDim.x) {
+      const uint32_t word =
+          load_u32_aligned_or_bytes<InputAlignment>(src + (word_idx * 4U), read_floor, read_end);
+      const uint32_t base_element_idx = word_idx * 2U;
+      const uint32_t ordered_word =
+          is_network_endianness(input_endianness) ? bswap16_lanes(word) : word;
+      const uint16_t first_raw = static_cast<uint16_t>(ordered_word & 0xFFFFU);
+      const uint16_t second_raw = static_cast<uint16_t>((ordered_word >> 16U) & 0xFFFFU);
+      const int32_t first_value = static_cast<int32_t>(static_cast<int16_t>(first_raw));
+      const int32_t second_value = static_cast<int32_t>(static_cast<int16_t>(second_raw));
+      ReorderOutputWriter<OutputType>::write(dst, base_element_idx, first_value);
+      ReorderOutputWriter<OutputType>::write(dst, base_element_idx + 1U, second_value);
+    }
+
+    const uint32_t first_tail_element = word_count * 2U;
+    const uint32_t element_count = input_payload_len / 2U;
+    for (uint32_t element_idx = first_tail_element + static_cast<uint32_t>(threadIdx.x);
+         element_idx < element_count;
+         element_idx += blockDim.x) {
+      convert_reorder_value<kReorderDataTypeInt16, OutputType>(
+          dst, src, element_idx, input_endianness);
+    }
+  }
+};
+
+template <uint8_t OutputType, uint8_t InputAlignment>
+struct ReorderPayloadConverter<kReorderDataTypeInt32, OutputType, InputAlignment> {
+  __device__ static inline void convert(uint8_t* __restrict__ dst,
+                                        const uint8_t* __restrict__ src,
+                                        const uint8_t* __restrict__ read_floor,
+                                        const uint8_t* __restrict__ read_end,
+                                        uint8_t input_endianness,
+                                        uint32_t input_payload_len) {
+    const uint32_t word_count = input_payload_len / 4U;
+
+    for (uint32_t word_idx = static_cast<uint32_t>(threadIdx.x);
+         word_idx < word_count;
+         word_idx += blockDim.x) {
+      const uint32_t word =
+          load_u32_aligned_or_bytes<InputAlignment>(src + (word_idx * 4U), read_floor, read_end);
+      const uint32_t value = is_network_endianness(input_endianness) ? bswap32(word) : word;
+      ReorderOutputWriter<OutputType>::write(dst, word_idx, static_cast<int32_t>(value));
+    }
+  }
+};
+
+template <uint8_t InputType, uint8_t OutputType, uint8_t InputAlignment>
+__device__ static inline void convert_reorder_payload_typed(uint8_t* __restrict__ dst,
+                                                            const uint8_t* __restrict__ src,
+                                                            const uint8_t* __restrict__ read_floor,
+                                                            const uint8_t* __restrict__ read_end,
+                                                            uint8_t input_endianness,
+                                                            uint32_t input_payload_len) {
+  ReorderPayloadConverter<InputType, OutputType, InputAlignment>::convert(
+      dst, src, read_floor, read_end, input_endianness, input_payload_len);
+}
+
+template <uint8_t InputType, uint8_t InputAlignment>
+__device__ static inline void convert_reorder_payload_for_input(uint8_t* __restrict__ dst,
+                                                                const uint8_t* __restrict__ src,
+                                                                const uint8_t* __restrict__ read_floor,
+                                                                const uint8_t* __restrict__ read_end,
+                                                                uint8_t input_endianness,
+                                                                uint32_t input_payload_len,
+                                                                uint8_t output_data_type) {
+  switch (output_data_type) {
+    case kReorderDataTypeFp16:
+      convert_reorder_payload_typed<InputType, kReorderDataTypeFp16, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len);
+      break;
+    case kReorderDataTypeBf16:
+      convert_reorder_payload_typed<InputType, kReorderDataTypeBf16, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len);
+      break;
+    case kReorderDataTypeFp32:
+      convert_reorder_payload_typed<InputType, kReorderDataTypeFp32, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len);
+      break;
+    case kReorderDataTypeFp64:
+      convert_reorder_payload_typed<InputType, kReorderDataTypeFp64, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len);
+      break;
+    case kReorderDataTypeInt32:
+      convert_reorder_payload_typed<InputType, kReorderDataTypeInt32, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len);
+      break;
+    default:
+      break;
+  }
+}
+
+template <uint8_t InputAlignment>
+__device__ static inline void convert_reorder_payload_for_alignment(
+    uint8_t* __restrict__ dst,
+    const uint8_t* __restrict__ src,
+    uint32_t input_payload_len,
+    uint8_t input_data_type,
+    uint8_t output_data_type,
+    uint8_t input_endianness,
+    const uint8_t* __restrict__ read_floor) {
+  const auto* read_end = src + input_payload_len;
+  switch (input_data_type) {
+    case kReorderDataTypeInt4:
+      convert_reorder_payload_for_input<kReorderDataTypeInt4, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len, output_data_type);
+      break;
+    case kReorderDataTypeInt8:
+      convert_reorder_payload_for_input<kReorderDataTypeInt8, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len, output_data_type);
+      break;
+    case kReorderDataTypeInt16:
+      convert_reorder_payload_for_input<kReorderDataTypeInt16, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len, output_data_type);
+      break;
+    case kReorderDataTypeInt32:
+      convert_reorder_payload_for_input<kReorderDataTypeInt32, InputAlignment>(
+          dst, src, read_floor, read_end, input_endianness, input_payload_len, output_data_type);
+      break;
+    default:
+      break;
+  }
+}
+
+__device__ static inline void convert_reorder_payload(uint8_t* __restrict__ dst,
+                                                      const uint8_t* __restrict__ src,
+                                                      uint32_t input_payload_len,
+                                                      uint8_t input_data_type,
+                                                      uint8_t output_data_type,
+                                                      uint8_t input_endianness,
+                                                      const uint8_t* __restrict__ read_floor) {
+  switch (static_cast<uint8_t>(reinterpret_cast<uintptr_t>(src) & 0x3U)) {
+    case 0U:
+      convert_reorder_payload_for_alignment<0U>(
+          dst, src, input_payload_len, input_data_type, output_data_type, input_endianness, read_floor);
+      break;
+    case 1U:
+      convert_reorder_payload_for_alignment<1U>(
+          dst, src, input_payload_len, input_data_type, output_data_type, input_endianness, read_floor);
+      break;
+    case 2U:
+      convert_reorder_payload_for_alignment<2U>(
+          dst, src, input_payload_len, input_data_type, output_data_type, input_endianness, read_floor);
+      break;
+    default:
+      convert_reorder_payload_for_alignment<3U>(
+          dst, src, input_payload_len, input_data_type, output_data_type, input_endianness, read_floor);
+      break;
+  }
+}
+
 template <typename T>
 __device__ static inline uint32_t copy_vector_chunks(uint8_t* __restrict__ dst,
                                                      const uint8_t* __restrict__ src,
@@ -118,7 +536,8 @@ __device__ static inline void copy_payload_vectorized(uint8_t* __restrict__ dst,
 __global__ void packet_reorder_copy_payload_by_sequence_kernel(
     void* __restrict__ out,
     const void* const* const __restrict__ in,
-    uint32_t payload_len,
+    uint32_t input_payload_len,
+    uint32_t output_payload_len,
     uint32_t payload_byte_offset,
     uint32_t num_pkts,
     uint16_t seq_bit_offset,
@@ -128,6 +547,9 @@ __global__ void packet_reorder_copy_payload_by_sequence_kernel(
     uint8_t has_batch_number,
     uint32_t packets_per_batch,
     uint32_t max_slot_idx,
+    uint8_t input_data_type,
+    uint8_t output_data_type,
+    uint8_t input_endianness,
     uint64_t* __restrict__ batch_id_out) {
   const uint32_t pkt_idx = static_cast<uint32_t>(blockIdx.x);
   if (pkt_idx >= num_pkts) { return; }
@@ -148,14 +570,21 @@ __global__ void packet_reorder_copy_payload_by_sequence_kernel(
   if (slot_idx > max_slot_idx) { return; }
 
   const auto* src = src_pkt + payload_byte_offset;
-  auto* dst = static_cast<uint8_t*>(out) + (static_cast<size_t>(slot_idx) * payload_len);
+  auto* dst = static_cast<uint8_t*>(out) + (static_cast<size_t>(slot_idx) * output_payload_len);
 
-  copy_payload_vectorized(dst, src, payload_len);
+  if (input_data_type == kReorderDataTypeSame || output_data_type == kReorderDataTypeSame) {
+    copy_payload_vectorized(dst, src, input_payload_len);
+    return;
+  }
+
+  convert_reorder_payload(
+      dst, src, input_payload_len, input_data_type, output_data_type, input_endianness, src_pkt);
 }
 
 extern "C" void packet_reorder_copy_payload_by_sequence(void* out,
                                                         const void* const* const in,
-                                                        uint32_t payload_len,
+                                                        uint32_t input_payload_len,
+                                                        uint32_t output_payload_len,
                                                         uint32_t payload_byte_offset,
                                                         uint32_t num_pkts,
                                                         uint16_t seq_bit_offset,
@@ -165,17 +594,21 @@ extern "C" void packet_reorder_copy_payload_by_sequence(void* out,
                                                         uint8_t has_batch_number,
                                                         uint32_t packets_per_batch,
                                                         uint32_t max_slot_idx,
+                                                        uint8_t input_data_type,
+                                                        uint8_t output_data_type,
+                                                        uint8_t input_endianness,
                                                         uint64_t* batch_id_out,
                                                         cudaStream_t stream) {
-  if (out == nullptr || in == nullptr || payload_len == 0 || num_pkts == 0
-      || packets_per_batch == 0) {
+  if (out == nullptr || in == nullptr || input_payload_len == 0 || output_payload_len == 0
+      || num_pkts == 0 || packets_per_batch == 0) {
     return;
   }
 
   packet_reorder_copy_payload_by_sequence_kernel<<<num_pkts, 128, 0, stream>>>(
       out,
       in,
-      payload_len,
+      input_payload_len,
+      output_payload_len,
       payload_byte_offset,
       num_pkts,
       seq_bit_offset,
@@ -185,5 +618,8 @@ extern "C" void packet_reorder_copy_payload_by_sequence(void* out,
       has_batch_number,
       packets_per_batch,
       max_slot_idx,
+      input_data_type,
+      output_data_type,
+      input_endianness,
       batch_id_out);
 }

--- a/src/kernels.h
+++ b/src/kernels.h
@@ -33,7 +33,8 @@ __attribute__((__visibility__("default"))) void simple_packet_reorder(void* out,
 __attribute__((__visibility__("default"))) void packet_reorder_copy_payload_by_sequence(
     void* out,
     const void* const* const in,
-    uint32_t payload_len,
+    uint32_t input_payload_len,
+    uint32_t output_payload_len,
     uint32_t payload_byte_offset,
     uint32_t num_pkts,
     uint16_t seq_bit_offset,
@@ -43,6 +44,9 @@ __attribute__((__visibility__("default"))) void packet_reorder_copy_payload_by_s
     uint8_t has_batch_number,
     uint32_t packets_per_batch,
     uint32_t max_slot_idx,
+    uint8_t input_data_type,
+    uint8_t output_data_type,
+    uint8_t input_endianness,
     uint64_t* batch_id_out,
     cudaStream_t stream);
 #if __cplusplus

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -673,6 +673,16 @@ Status Manager::get_rx_burst(BurstParams** burst, uintptr_t conn_id, bool server
   return Status::NOT_SUPPORTED;
 }
 
+Status Manager::set_all_packet_lengths(BurstParams* burst,
+                                       const std::initializer_list<int>& lens) {
+  if (burst == nullptr) { return Status::NULL_PTR; }
+  for (size_t idx = 0; idx < burst->hdr.hdr.num_pkts; ++idx) {
+    const auto status = set_packet_lengths(burst, static_cast<int>(idx), lens);
+    if (status != Status::SUCCESS) { return status; }
+  }
+  return Status::SUCCESS;
+}
+
 Status Manager::set_reorder_cuda_stream(const std::string& interface_name,
                                         const std::string& reorder_name,
                                         cudaStream_t stream) {

--- a/src/manager.h
+++ b/src/manager.h
@@ -60,6 +60,8 @@ class Manager {
 
   virtual Status set_packet_lengths(BurstParams* burst, int idx,
                                     const std::initializer_list<int>& lens) = 0;
+  virtual Status set_all_packet_lengths(BurstParams* burst,
+                                        const std::initializer_list<int>& lens);
   virtual void free_all_segment_packets(BurstParams* burst, int seg) = 0;
   virtual void free_all_packets(BurstParams* burst) = 0;
   virtual void free_packet_segment(BurstParams* burst, int seg, int pkt) = 0;

--- a/src/managers/dpdk/daqiri_dpdk_mgr.cpp
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.cpp
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-#include <atomic>
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cmath>
 #include <complex>
 #include <chrono>
@@ -138,6 +139,71 @@ static inline uint64_t derive_reorder_batch_id_host(const ReorderConfig& cfg,
                                             get_reorder_seq_bit_offset(cfg),
                                             get_reorder_seq_bit_width(cfg));
   return packets_per_batch == 0 ? 0U : static_cast<uint64_t>(seq / packets_per_batch);
+}
+
+static inline bool reorder_uses_data_type_conversion(const ReorderConfig& cfg) {
+  if (!cfg.data_types_.enabled_) { return false; }
+  if (cfg.data_types_.input_type_ != cfg.data_types_.output_type_) { return true; }
+
+  return cfg.data_types_.input_endianness_ == ReorderEndianness::NETWORK
+         && reorder_data_type_bit_width(cfg.data_types_.input_type_) > 8
+         && (reorder_data_type_bit_width(cfg.data_types_.input_type_) % 8) == 0;
+}
+
+static inline bool compute_reorder_output_payload_len(const ReorderConfig& cfg,
+                                                      uint32_t input_payload_len,
+                                                      uint32_t* output_payload_len) {
+  if (output_payload_len == nullptr) { return false; }
+  if (!reorder_uses_data_type_conversion(cfg)) {
+    *output_payload_len = input_payload_len;
+    return true;
+  }
+
+  const uint32_t input_bits = reorder_data_type_bit_width(cfg.data_types_.input_type_);
+  const uint32_t output_bits = reorder_data_type_bit_width(cfg.data_types_.output_type_);
+  if (input_bits == 0 || output_bits == 0) { return false; }
+
+  const uint64_t total_input_bits = static_cast<uint64_t>(input_payload_len) * 8ULL;
+  if ((total_input_bits % static_cast<uint64_t>(input_bits)) != 0ULL) { return false; }
+
+  const uint64_t element_count = total_input_bits / static_cast<uint64_t>(input_bits);
+  const uint64_t total_output_bits = element_count * static_cast<uint64_t>(output_bits);
+  if ((total_output_bits % 8ULL) != 0ULL) { return false; }
+
+  const uint64_t total_output_bytes = total_output_bits / 8ULL;
+  if (total_output_bytes > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
+    return false;
+  }
+
+  *output_payload_len = static_cast<uint32_t>(total_output_bytes);
+  return true;
+}
+
+static inline bool compute_reorder_max_output_payload_len(const ReorderConfig& cfg,
+                                                          uint32_t max_input_payload_len,
+                                                          uint32_t* output_payload_len) {
+  if (output_payload_len == nullptr) { return false; }
+  if (!reorder_uses_data_type_conversion(cfg)) {
+    *output_payload_len = max_input_payload_len;
+    return true;
+  }
+
+  const uint32_t input_bits = reorder_data_type_bit_width(cfg.data_types_.input_type_);
+  const uint32_t output_bits = reorder_data_type_bit_width(cfg.data_types_.output_type_);
+  if (input_bits == 0 || output_bits == 0) { return false; }
+
+  const uint64_t total_input_bits = static_cast<uint64_t>(max_input_payload_len) * 8ULL;
+  const uint64_t element_count = total_input_bits / static_cast<uint64_t>(input_bits);
+  const uint64_t total_output_bits = element_count * static_cast<uint64_t>(output_bits);
+  if ((total_output_bits % 8ULL) != 0ULL) { return false; }
+
+  const uint64_t total_output_bytes = total_output_bits / 8ULL;
+  if (total_output_bytes > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
+    return false;
+  }
+
+  *output_payload_len = static_cast<uint32_t>(total_output_bytes);
+  return true;
 }
 
 // --- End Helper Functions ---
@@ -379,18 +445,36 @@ bool DpdkMgr::init_reorder_queue_state(const InterfaceConfig& intf, const RxQueu
 
     const uint32_t slot_stride =
         static_cast<uint32_t>(copy_src_mr->buf_size_ - copy_source_offset);
+    uint32_t output_slot_stride = slot_stride;
+    if (!compute_reorder_max_output_payload_len(reorder_cfg, slot_stride, &output_slot_stride)) {
+      DAQIRI_LOG_ERROR(
+          "Reorder config '{}' cannot convert source slot size {} from {} to {}",
+          reorder_cfg.name_,
+          slot_stride,
+          reorder_data_type_to_string(reorder_cfg.data_types_.input_type_),
+          reorder_data_type_to_string(reorder_cfg.data_types_.output_type_));
+      return false;
+    }
+    const bool use_data_type_conversion = reorder_uses_data_type_conversion(reorder_cfg);
+    if (use_data_type_conversion && !use_gpu_backend) {
+      DAQIRI_LOG_ERROR(
+          "Reorder config '{}' data type conversion is supported only for gpu reorder_type",
+          reorder_cfg.name_);
+      return false;
+    }
+
     const uint64_t min_required_out =
-        static_cast<uint64_t>(slot_stride) * static_cast<uint64_t>(packets_per_batch);
+        static_cast<uint64_t>(output_slot_stride) * static_cast<uint64_t>(packets_per_batch);
     if (min_required_out > out_mr.buf_size_) {
       DAQIRI_LOG_ERROR(
           "Reorder output MR '{}' buffer size {} is too small for config '{}' "
-          "(required at least {} = packets_per_batch {} * slot_stride {})",
+          "(required at least {} = packets_per_batch {} * output_slot_stride {})",
           out_mr.name_,
           out_mr.buf_size_,
           reorder_cfg.name_,
           min_required_out,
           packets_per_batch,
-          slot_stride);
+          output_slot_stride);
       return false;
     }
 
@@ -519,6 +603,10 @@ bool DpdkMgr::init_reorder_queue_state(const InterfaceConfig& intf, const RxQueu
     plan.payload_byte_offset = reorder_cfg.payload_byte_offset_;
     plan.copy_source_offset = copy_source_offset;
     plan.slot_stride = slot_stride;
+    plan.data_type_conversion_enabled = use_data_type_conversion;
+    plan.input_data_type = reorder_cfg.data_types_.input_type_;
+    plan.output_data_type = reorder_cfg.data_types_.output_type_;
+    plan.input_endianness = reorder_cfg.data_types_.input_endianness_;
     plan.use_gpu_backend = use_gpu_backend;
     plan.cuda_staging_capacity = std::max<uint32_t>(
         packets_per_batch, static_cast<uint32_t>(qcfg.common_.batch_size_));
@@ -614,6 +702,7 @@ void DpdkMgr::cleanup_reorder_state() {
                               static_cast<unsigned int>(plan.direct_arrival_batch.packet_count));
       }
       plan.direct_arrival_batch.first_packet_cycles = 0;
+      plan.direct_arrival_batch.input_payload_len = 0;
       plan.direct_arrival_batch.payload_len = 0;
       plan.direct_arrival_batch.packet_count = 0;
 
@@ -784,24 +873,48 @@ Status DpdkMgr::poll_reorder_events(ReorderPlanRuntime& plan) {
   return final_status;
 }
 
-size_t DpdkMgr::append_reorder_packet(ReorderPlanRuntime& plan,
+Status DpdkMgr::append_reorder_packet(ReorderPlanRuntime& plan,
                                       struct rte_mbuf* mbuf,
                                       void* pkt_ptr,
-                                      uint64_t now_cycles) {
+                                      uint64_t now_cycles,
+                                      size_t* batch_size) {
+  if (batch_size == nullptr) { return Status::NULL_PTR; }
+  *batch_size = 0;
+
   auto& batch = plan.direct_arrival_batch;
   const uint32_t packet_idx = batch.packet_count;
+  if (packet_idx >= plan.h_input_ptrs.size() || packet_idx >= plan.h_source_mbufs.size()) {
+    DAQIRI_LOG_ERROR("Reorder packet staging storage is full for config '{}'",
+                     plan.config->name_);
+    return Status::NO_SPACE_AVAILABLE;
+  }
+
   if (packet_idx == 0) {
     batch.first_packet_cycles = now_cycles;
     const uint32_t pkt_len = mbuf != nullptr ? mbuf->pkt_len : 0U;
     uint32_t copy_len = 0;
     if (pkt_len > plan.payload_byte_offset) { copy_len = pkt_len - plan.payload_byte_offset; }
-    batch.payload_len = std::min(copy_len, plan.slot_stride);
+    batch.input_payload_len = std::min(copy_len, plan.slot_stride);
+    if (!compute_reorder_output_payload_len(
+            *(plan.config), batch.input_payload_len, &batch.payload_len)) {
+      DAQIRI_LOG_ERROR(
+          "Reorder config '{}' cannot convert packet payload size {} from {} to {}",
+          plan.config->name_,
+          batch.input_payload_len,
+          reorder_data_type_to_string(plan.input_data_type),
+          reorder_data_type_to_string(plan.output_data_type));
+      batch.first_packet_cycles = 0;
+      batch.input_payload_len = 0;
+      batch.payload_len = 0;
+      return Status::INVALID_PARAMETER;
+    }
   }
 
   plan.h_source_mbufs[packet_idx] = mbuf;
   plan.h_input_ptrs[packet_idx] = pkt_ptr;
   batch.packet_count = packet_idx + 1U;
-  return batch.packet_count;
+  *batch_size = batch.packet_count;
+  return Status::SUCCESS;
 }
 
 Status DpdkMgr::create_reorder_output_burst(ReorderPlanRuntime& plan,
@@ -874,16 +987,18 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
 
   if (batch->packet_count == 0) {
     batch->first_packet_cycles = 0;
+    batch->input_payload_len = 0;
     batch->payload_len = 0;
     return Status::SUCCESS;
   }
 
-  const uint32_t payload_len = batch->payload_len;
+  const uint32_t input_payload_len = batch->input_payload_len;
+  const uint32_t output_payload_len = batch->payload_len;
 
   const uint32_t num_pkts = batch->packet_count;
   const uint32_t output_slots = plan.packets_per_batch;
   const uint64_t aggregate_len64 =
-      static_cast<uint64_t>(output_slots) * static_cast<uint64_t>(payload_len);
+      static_cast<uint64_t>(output_slots) * static_cast<uint64_t>(output_payload_len);
   if (aggregate_len64 > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
     DAQIRI_LOG_ERROR("Reorder output length {} is too large for config '{}'",
                      aggregate_len64,
@@ -948,7 +1063,8 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
     packet_reorder_copy_payload_by_sequence(
         output_buffer,
         reinterpret_cast<const void* const*>(plan.d_input_ptrs),
-        payload_len,
+        input_payload_len,
+        output_payload_len,
         plan.copy_source_offset,
         num_pkts,
         get_reorder_seq_bit_offset(cfg),
@@ -958,6 +1074,9 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
         cfg.method_ == ReorderMethod::SEQ_BATCH_NUMBER ? 1U : 0U,
         plan.packets_per_batch,
         output_slots - 1U,
+        plan.data_type_conversion_enabled ? static_cast<uint8_t>(plan.input_data_type) : 0U,
+        plan.data_type_conversion_enabled ? static_cast<uint8_t>(plan.output_data_type) : 0U,
+        plan.data_type_conversion_enabled ? static_cast<uint8_t>(plan.input_endianness) : 0U,
         output_state.d_batch_id,
         plan.stream);
     if (cudaGetLastError() != cudaSuccess) {
@@ -1013,9 +1132,9 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
       const uint32_t slot_idx = seq % plan.packets_per_batch;
       if (slot_idx >= output_slots) { continue; }
 
-      std::memcpy(out_bytes + (static_cast<size_t>(slot_idx) * payload_len),
+      std::memcpy(out_bytes + (static_cast<size_t>(slot_idx) * output_payload_len),
                   src_pkt + plan.copy_source_offset,
-                  payload_len);
+                  output_payload_len);
     }
   }
 
@@ -1025,7 +1144,7 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
                                        output_buffer,
                                        aggregate_len,
                                        num_pkts,
-                                       payload_len,
+                                       output_payload_len,
                                        output_batch_id,
                                        output_batch_id_ready,
                                        output_batch_id_host,
@@ -1047,6 +1166,7 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
   }
 
   batch->first_packet_cycles = 0;
+  batch->input_payload_len = 0;
   batch->payload_len = 0;
   batch->packet_count = 0;
 
@@ -1106,7 +1226,14 @@ Status DpdkMgr::process_burst_for_reorder(uint32_t key, ReorderQueueState& qstat
 
       void* pkt_ptr = rte_pktmbuf_mtod(mbuf, void*);
 
-      const size_t batch_size = append_reorder_packet(plan, mbuf, pkt_ptr, now_cycles);
+      size_t batch_size = 0;
+      const auto append_status =
+          append_reorder_packet(plan, mbuf, pkt_ptr, now_cycles, &batch_size);
+      if (append_status != Status::SUCCESS) {
+        if (final_status == Status::SUCCESS) { final_status = append_status; }
+        rte_pktmbuf_free(mbuf);
+        continue;
+      }
       if (batch_size >= plan.packets_per_batch) {
         BurstParams* out = nullptr;
         const auto status = flush_reorder_batch(plan, 0, false, &out);
@@ -1181,7 +1308,14 @@ Status DpdkMgr::process_burst_for_reorder(uint32_t key, ReorderQueueState& qstat
       auto* mbuf = reinterpret_cast<rte_mbuf*>(burst->pkts[0][pkt_idx]);
 
       void* pkt_ptr = rte_pktmbuf_mtod(mbuf, void*);
-      const size_t batch_size = append_reorder_packet(plan, mbuf, pkt_ptr, now_cycles);
+      size_t batch_size = 0;
+      const auto append_status =
+          append_reorder_packet(plan, mbuf, pkt_ptr, now_cycles, &batch_size);
+      if (append_status != Status::SUCCESS) {
+        if (final_status == Status::SUCCESS) { final_status = append_status; }
+        rte_pktmbuf_free(mbuf);
+        continue;
+      }
       if (batch_size >= plan.packets_per_batch) {
         BurstParams* out = nullptr;
         status = flush_reorder_batch(plan, 0, false, &out);
@@ -2970,6 +3104,65 @@ bool DpdkMgr::validate_config() const {
             reorder_cfg.name_);
         return false;
       }
+      const bool use_data_type_conversion = reorder_uses_data_type_conversion(reorder_cfg);
+      if (use_data_type_conversion && use_cpu_backend) {
+        DAQIRI_LOG_ERROR(
+            "Reorder config '{}' data type conversion is supported only for gpu reorder_type",
+            reorder_cfg.name_);
+        return false;
+      }
+      if (reorder_cfg.payload_byte_offset_ >= source_mr_it->second.buf_size_) {
+        DAQIRI_LOG_ERROR(
+            "Reorder config '{}' payload_byte_offset {} is out of range for source MR '{}' size {}",
+            reorder_cfg.name_,
+            reorder_cfg.payload_byte_offset_,
+            source_mr_it->second.name_,
+            source_mr_it->second.buf_size_);
+        return false;
+      }
+
+      const size_t source_slot_stride_size =
+          source_mr_it->second.buf_size_ - reorder_cfg.payload_byte_offset_;
+      if (source_slot_stride_size > static_cast<size_t>(std::numeric_limits<uint32_t>::max())) {
+        DAQIRI_LOG_ERROR(
+            "Reorder config '{}' source slot size {} is too large",
+            reorder_cfg.name_,
+            source_slot_stride_size);
+        return false;
+      }
+      const auto source_slot_stride = static_cast<uint32_t>(source_slot_stride_size);
+      uint32_t output_slot_stride = 0;
+      if (!compute_reorder_max_output_payload_len(
+              reorder_cfg, source_slot_stride, &output_slot_stride)) {
+        DAQIRI_LOG_ERROR(
+            "Reorder config '{}' cannot convert source slot size {} from {} to {}",
+            reorder_cfg.name_,
+            source_slot_stride,
+            reorder_data_type_to_string(reorder_cfg.data_types_.input_type_),
+            reorder_data_type_to_string(reorder_cfg.data_types_.output_type_));
+        return false;
+      }
+
+      uint32_t packets_per_batch = 0;
+      if (reorder_cfg.method_ == ReorderMethod::SEQ_BATCH_NUMBER) {
+        packets_per_batch = reorder_cfg.seq_batch_number_.packets_per_batch_;
+      } else if (reorder_cfg.method_ == ReorderMethod::SEQ_PACKETS_PER_BATCH) {
+        packets_per_batch = reorder_cfg.seq_packets_per_batch_.packets_per_batch_;
+      }
+      const uint64_t min_required_out =
+          static_cast<uint64_t>(output_slot_stride) * static_cast<uint64_t>(packets_per_batch);
+      if (min_required_out > output_mr_it->second.buf_size_) {
+        DAQIRI_LOG_ERROR(
+            "Reorder output MR '{}' buffer size {} is too small for config '{}' "
+            "(required at least {} = packets_per_batch {} * output_slot_stride {})",
+            output_mr_it->second.name_,
+            output_mr_it->second.buf_size_,
+            reorder_cfg.name_,
+            min_required_out,
+            packets_per_batch,
+            output_slot_stride);
+        return false;
+      }
     }
   }
 
@@ -3846,6 +4039,29 @@ Status DpdkMgr::set_packet_lengths(BurstParams* burst, int idx,
   }
 
   reinterpret_cast<rte_mbuf**>(burst->pkts[0])[idx]->pkt_len = ttl_len;
+
+  return Status::SUCCESS;
+}
+
+Status DpdkMgr::set_all_packet_lengths(BurstParams* burst,
+                                       const std::initializer_list<int>& lens) {
+  if (burst == nullptr) { return Status::NULL_PTR; }
+
+  std::array<uint32_t, MAX_NUM_SEGS> seg_lens{};
+  uint32_t ttl_len = 0;
+  for (int seg = 0; seg < burst->hdr.hdr.num_segs; ++seg) {
+    seg_lens[seg] = static_cast<uint32_t>(*(lens.begin() + seg));
+    ttl_len += seg_lens[seg];
+  }
+
+  const auto num_pkts = static_cast<int>(burst->hdr.hdr.num_pkts);
+  for (int seg = 0; seg < burst->hdr.hdr.num_segs; ++seg) {
+    auto** mbufs = reinterpret_cast<rte_mbuf**>(burst->pkts[seg]);
+    for (int idx = 0; idx < num_pkts; ++idx) { mbufs[idx]->data_len = seg_lens[seg]; }
+  }
+
+  auto** first_seg = reinterpret_cast<rte_mbuf**>(burst->pkts[0]);
+  for (int idx = 0; idx < num_pkts; ++idx) { first_seg[idx]->pkt_len = ttl_len; }
 
   return Status::SUCCESS;
 }

--- a/src/managers/dpdk/daqiri_dpdk_mgr.h
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.h
@@ -112,6 +112,8 @@ class DpdkMgr : public Manager {
 
   Status set_packet_lengths(BurstParams* burst, int idx,
                             const std::initializer_list<int>& lens) override;
+  Status set_all_packet_lengths(BurstParams* burst,
+                                const std::initializer_list<int>& lens) override;
   void free_all_segment_packets(BurstParams* burst, int seg) override;
   void free_packet_segment(BurstParams* burst, int seg, int pkt) override;
   void free_packet(BurstParams* burst, int pkt) override;
@@ -166,6 +168,7 @@ class DpdkMgr : public Manager {
 
   struct ReorderBatchState {
     uint64_t first_packet_cycles = 0;
+    uint32_t input_payload_len = 0;
     uint32_t payload_len = 0;
     uint32_t packet_count = 0;
   };
@@ -216,6 +219,10 @@ class DpdkMgr : public Manager {
     uint32_t payload_byte_offset = 0;
     uint32_t copy_source_offset = 0;
     uint32_t slot_stride = 0;
+    bool data_type_conversion_enabled = false;
+    ReorderDataType input_data_type = ReorderDataType::SAME;
+    ReorderDataType output_data_type = ReorderDataType::SAME;
+    ReorderEndianness input_endianness = ReorderEndianness::HOST;
     uint64_t timeout_cycles = 0;
     bool use_gpu_backend = false;
     int cuda_device_id = 0;
@@ -285,10 +292,11 @@ class DpdkMgr : public Manager {
   Status acquire_reorder_output_buffer(ReorderPlanRuntime& plan, size_t* buffer_idx, void** output_buffer);
   void release_reorder_output_buffer(std::shared_ptr<ReorderOutputPool> output_pool,
                                      size_t buffer_idx);
-  size_t append_reorder_packet(ReorderPlanRuntime& plan,
+  Status append_reorder_packet(ReorderPlanRuntime& plan,
                                struct rte_mbuf* mbuf,
                                void* pkt_ptr,
-                               uint64_t now_cycles);
+                               uint64_t now_cycles,
+                               size_t* batch_size);
   Status get_next_output_or_ready(uint32_t key, ReorderQueueState& qstate, BurstParams** burst);
   void release_reorder_output_context(BurstParams* burst);
 

--- a/src/types.h
+++ b/src/types.h
@@ -624,6 +624,110 @@ enum class ReorderMethod {
   SEQ_PACKETS_PER_BATCH,
 };
 
+enum class ReorderDataType : uint8_t {
+  SAME = 0,
+  INT4,
+  INT8,
+  INT16,
+  INT32,
+  FP16,
+  BF16,
+  FP32,
+  FP64,
+  INVALID,
+};
+
+enum class ReorderEndianness : uint8_t {
+  HOST = 0,
+  NETWORK,
+  INVALID,
+};
+
+inline ReorderDataType reorder_data_type_from_string(const std::string& str) {
+  if (str == "int4") { return ReorderDataType::INT4; }
+  if (str == "int8") { return ReorderDataType::INT8; }
+  if (str == "int16") { return ReorderDataType::INT16; }
+  if (str == "int32") { return ReorderDataType::INT32; }
+  if (str == "fp16") { return ReorderDataType::FP16; }
+  if (str == "bf16") { return ReorderDataType::BF16; }
+  if (str == "fp32") { return ReorderDataType::FP32; }
+  if (str == "fp64") { return ReorderDataType::FP64; }
+  return ReorderDataType::INVALID;
+}
+
+inline std::string reorder_data_type_to_string(ReorderDataType type) {
+  switch (type) {
+    case ReorderDataType::SAME:
+      return "same";
+    case ReorderDataType::INT4:
+      return "int4";
+    case ReorderDataType::INT8:
+      return "int8";
+    case ReorderDataType::INT16:
+      return "int16";
+    case ReorderDataType::INT32:
+      return "int32";
+    case ReorderDataType::FP16:
+      return "fp16";
+    case ReorderDataType::BF16:
+      return "bf16";
+    case ReorderDataType::FP32:
+      return "fp32";
+    case ReorderDataType::FP64:
+      return "fp64";
+    default:
+      return "invalid";
+  }
+}
+
+inline ReorderEndianness reorder_endianness_from_string(const std::string& str) {
+  if (str == "host") { return ReorderEndianness::HOST; }
+  if (str == "network") { return ReorderEndianness::NETWORK; }
+  return ReorderEndianness::INVALID;
+}
+
+inline std::string reorder_endianness_to_string(ReorderEndianness endianness) {
+  switch (endianness) {
+    case ReorderEndianness::HOST:
+      return "host";
+    case ReorderEndianness::NETWORK:
+      return "network";
+    default:
+      return "invalid";
+  }
+}
+
+inline bool is_reorder_input_data_type(ReorderDataType type) {
+  return type == ReorderDataType::INT4 || type == ReorderDataType::INT8
+         || type == ReorderDataType::INT16 || type == ReorderDataType::INT32;
+}
+
+inline bool is_reorder_output_data_type(ReorderDataType type) {
+  return type == ReorderDataType::FP16 || type == ReorderDataType::BF16
+         || type == ReorderDataType::FP32 || type == ReorderDataType::FP64
+         || type == ReorderDataType::INT32;
+}
+
+inline uint32_t reorder_data_type_bit_width(ReorderDataType type) {
+  switch (type) {
+    case ReorderDataType::INT4:
+      return 4;
+    case ReorderDataType::INT8:
+      return 8;
+    case ReorderDataType::INT16:
+    case ReorderDataType::FP16:
+    case ReorderDataType::BF16:
+      return 16;
+    case ReorderDataType::INT32:
+    case ReorderDataType::FP32:
+      return 32;
+    case ReorderDataType::FP64:
+      return 64;
+    default:
+      return 0;
+  }
+}
+
 struct ReorderBitFieldConfig {
   uint16_t bit_offset_ = 0;
   uint8_t bit_width_ = 0;
@@ -640,6 +744,13 @@ struct ReorderSeqPacketsPerBatchConfig {
   uint32_t packets_per_batch_ = 0;
 };
 
+struct ReorderDataTypesConfig {
+  bool enabled_ = false;
+  ReorderDataType input_type_ = ReorderDataType::SAME;
+  ReorderDataType output_type_ = ReorderDataType::SAME;
+  ReorderEndianness input_endianness_ = ReorderEndianness::HOST;
+};
+
 struct ReorderConfig {
   std::string name_;
   std::string reorder_type_;
@@ -649,6 +760,7 @@ struct ReorderConfig {
   ReorderMethod method_ = ReorderMethod::INVALID;
   ReorderSeqBatchNumberConfig seq_batch_number_;
   ReorderSeqPacketsPerBatchConfig seq_packets_per_batch_;
+  ReorderDataTypesConfig data_types_;
 };
 
 struct RxConfig {


### PR DESCRIPTION
When combined with a reorder plan, this PR allows DAQIRI to do datatype conversion on-the-fly into the reassembled buffer. For instance, it can convert an int4 into fp32 or other types more amenable to the GPU.