### PR TITLE
#37 - Fix stale doc references and rename tutorials/configuration.md

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -1,7 +1,7 @@
 # API Guide
 
 This guide covers the core DAQIRI API for receiving and transmitting packets. For the
-complete function list, see the [`daqiri/common.h`](/src/common.h) header file.
+complete function list, see the [`daqiri/common.h`](https://github.com/NVIDIA/daqiri/blob/main/src/common.h) header file.
 
 ## Key Concepts
 

--- a/docs/daqiri-api.html
+++ b/docs/daqiri-api.html
@@ -276,7 +276,7 @@
 }</pre>
           <div class="callout callout-note" style="margin-top:1rem;">
             <span style="flex-shrink:0;">💡</span>
-            <p>See <a href="configuration.md">configuration.md</a> for the full YAML schema and worked examples for DPDK and RDMA backends.</p>
+            <p>See <a href="configuration/">the configuration reference</a> for the full YAML schema and worked examples for DPDK and RDMA backends.</p>
           </div>
         </div>
 
@@ -554,8 +554,8 @@ daqiri::<span class="fn">shutdown</span>();</pre>
       <div style="margin-top:4rem;padding-top:2rem;border-top:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:1rem;">
         <a href="index.html" style="font-size:.875rem;color:var(--text-mut);">← Back to Home</a>
         <div style="display:flex;gap:1rem;">
-          <a href="getting-started.md" style="font-size:.875rem;color:var(--text-mut);">Getting Started</a>
-          <a href="configuration.md" style="font-size:.875rem;color:var(--text-mut);">Configuration</a>
+          <a href="getting-started/" style="font-size:.875rem;color:var(--text-mut);">Getting Started</a>
+          <a href="configuration/" style="font-size:.875rem;color:var(--text-mut);">Configuration</a>
           <a href="https://github.com/NVIDIA/daqiri/blob/main/src/common.h" style="font-size:.875rem;color:var(--text-mut);" target="_blank">common.h ↗</a>
         </div>
       </div>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ DAQIRI requires a system with an [**NVIDIA SmartNIC**](https://www.nvidia.com/en
 | **NIC** | NVIDIA ConnectX-6 Dx or later, with MLNX_OFED or inbox drivers |
 | **GPU** | Workstation/Quadro/RTX or Data Center GPU (GPUDirect-capable) |
 | **CUDA** | CUDA Toolkit 11.7+ |
-| **DPDK** | Included in the DAQIRI container; see [Dockerfile](../Dockerfile) for bare-metal deps |
+| **DPDK** | Included in the DAQIRI container; see [Dockerfile](https://github.com/NVIDIA/daqiri/blob/main/Dockerfile) for bare-metal deps |
 | **RDMA** | `libibverbs` and `librdmacm` (for the RDMA backend) |
 
 Supported platforms include [NVIDIA Data Center](https://www.nvidia.com/en-us/data-center/) systems, edge systems like [NVIDIA IGX](https://www.nvidia.com/en-us/edge-computing/products/igx/) and [NVIDIA Project DIGITS](https://www.nvidia.com/en-us/project-digits/), and `x86_64` systems with the above components.
@@ -72,7 +72,7 @@ Then build the DAQIRI library:
     ```bash
     git clone git@github.com:nvidia-holoscan/daqiri.git
     cd daqiri
-    BASE_TARGET=dpdk DAQIRI_MGR="dpdk rdma" scripts/build-container.sh
+    BASE_TARGET=dpdk DAQIRI_MGR="dpdk socket rdma" scripts/build-container.sh
     ```
 
 === "CMake build (bare-metal)"
@@ -80,18 +80,18 @@ Then build the DAQIRI library:
     ```bash
     git clone git@github.com:nvidia-holoscan/daqiri.git
     cd daqiri
-    cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_MGR="dpdk rdma"
+    cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_MGR="dpdk socket rdma"
     cmake --build build -j
     cmake --install build --prefix /opt/daqiri
     ```
 
-    Inspect the [Dockerfile](https://github.com/nvidia-holoscan/daqiri/blob/main/Dockerfile) to see the full list of user-space dependencies needed for a bare-metal build.
+    Inspect the [Dockerfile](https://github.com/NVIDIA/daqiri/blob/main/Dockerfile) to see the full list of user-space dependencies needed for a bare-metal build.
 
 ### CMake Options
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `DAQIRI_MGR` | `"dpdk rdma"` | Space-separated list of backends to build. Valid values: `dpdk`, `rdma`. |
+| `DAQIRI_MGR` | `"dpdk socket rdma"` | Space-separated list of backends to build. Valid values: `dpdk`, `socket`, `rdma`. |
 | `DAQIRI_BUILD_PYTHON` | `OFF` | Build pybind11 Python bindings. |
 | `DAQIRI_BUILD_EXAMPLES` | `ON` | Build benchmark executables. |
 | `BUILD_SHARED_LIBS` | — | Build as shared library. |
@@ -104,5 +104,5 @@ Once DAQIRI is built, follow the tutorials to configure your system and run your
 
 1. [**Background**](tutorials/background.md) — Kernel Bypass and GPUDirect concepts
 2. [**System Configuration**](tutorials/system_configuration.md) — NIC drivers, link layers, GPUDirect, hugepages, CPU isolation, GPU clocks, and more
-3. [**Benchmarking Examples**](tutorials/benchmarking_examples.md) — run `daqiri_bench_default` with a loopback test
-4. [**Understanding the Configuration File**](tutorials/configuration.md) — annotated YAML walkthrough
+3. [**Benchmarking Examples**](tutorials/benchmarking_examples.md) — run `daqiri_bench_raw_gpudirect` with a loopback test
+4. [**Understanding the Configuration File**](tutorials/configuration-walkthrough.md) — annotated YAML walkthrough

--- a/docs/index.html
+++ b/docs/index.html
@@ -331,7 +331,7 @@
 cmake -S . -B build \
   -DBUILD_SHARED_LIBS=ON \
   -DDAQIRI_BUILD_PYTHON=OFF \
-  -DDAQIRI_MGR=<span class="str">"dpdk rdma"</span>
+  -DDAQIRI_MGR=<span class="str">"dpdk socket rdma"</span>
 cmake --build build -j
 cmake --install build --prefix /opt/daqiri</pre>
             </div>
@@ -342,7 +342,7 @@ cmake --install build --prefix /opt/daqiri</pre>
               <h4>Or Build the Container</h4>
               <p>The Dockerfile builds DPDK from source with dmabuf patches — no peermem needed inside the container.</p>
               <pre>BASE_TARGET=dpdk \
-  DAQIRI_MGR=<span class="str">"dpdk rdma"</span> \
+  DAQIRI_MGR=<span class="str">"dpdk socket rdma"</span> \
   scripts/build-container.sh</pre>
             </div>
           </div>
@@ -359,8 +359,8 @@ cmake --install build --prefix /opt/daqiri</pre>
             <div class="gs-step-body">
               <h4>Run a Benchmark</h4>
               <p>Edit the YAML to match your hardware (PCIe BDF, CPU cores, IPs), then:</p>
-              <pre>./build/examples/daqiri_bench_default \
-  examples/daqiri_bench_default_tx_rx.yaml \
+              <pre>./build/examples/daqiri_bench_raw_gpudirect \
+  examples/daqiri_bench_raw_tx_rx.yaml \
   --seconds 10</pre>
             </div>
           </div>
@@ -520,17 +520,17 @@ daqiri::<span class="fn">free_all_packets_and_burst_rx</span>(
           <div class="ex-body"><pre><span class="cm"># Build with examples</span>
 cmake -S . -B build \
   -DDAQIRI_BUILD_EXAMPLES=ON \
-  -DDAQIRI_MGR=<span class="str">"dpdk rdma"</span>
+  -DDAQIRI_MGR=<span class="str">"dpdk socket rdma"</span>
 cmake --build build -j
 
 <span class="cm"># TX/RX throughput (10 s)</span>
-./build/examples/daqiri_bench_default \
-  examples/daqiri_bench_default_tx_rx.yaml \
+./build/examples/daqiri_bench_raw_gpudirect \
+  examples/daqiri_bench_raw_tx_rx.yaml \
   --seconds <span class="nm">10</span>
 
 <span class="cm"># Header-data split / GPUDirect</span>
-./build/examples/daqiri_bench_default \
-  examples/daqiri_bench_default_tx_rx_hds.yaml \
+./build/examples/daqiri_bench_raw_hds \
+  examples/daqiri_bench_raw_tx_rx_hds.yaml \
   --seconds <span class="nm">10</span></pre></div>
           <div class="ex-footer"><span class="ex-desc">Run DPDK TX/RX and HDS benchmarks</span><a href="https://github.com/NVIDIA/daqiri/tree/main/examples" class="ex-link" target="_blank">Open ↗</a></div>
         </div>
@@ -543,13 +543,13 @@ cmake --build build -j
   --seconds <span class="nm">10</span> --mode both
 
 <span class="cm"># Software loopback (no physical link)</span>
-./build/examples/daqiri_bench_default \
-  examples/daqiri_bench_default_sw_loopback.yaml \
+./build/examples/daqiri_bench_raw_gpudirect \
+  examples/daqiri_bench_raw_sw_loopback.yaml \
   --seconds <span class="nm">10</span>
 
 <span class="cm"># Multi-queue RX</span>
-./build/examples/daqiri_bench_default \
-  examples/daqiri_bench_default_rx_multi_q.yaml \
+./build/examples/daqiri_bench_raw_gpudirect \
+  examples/daqiri_bench_raw_rx_multi_q.yaml \
   --seconds <span class="nm">10</span></pre></div>
           <div class="ex-footer"><span class="ex-desc">RDMA, loopback, and multi-queue benchmarks</span><a href="https://github.com/NVIDIA/daqiri/tree/main/examples" class="ex-link" target="_blank">Open ↗</a></div>
         </div>
@@ -576,7 +576,7 @@ cmake --build build -j
         <div class="tut-item tut-soon"><span class="tut-num">04</span><div class="tut-info"><div class="tut-title">Container Build with Patched DPDK</div><div class="tut-desc">Build the Docker image with <code>build-container.sh</code>. The container ships a dmabuf-patched DPDK, so peermem is not required.</div></div><div class="tut-meta"><span class="tag tag-soon">Coming Soon</span></div><span class="tut-arrow">→</span></div>
         <a href="tutorials/system_configuration/" class="tut-item" style="text-decoration:none;color:inherit;"><span class="tut-num">05</span><div class="tut-info"><div class="tut-title">System Tuning for High-Performance Networking</div><div class="tut-desc">Isolate CPU cores, configure hugepages, set NUMA affinity, and run <code>python/tune_system.py</code> to diagnose common configuration issues.</div></div><div class="tut-meta"><span class="tag tag-int">Intermediate</span><span class="tut-time">~30 min</span></div><span class="tut-arrow">→</span></a>
         <a href="tutorials/benchmarking_examples/" class="tut-item" style="text-decoration:none;color:inherit;"><span class="tut-num">06</span><div class="tut-info"><div class="tut-title">Benchmarking Examples</div><div class="tut-desc">Run a TX/RX loopback test to validate your setup, and walk through interpreting throughput results.</div></div><div class="tut-meta"><span class="tag tag-beg">Beginner</span><span class="tut-time">~20 min</span></div><span class="tut-arrow">→</span></a>
-        <a href="tutorials/configuration/" class="tut-item" style="text-decoration:none;color:inherit;"><span class="tut-num">07</span><div class="tut-info"><div class="tut-title">YAML Configuration Deep Dive</div><div class="tut-desc">Memory regions (<code>huge</code>, <code>device</code>, <code>host_pinned</code>), RX/TX queue setup, flow steering rules, flex items, and RDMA client/server config schemas.</div></div><div class="tut-meta"><span class="tag tag-int">Intermediate</span><span class="tut-time">~40 min</span></div><span class="tut-arrow">→</span></a>
+        <a href="tutorials/configuration-walkthrough/" class="tut-item" style="text-decoration:none;color:inherit;"><span class="tut-num">07</span><div class="tut-info"><div class="tut-title">YAML Configuration Deep Dive</div><div class="tut-desc">Memory regions (<code>huge</code>, <code>device</code>, <code>host_pinned</code>), RX/TX queue setup, flow steering rules, flex items, and RDMA client/server config schemas.</div></div><div class="tut-meta"><span class="tag tag-int">Intermediate</span><span class="tut-time">~40 min</span></div><span class="tut-arrow">→</span></a>
         <div class="tut-item tut-soon"><span class="tut-num">08</span><div class="tut-info"><div class="tut-title">GPUDirect: Header-Data Split Pipeline</div><div class="tut-desc">Configure a two-region memory layout, access CPU headers and GPU payloads per-packet with <code>get_segment_packet_ptr()</code>, and reorder scattered GPU buffers with the built-in CUDA kernel.</div></div><div class="tut-meta"><span class="tag tag-soon">Coming Soon</span></div><span class="tut-arrow">→</span></div>
         <div class="tut-item tut-soon"><span class="tut-num">09</span><div class="tut-info"><div class="tut-title">RDMA Client/Server Setup</div><div class="tut-desc">Configure the RDMA backend with RC transport, assign client and server roles across two hosts, and run <code>daqiri_bench_rdma</code> to validate the connection.</div></div><div class="tut-meta"><span class="tag tag-soon">Coming Soon</span></div><span class="tut-arrow">→</span></div>
         <div class="tut-item tut-soon"><span class="tut-num">10</span><div class="tut-info"><div class="tut-title">Timed TX with ConnectX-7</div><div class="tut-desc">Enable <code>accurate_send</code> in the TX config and use <code>set_packet_tx_time()</code> for PTP-synchronized, hardware-scheduled packet transmission on ConnectX-7+.</div></div><div class="tut-meta"><span class="tag tag-soon">Coming Soon</span></div><span class="tut-arrow">→</span></div>
@@ -627,7 +627,7 @@ cmake --build build -j
 git clone https://github.com/NVIDIA/daqiri
 cmake -S daqiri -B build \
   -DBUILD_SHARED_LIBS=ON \
-  -DDAQIRI_MGR=<span class="str">"dpdk rdma"</span>
+  -DDAQIRI_MGR=<span class="str">"dpdk socket rdma"</span>
 cmake --build build -j</pre>
       <div class="cta-actions">
         <a href="#getting-started" class="btn btn-primary">Quick Start Guide →</a>

--- a/docs/tutorials/background.md
+++ b/docs/tutorials/background.md
@@ -44,4 +44,4 @@ Which backend is best for your use case will depend on multiple factors, such as
 
 - [System Configuration](system_configuration.md)
 - [Benchmarking Examples](benchmarking_examples.md)
-- [Understanding the Configuration File](configuration.md)
+- [Understanding the Configuration File](configuration-walkthrough.md)

--- a/docs/tutorials/benchmarking_examples.md
+++ b/docs/tutorials/benchmarking_examples.md
@@ -6,7 +6,7 @@ hide:
 
 DAQIRI provides a benchmarking application named `daqiri_bench_raw_gpudirect` that can be used to test the performance of the networking configuration. In this section, we'll walk you through the steps needed to configure the application for your NIC for Tx and Rx, and run a loopback test between the two interfaces with a [physical SFP cable](https://www.nvidia.com/en-us/networking/interconnect/) connecting them.
 
-Make sure to [build the DAQIRI library](../getting-started.md#building-from-source) beforehand.
+Make sure to [build the DAQIRI library](../getting-started.md#build-the-daqiri-library) beforehand.
 
 !!! note "Prerequisites"
 
@@ -42,7 +42,7 @@ The benchmark executables and example YAML configurations are located at:
 | **Container** | `/opt/daqiri/bin/` | `/opt/daqiri/bin/` |
 | **From source** | `./build/examples/` | `./examples/` |
 
-The fields in the YAML configs will be explained in more detail in [Understanding the Configuration File](configuration.md). For now, we'll stick to modifying the strict minimum required fields to run the application as-is on your system.
+The fields in the YAML configs will be explained in more detail in [Understanding the Configuration File](configuration-walkthrough.md). For now, we'll stick to modifying the strict minimum required fields to run the application as-is on your system.
 
 ##### Identify your NIC's PCIe addresses
 
@@ -423,4 +423,4 @@ sudo mlnx_perf -i $if_name
 
 ---
 **Previous:** [System Configuration](system_configuration.md)  
-**Next:** [Understanding the Configuration File](configuration.md) — deep dive into the YAML parameters
+**Next:** [Understanding the Configuration File](configuration-walkthrough.md) — deep dive into the YAML parameters

--- a/docs/tutorials/configuration-walkthrough.md
+++ b/docs/tutorials/configuration-walkthrough.md
@@ -4,7 +4,7 @@ hide:
 ---
 # Understanding the Configuration File
 
-This section walks through the YAML configuration used by the benchmark applications. The annotated example below is based on `daqiri_bench_default_tx_rx.yaml`. Click on the :material-plus-circle: icons to expand explanations for each annotated line.
+This section walks through the YAML configuration used by the benchmark applications. The annotated example below is based on `daqiri_bench_raw_tx_rx.yaml`. Click on the :material-plus-circle: icons to expand explanations for each annotated line.
 
 Annotations are prefixed with a category:
 

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -868,7 +868,7 @@ Rerunning the initial commands should now list 4 hugepages of 1GB each. 1GB will
 
 The CPU interacting with the NIC to route packets is sensitive to perturbations, especially with smaller packet/batch sizes requiring more frequent work. Isolating a CPU in Linux prevents unwanted user or kernel threads from running on it, reducing context switching and latency spikes from noisy neighbors.
 
-We recommend isolating the CPU cores you will select to interact with the NIC (defined in the `daqiri` configuration [described in the configuration reference](configuration.md) in this tutorial). This is done by setting additional flags on the kernel bootline.
+We recommend isolating the CPU cores you will select to interact with the NIC (defined in the `daqiri` configuration [described in the configuration reference](configuration-walkthrough.md) in this tutorial). This is done by setting additional flags on the kernel bootline.
 
 You can first check if any of the recommended flags were already set on the last boot:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,7 +39,7 @@ nav:
     - Background: tutorials/background.md
     - System Configuration: tutorials/system_configuration.md
     - Benchmarking Examples: tutorials/benchmarking_examples.md
-    - Configuration File: tutorials/configuration.md
+    - Configuration File: tutorials/configuration-walkthrough.md
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Several documentation references were authored against an older code shape and never updated. This pass cleans them up so the published site is accurate and mkdocs build runs without link warnings.

Content fixes:

* Replace remaining daqiri_bench_default references on the landing page (5 command blocks), getting-started.md "Next Steps", and the configuration walkthrough intro. Mapped per CLAUDE.md:
    *_tx_rx.yaml       -> daqiri_bench_raw_gpudirect + raw_tx_rx
    *_tx_rx_hds.yaml   -> daqiri_bench_raw_hds + raw_tx_rx_hds
    *_sw_loopback.yaml -> daqiri_bench_raw_gpudirect + raw_sw_loopback
    *_rx_multi_q.yaml  -> daqiri_bench_raw_gpudirect + raw_rx_multi_q
* Switch DAQIRI_MGR examples from "dpdk rdma" to "dpdk socket rdma"
  in 4 landing-page code blocks and getting-started.md (build
  commands and options table). Add socket to the valid-values list.
* Repoint .md hrefs in daqiri-api.html (body link to the configuration
  reference; footer links to Getting Started and Configuration).
* Fix the three mkdocs link warnings:
    api-guide.md             /src/common.h         -> GitHub URL
    getting-started.md       ../Dockerfile         -> GitHub URL
    benchmarking_examples.md #building-from-source -> #build-the-daqiri-library
* Fix wrong-org URL in getting-started.md (nvidia-holoscan -> NVIDIA).

Rename:

* docs/tutorials/configuration.md -> docs/tutorials/configuration-walkthrough.md so it no longer collides with the top-level docs/configuration.md (the YAML reference). Five cross-link references and the mkdocs.yml nav entry are updated to match.

Ref #37  