### PR TITLE
#37 - Add CI gate for documentation drift

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ on:
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
       - 'scripts/check_html_links.py'
+      - 'scripts/check_doc_refs.py'
+      - 'examples/CMakeLists.txt'
+      - 'examples/*.yaml'
+      - 'README.md'
 
 permissions:
   contents: write
@@ -32,6 +36,9 @@ jobs:
 
       - name: Verify hand-maintained HTML link targets
         run: python scripts/check_html_links.py site
+
+      - name: Verify benchmark and config references in docs
+        run: python scripts/check_doc_refs.py
 
   deploy:
     needs: check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,41 @@
-name: Deploy Documentation
+name: Documentation
 
 on:
   push:
     branches:
       - main
-      - unified_docs
-      - website
-      - tutorial
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+      - 'scripts/check_html_links.py'
 
 permissions:
   contents: write
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install mkdocs-material
+
+      - name: Build site (strict mode)
+        run: mkdocs build --strict
+
+      - name: Verify hand-maintained HTML link targets
+        run: python scripts/check_html_links.py site
+
   deploy:
+    needs: check
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,5 +63,16 @@ markdown_extensions:
 
 docs_dir: docs
 
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    absolute_links: warn
+    unrecognized_links: warn
+    anchors: warn
+
 plugins:
   - search

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Verify that every daqiri_bench_<name> binary and daqiri_bench_*.yaml
+config referenced in user-facing docs actually exists in examples/.
+
+Catches the #37-class drift: tutorials referencing daqiri_bench_default
+when the actual binary is daqiri_bench_raw_gpudirect.
+
+Scope:
+  * docs/**/*.md, docs/**/*.html
+  * README.md
+  * (CLAUDE.md is intentionally skipped — its benchmark table uses
+    wildcards and brace expansion that literal grep would mis-flag.
+    The .claude/rules/docs-sync.md rule covers CLAUDE.md drift via a
+    soft commit-time check for Claude Code users.)
+
+Sources of truth:
+  * Binary names: add_executable() and add_daqiri_raw_bench() calls in
+    examples/CMakeLists.txt.
+  * YAML config names: actual *.yaml files in examples/.
+
+Exit codes:
+  0  all references resolve
+  1  one or more references do not match a real binary or config
+  2  could not parse the canonical lists (missing CMakeLists.txt etc.)
+
+Usage: python scripts/check_doc_refs.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+EXAMPLES = REPO / "examples"
+DOCS = REPO / "docs"
+README = REPO / "README.md"
+
+# Match daqiri_bench_<name>.yaml — the full filename.
+YAML_RE = re.compile(r"\b(daqiri_bench_\w+\.yaml)\b")
+
+# Match daqiri_bench_<name> as a binary. Anchored by word boundary on
+# both sides; the negative lookahead prevents a YAML basename from
+# being treated as a binary (the "\b" before ".yaml" would otherwise
+# allow the binary regex to match the same characters).
+BIN_RE = re.compile(r"\b(daqiri_bench_\w+)\b(?!\.yaml)")
+
+# Lines in examples/CMakeLists.txt that declare a benchmark binary,
+# either via the helper add_daqiri_raw_bench(name ...) or directly via
+# add_executable(name ...).
+DEFN_RE = re.compile(
+    r"(?:add_executable|add_daqiri_raw_bench)\s*\(\s*(daqiri_bench_\w+)"
+)
+
+
+def known_binaries() -> set[str]:
+    cml = (EXAMPLES / "CMakeLists.txt").read_text(encoding="utf-8")
+    return set(DEFN_RE.findall(cml))
+
+
+def known_yamls() -> set[str]:
+    return {p.name for p in EXAMPLES.glob("*.yaml")}
+
+
+def doc_files() -> list[Path]:
+    files: list[Path] = []
+    files.extend(sorted(DOCS.rglob("*.md")))
+    files.extend(sorted(DOCS.rglob("*.html")))
+    if README.exists():
+        files.append(README)
+    return files
+
+
+def main() -> int:
+    if not (EXAMPLES / "CMakeLists.txt").exists():
+        print(
+            "examples/CMakeLists.txt not found — cannot determine canonical binaries.",
+            file=sys.stderr,
+        )
+        return 2
+
+    bins = known_binaries()
+    yamls = known_yamls()
+
+    if not bins:
+        print(
+            "No add_executable(daqiri_bench_*) / add_daqiri_raw_bench(daqiri_bench_*) "
+            "calls found in examples/CMakeLists.txt.",
+            file=sys.stderr,
+        )
+        return 2
+
+    errors: list[str] = []
+    for path in doc_files():
+        try:
+            content = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        rel = path.relative_to(REPO)
+
+        for match in YAML_RE.finditer(content):
+            name = match.group(1)
+            if name not in yamls:
+                errors.append(f"{rel}: unknown YAML config {name!r}")
+
+        for match in BIN_RE.finditer(content):
+            name = match.group(1)
+            if name not in bins:
+                errors.append(f"{rel}: unknown binary {name!r}")
+
+    errors = sorted(set(errors))
+    if errors:
+        print("Stale benchmark/config references in docs:", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        return 1
+
+    print(
+        f"All daqiri_bench_* references resolve. "
+        f"Checked {len(bins)} binaries and {len(yamls)} YAML configs "
+        f"across {len(doc_files())} doc files."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_html_links.py
+++ b/scripts/check_html_links.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Verify that hand-maintained HTML pages link only to existing locations
+in the rendered MkDocs site.
+
+The hand-maintained HTML files (docs/index.html, docs/daqiri-api.html) are
+not part of the MkDocs link graph, so `mkdocs build --strict` does not
+check their hrefs. This script does, by walking each href and confirming
+the target resolves under site/.
+
+Usage: python scripts/check_html_links.py [SITE_DIR]
+       (default SITE_DIR is ./site, the output of `mkdocs build`)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urldefrag, urlparse
+
+HTML_PAGES = ("index.html", "daqiri-api.html")
+HREF_RE = re.compile(r'href="([^"]+)"')
+
+
+def is_external(href: str) -> bool:
+    parsed = urlparse(href)
+    if parsed.scheme:
+        return True
+    if href.startswith(("//", "#")):
+        return True
+    return False
+
+
+def resolve(file_dir: Path, site_root: Path, href: str) -> tuple[bool, str]:
+    target, _ = urldefrag(href)
+    target = target.split("?", 1)[0]
+    if not target:
+        return True, ""
+    candidate = (file_dir / target).resolve()
+    try:
+        candidate.relative_to(site_root.resolve())
+    except ValueError:
+        return False, f"escapes site root: {href!r}"
+    if candidate.is_file():
+        return True, ""
+    if candidate.is_dir() and (candidate / "index.html").exists():
+        return True, ""
+    return False, f"target not found: {href!r}"
+
+
+def main() -> int:
+    site = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("site")
+    if not site.is_dir():
+        print(f"site directory not found: {site}", file=sys.stderr)
+        return 1
+    errors: list[str] = []
+    for page in HTML_PAGES:
+        path = site / page
+        if not path.exists():
+            errors.append(f"{page}: not present in {site}")
+            continue
+        content = path.read_text(encoding="utf-8")
+        for match in HREF_RE.finditer(content):
+            href = match.group(1)
+            if is_external(href):
+                continue
+            ok, msg = resolve(path.parent, site, href)
+            if not ok:
+                errors.append(f"{page}: {msg}")
+    if errors:
+        print("Broken HTML links:", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        return 1
+    print(f"All HTML links in {', '.join(HTML_PAGES)} resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a check job that runs on every PR touching docs/, mkdocs.yml, the workflow, or the link-checker script, and restructures the deploy job to gate on the check passing. Two safeguards:

1. `mkdocs build --strict` with an explicit `validation:` block in mkdocs.yml that escalates link, anchor, and nav warnings (broken internal markdown links, missing nav files, broken anchors, absolute paths) from INFO to WARNING. `--strict` then fails the build on any of them. Without this block, MkDocs treats those as informational and `--strict` lets them through.

2. `scripts/check_html_links.py` parses every `href` in the hand-maintained `docs/index.html` and `docs/daqiri-api.html`, resolves each against the rendered `site/` directory, and fails if any target is missing. MkDocs' link graph does not cover these standalone HTML pages, so the script closes that gap.

Together these catch the class of drift tracked in #37: stale binary names in markdown, broken cross-links after a doc reorg, and unresolvable hrefs on the landing page after MkDocs URL changes.

Also drops the obsolete unified_docs / website / tutorial branches from the workflow trigger list — only main triggers a deploy now.