### PR TITLE
#46 update readme backends defaults tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,30 +12,30 @@ DAQIRI provides direct NIC hardware access in userspace, bypassing the Linux ker
 
 📖 **Live documentation: [nvidia.github.io/daqiri](https://nvidia.github.io/daqiri/)**
 
-**Requires** an NVIDIA SmartNIC (ConnectX-6 Dx or later) and a discrete GPU. Tested on the NVIDIA DGX Spark, NVIDIA IGX platform, and an x86_64 RTX Pro server. See [Getting Started](docs/getting-started.md) for the full requirements list.
+**Requires** an NVIDIA SmartNIC (ConnectX-6 Dx or later) and a GPUDirect-capable NVIDIA GPU. Tested on the NVIDIA DGX Spark, NVIDIA IGX platform, and an x86_64 RTX Pro server. See [Getting Started](docs/getting-started.md) for the full requirements list.
 
 ## Features
 
-- **High Throughput** — Hundreds of gigabits per second with proper hardware and tuning.
+- **High Throughput** — Sustained line rate with proper hardware and tuning.
 - **Low Latency** — Direct access to NIC ring buffers; most latency is PCIe transit only.
 - **GPUDirect** — Receive data directly into GPU memory via two modes:
-  - *Header-data split*: Headers to CPU, payload to GPU (recommended for most workloads).
+  - *Header-Data Split*: Headers to CPU, payload to GPU (recommended for most workloads).
   - *Batched GPU*: Entire packets to GPU memory (maximum bandwidth, GPU-side parsing required).
 - **Flow Steering** — Configure the NIC's hardware flow engine to route packets by UDP
   source/destination port.
-- **RDMA** — InfiniBand RDMA operations (READ, WRITE, SEND) via the RDMA backend.
+- **RDMA** — RDMA verbs (READ, WRITE, SEND) over RoCE on Ethernet NICs or InfiniBand.
 
 ### Backends
 
 | Backend | Config value | Description |
 |---------|-------------|-------------|
 | DPDK | `dpdk` | Userspace packet processing with DPDK mbufs and rings. |
-| RDMA | `rdma` | InfiniBand RDMA via libibverbs (client/server model). |
+| RDMA | `rdma` | RDMA verbs via libibverbs over RoCE or InfiniBand (client/server model). |
 | Socket | `socket` | Linux kernel sockets (UDP/TCP), plus a RoCE path that delegates to the RDMA backend. Selecting `socket` automatically builds `rdma`. |
 
 ### Limitations
 
-- Only UDP fill mode is currently supported.
+- TX header-fill helpers currently support UDP only.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 DAQIRI provides direct NIC hardware access in userspace, bypassing the Linux kernel network stack to achieve the highest possible throughput and lowest latency for Ethernet frame transmission and reception. It targets NVIDIA ConnectX-6 Dx and later NICs and supports GPU direct memory access (GPUDirect) for zero-copy data paths between the NIC and GPU.
 
+📖 **Live documentation: [nvidia.github.io/daqiri](https://nvidia.github.io/daqiri/)**
+
+**Requires** an NVIDIA SmartNIC (ConnectX-6 Dx or later) and a discrete GPU. Tested on the NVIDIA DGX Spark, NVIDIA IGX platform, and an x86_64 RTX Pro server. See [Getting Started](docs/getting-started.md) for the full requirements list.
+
 ## Features
 
 - **High Throughput** — Hundreds of gigabits per second with proper hardware and tuning.
@@ -25,8 +29,9 @@ DAQIRI provides direct NIC hardware access in userspace, bypassing the Linux ker
 
 | Backend | Config value | Description |
 |---------|-------------|-------------|
-| DPDK | `dpdk` (default) | Userspace packet processing with DPDK mbufs and rings. |
+| DPDK | `dpdk` | Userspace packet processing with DPDK mbufs and rings. |
 | RDMA | `rdma` | InfiniBand RDMA via libibverbs (client/server model). |
+| Socket | `socket` | Linux kernel sockets (UDP/TCP), plus a RoCE path that delegates to the RDMA backend. Selecting `socket` automatically builds `rdma`. |
 
 ### Limitations
 
@@ -34,29 +39,39 @@ DAQIRI provides direct NIC hardware access in userspace, bypassing the Linux ker
 
 ## Quick Start
 
+Pick **one** of the two build paths below.
+
+**Container build (recommended)** — bundles all user-space dependencies, including a patched DPDK with dmabuf support, so no host-side dependency setup is required:
+
 ```bash
-cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_MGR="dpdk rdma"
+BASE_TARGET=dpdk DAQIRI_MGR="dpdk socket rdma" scripts/build-container.sh
+```
+
+**Bare-metal CMake build** — use if you have all dependencies installed on the host (see the [Dockerfile](Dockerfile) for the full list):
+
+```bash
+cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_MGR="dpdk socket rdma"
 cmake --build build -j
 cmake --install build --prefix /opt/daqiri
 ```
 
-Container build:
-
-```bash
-BASE_TARGET=dpdk DAQIRI_MGR="dpdk rdma" scripts/build-container.sh
-```
-
-See [Getting Started](docs/getting-started.md) for requirements, CMake options, and
-running the benchmarks.
-
 ## Documentation
 
-| Document | Description |
-|----------|-------------|
-| [Getting Started](docs/getting-started.md) | Build, install, system requirements, benchmarks |
-| [Configuration Reference](docs/configuration.md) | Full YAML config reference for all backends |
-| [API Guide](docs/api-guide.md) | BurstParams, RX/TX workflows, buffer lifecycle, status codes |
-| [Contributing](CONTRIBUTING.md) | Contribution guidelines, coding standards, DCO sign-off |
+Reference material for the DAQIRI codebase:
+
+- [Getting Started](docs/getting-started.md) — System requirements, build/install instructions, and CMake options
+- [Configuration Reference](docs/configuration.md) — Full YAML config reference for all backends
+- [API Guide](docs/api-guide.md) — BurstParams, RX/TX workflows, buffer lifecycle, status codes
+- [Contributing](CONTRIBUTING.md) — Contribution guidelines, coding standards, DCO sign-off
+
+## Tutorials
+
+Step-by-step walkthroughs to get hands-on:
+
+- [Background](docs/tutorials/background.md) — Kernel-bypass and GPUDirect concepts
+- [System Configuration](docs/tutorials/system_configuration.md) — NIC drivers, link layers, GPUDirect, hugepages, CPU isolation, GPU clocks
+- [Benchmarking Examples](docs/tutorials/benchmarking_examples.md) — run `daqiri_bench_raw_gpudirect` with a loopback test
+- [Understanding the Configuration File](docs/tutorials/configuration-walkthrough.md) — annotated YAML walkthrough
 
 ## License
 


### PR DESCRIPTION
  ## Summary

  The front-page `README.md` had drifted from the codebase and the web docs
  in `docs/`. This PR aligns it on four fronts:

  - **Backends table.** Add the missing `socket` row, describe the
    RoCE-under-socket path that delegates to `rdma` (and the resulting
    `socket` → `rdma` build coupling), and drop the misleading "(default)"
    annotation on DPDK. Reword the RDMA description to clarify it supports
    RoCE on ConnectX Ethernet NICs in addition to InfiniBand.
  - **`DAQIRI_MGR` examples.** Quick Start and container-build commands
    now use the explicit `"dpdk socket rdma"` list, matching
    `docs/getting-started.md`.
  - **Quick Start structure.** Lead with the recommended container build
    and present the bare-metal CMake build as an alternative, instead of
    the previous ordering that read like sequential steps.
  - **Tutorial discoverability.** New `## Tutorials` section linking the
    four walkthroughs in `docs/tutorials/`. Convert the `## Documentation`
    section from a table to a bullet list so it reads as a visual peer of
    Tutorials, with a one-line leadin distinguishing reference material
    from hands-on walkthroughs.

  Also includes smaller corrections surfaced during review:

  - New top-of-README link to the live docs site
    (`nvidia.github.io/daqiri`) and a `Requires` line covering the SmartNIC
    + GPUDirect-capable GPU prerequisite, plus tested platforms (DGX
    Spark, IGX, x86_64 RTX Pro server).
  - Replace jargon "Only UDP fill mode is currently supported" with
    "TX header-fill helpers currently support UDP only".
  - Drop the duplicated throughput claim ("Hundreds of gigabits per
    second") from the Features list — it's already in the intro.
  - Normalize GPUDirect mode names to title case (Header-Data Split,
    Batched GPU).
  - Tighten the Getting Started description (no false "benchmarks"
    reference; that lives in the tutorial).

  ## Out of scope (follow-ups)

  The review also surfaced items that warrant separate issues:

  - A doc-sync bug in `docs/getting-started.md:94` (advertises the
    `DAQIRI_MGR` default as `"dpdk socket rdma"`, but the literal default
    in `src/CMakeLists.txt:137` is `"dpdk socket"`, which auto-expands).
  - Repo URL inconsistency across docs files
    (`nvidia-holoscan/daqiri` vs `NVIDIA/daqiri`).