### PR TITLE
Added RX HW timestamping

### DIFF
--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -13,7 +13,7 @@ grouped together for efficient transfer between the NIC and the application.
 `BurstParams` provides:
 - Pointers to packet buffers (CPU or GPU memory)
 - Packet metadata: packet count, port/queue IDs, segment count, byte totals
-- Per-packet lengths and flow IDs
+- Per-packet lengths, flow IDs, and optional RX hardware timestamps
 
 Interact with `BurstParams` only through the helper functions described below — the
 internal layout is opaque.
@@ -138,9 +138,22 @@ for (int i = 0; i < daqiri::get_num_packets(burst); i++) {
     void *pkt = daqiri::get_packet_ptr(burst, i);
     uint32_t len = daqiri::get_packet_length(burst, i);
     uint16_t flow = daqiri::get_packet_flow_id(burst, i);
+    uint64_t rx_ts_ns = 0;
+    if (daqiri::get_packet_rx_timestamp(burst, i, &rx_ts_ns) == daqiri::Status::SUCCESS) {
+        // rx_ts_ns is in the NIC timestamp clock domain.
+    }
     // process packet...
 }
 ```
+
+RX hardware timestamps are available only when the DPDK backend is configured with
+`rx.hardware_timestamps: true` and the NIC supports `RTE_ETH_RX_OFFLOAD_TIMESTAMP`.
+DAQIRI converts the NIC timestamp counter to nanoseconds internally using DPDK's
+matching device clock when available, or the PMD's nanosecond timestamp format when
+the driver already supplies nanoseconds. DAQIRI does not expose NIC clock reads or
+convert timestamps to wall-clock time. For reordered aggregate bursts,
+`get_packet_rx_timestamp(burst, 0, &ts)` returns the timestamp of the first source
+packet accepted into the aggregate.
 
 For header-data split (two segments):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,6 +185,17 @@ Unmatched packets are dropped. When `false`, unmatched packets go to a default q
 - type: `boolean`
 - default: `false`
 
+### Hardware Timestamps
+
+`rx.hardware_timestamps:` — Enable per-packet hardware RX timestamps for the DPDK backend.
+When enabled, DAQIRI requires `RTE_ETH_RX_OFFLOAD_TIMESTAMP` support from the NIC/PMD and
+initialization fails if DAQIRI cannot provide nanosecond timestamps for the selected PMD.
+Timestamps are returned by `get_packet_rx_timestamp()` in nanoseconds in the NIC timestamp
+clock domain, not wall-clock time.
+
+- type: `boolean`
+- default: `false`
+
 ### RX Reorder Configs (DPDK v1)
 
 `rx.reorder_configs:` — Optional automatic packet reordering/aggregation plans. In v1 this is

--- a/python/daqiri_common_pybind.cpp
+++ b/python/daqiri_common_pybind.cpp
@@ -606,6 +606,7 @@ void bind_config_types(py::module_ &m) {
   py::class_<RxConfig>(m, "RxConfig")
       .def(py::init<>())
       .def_readwrite("flow_isolation", &RxConfig::flow_isolation_)
+      .def_readwrite("hardware_timestamps", &RxConfig::hardware_timestamps_)
       .def_readwrite("queues", &RxConfig::queues_)
       .def_readwrite("flows", &RxConfig::flows_)
       .def_readwrite("flex_items", &RxConfig::flex_items_)
@@ -747,6 +748,16 @@ PYBIND11_MODULE(_daqiri, m) {
         "seg"_a, "idx"_a);
   m.def("get_packet_length", &get_packet_length, "burst"_a, "idx"_a);
   m.def("get_packet_flow_id", &get_packet_flow_id, "burst"_a, "idx"_a);
+  m.def(
+      "get_packet_rx_timestamp",
+      [](BurstParams *burst, int idx) {
+        uint64_t timestamp_ns = 0;
+        const Status status =
+            get_packet_rx_timestamp(burst, idx, &timestamp_ns);
+        return py::make_tuple(status, timestamp_ns);
+      },
+      "burst"_a, "idx"_a,
+      "Return (Status, RX timestamp nanoseconds) for a packet");
   m.def("get_burst_tot_byte", &get_burst_tot_byte, "burst"_a);
 
   m.def("copy_buffer_to_segment_packet", &copy_buffer_to_segment_packet_impl,

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -107,6 +107,11 @@ uint16_t get_packet_flow_id(BurstParams* burst, int idx) {
   return g_daqiri_mgr->get_packet_flow_id(burst, idx);
 }
 
+Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) {
+  ASSERT_DAQIRI_MGR_INITIALIZED();
+  return g_daqiri_mgr->get_packet_rx_timestamp(burst, idx, timestamp_ns);
+}
+
 uint64_t get_burst_tot_byte(BurstParams* burst) {
   ASSERT_DAQIRI_MGR_INITIALIZED();
   return g_daqiri_mgr->get_burst_tot_byte(burst);

--- a/src/common.h
+++ b/src/common.h
@@ -160,6 +160,25 @@ uint32_t get_packet_length(BurstParams* burst, int idx);
 uint16_t get_packet_flow_id(BurstParams* burst, int idx);
 
 /**
+ * @brief Get the hardware RX timestamp of a packet in nanoseconds
+ *
+ * Retrieves the 64-bit receive timestamp for a packet when the DPDK backend
+ * was configured with rx.hardware_timestamps enabled and the NIC provided a
+ * timestamp for this packet. The value is converted to nanoseconds in the NIC
+ * timestamp clock domain; it is not converted to wall-clock or PTP time.
+ *
+ * @param burst Burst structure containing packets
+ * @param idx Index of packet
+ * @param timestamp_ns Output pointer for the RX timestamp in nanoseconds
+ * @return Status indicating status. Valid values are:
+ *    SUCCESS: Timestamp retrieved
+ *    NULL_PTR: Burst or output pointer is null
+ *    INVALID_PARAMETER: Packet index is out of range
+ *    NOT_SUPPORTED: Timestamp is unavailable for this packet/backend
+ */
+Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns);
+
+/**
  * @brief Populate a TX packet burst buffer
  *
  * Populates a transmit packet burst buffer with allocated packets. The user can take these
@@ -913,6 +932,10 @@ struct YAML::convert<daqiri::NetworkConfig> {
             try {
               rx_cfg.flow_isolation_ = rx["flow_isolation"].as<bool>();
             } catch (const std::exception& e) { rx_cfg.flow_isolation_ = false; }
+
+            try {
+              rx_cfg.hardware_timestamps_ = rx["hardware_timestamps"].as<bool>();
+            } catch (const std::exception& e) { rx_cfg.hardware_timestamps_ = false; }
 
             for (const auto& q_item : rx["queues"]) {
               daqiri::RxQueueConfig q;

--- a/src/manager.h
+++ b/src/manager.h
@@ -48,6 +48,7 @@ class Manager {
   virtual void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) = 0;
   virtual uint32_t get_segment_packet_length(BurstParams* burst, int seg, int idx) = 0;
   virtual uint16_t get_packet_flow_id(BurstParams* burst, int idx) = 0;
+  virtual Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) = 0;
   virtual void* get_packet_extra_info(BurstParams* burst, int idx) = 0;
   virtual Status get_tx_packet_burst(BurstParams* burst) = 0;
   virtual Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) = 0;

--- a/src/managers/dpdk/daqiri_dpdk_mgr.cpp
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.cpp
@@ -36,6 +36,8 @@
 #include <memory>
 #include <utility>
 
+#include <rte_mbuf_dyn.h>
+
 #include "src/dpdk_log.h"
 #include "daqiri_dpdk_mgr.h"
 #include "src/kernels.h"
@@ -233,6 +235,10 @@ struct RxWorkerParams {
   uint64_t timeout_us;
   uint32_t batch_size;
   int rx_meta_pool_size;
+  bool hardware_timestamps;
+  int timestamp_offset;
+  uint64_t timestamp_mask;
+  RxTimestampConversion timestamp_conversion;
   struct rte_ring* ring;
   struct rte_ring* lb_ring;
   struct rte_mempool* flowid_pool;
@@ -248,6 +254,10 @@ struct RxWorkerMultiQPerQParams {
   int num_segs;
   int batch_size;
   uint64_t timeout_us;
+  bool hardware_timestamps;
+  int timestamp_offset;
+  uint64_t timestamp_mask;
+  RxTimestampConversion timestamp_conversion;
   struct rte_ring* ring;
   struct rte_ring* lb_ring;
 };
@@ -275,7 +285,32 @@ struct UDPPkt {
 
 struct ExtraRxPacketInfo {
   uint16_t flow_id;
+  uint64_t rx_timestamp_ns;
+  bool rx_timestamp_ns_valid;
 };
+
+static inline uint64_t convert_rx_timestamp_ticks_to_ns(uint64_t timestamp,
+                                                        const RxTimestampConversion& conversion) {
+  if (!conversion.valid || conversion.ticks_per_second == 0) { return 0; }
+  const auto ns = (static_cast<unsigned __int128>(timestamp) * 1000000000ULL) /
+                  conversion.ticks_per_second;
+  return static_cast<uint64_t>(ns);
+}
+
+static inline bool extract_mbuf_rx_timestamp_ns(struct rte_mbuf* mbuf,
+                                                int timestamp_offset,
+                                                uint64_t timestamp_mask,
+                                                const RxTimestampConversion& conversion,
+                                                uint64_t* timestamp_ns) {
+  if (mbuf == nullptr || timestamp_ns == nullptr || timestamp_offset < 0 || timestamp_mask == 0) {
+    return false;
+  }
+  if (!conversion.valid || conversion.ticks_per_second == 0) { return false; }
+  if ((mbuf->ol_flags & timestamp_mask) == 0) { return false; }
+  const uint64_t timestamp_ticks = *RTE_MBUF_DYNFIELD(mbuf, timestamp_offset, uint64_t*);
+  *timestamp_ns = convert_rx_timestamp_ticks_to_ns(timestamp_ticks, conversion);
+  return true;
+}
 
 bool DpdkMgr::init_reorder_queue_state(const InterfaceConfig& intf, const RxQueueConfig& qcfg) {
   if (intf.rx_.reorder_configs_.empty()) { return true; }
@@ -702,6 +737,8 @@ void DpdkMgr::cleanup_reorder_state() {
                               static_cast<unsigned int>(plan.direct_arrival_batch.packet_count));
       }
       plan.direct_arrival_batch.first_packet_cycles = 0;
+      plan.direct_arrival_batch.first_packet_rx_timestamp_ns = 0;
+      plan.direct_arrival_batch.first_packet_rx_timestamp_ns_valid = false;
       plan.direct_arrival_batch.input_payload_len = 0;
       plan.direct_arrival_batch.payload_len = 0;
       plan.direct_arrival_batch.packet_count = 0;
@@ -891,6 +928,13 @@ Status DpdkMgr::append_reorder_packet(ReorderPlanRuntime& plan,
 
   if (packet_idx == 0) {
     batch.first_packet_cycles = now_cycles;
+    batch.first_packet_rx_timestamp_ns = 0;
+    batch.first_packet_rx_timestamp_ns_valid =
+        extract_mbuf_rx_timestamp_ns(mbuf,
+                                     timestamp_dynfield_offset_,
+                                     rx_timestamp_dynflag_mask_,
+                                     rx_timestamp_conversions_[plan.port_id],
+                                     &batch.first_packet_rx_timestamp_ns);
     const uint32_t pkt_len = mbuf != nullptr ? mbuf->pkt_len : 0U;
     uint32_t copy_len = 0;
     if (pkt_len > plan.payload_byte_offset) { copy_len = pkt_len - plan.payload_byte_offset; }
@@ -904,6 +948,8 @@ Status DpdkMgr::append_reorder_packet(ReorderPlanRuntime& plan,
           reorder_data_type_to_string(plan.input_data_type),
           reorder_data_type_to_string(plan.output_data_type));
       batch.first_packet_cycles = 0;
+      batch.first_packet_rx_timestamp_ns = 0;
+      batch.first_packet_rx_timestamp_ns_valid = false;
       batch.input_payload_len = 0;
       batch.payload_len = 0;
       return Status::INVALID_PARAMETER;
@@ -927,6 +973,8 @@ Status DpdkMgr::create_reorder_output_burst(ReorderPlanRuntime& plan,
                                             uint64_t batch_id,
                                             bool batch_id_ready,
                                             const uint64_t* h_batch_id,
+                                            uint64_t rx_timestamp_ns,
+                                            bool rx_timestamp_ns_valid,
                                             cudaEvent_t event,
                                             bool timeout_flush,
                                             BurstParams** out_burst) {
@@ -958,6 +1006,8 @@ Status DpdkMgr::create_reorder_output_burst(ReorderPlanRuntime& plan,
   ctx->info.aggregate_len = aggregate_len;
   ctx->info.burst_flags = burst->hdr.hdr.burst_flags;
   ctx->h_batch_id = batch_id_ready ? nullptr : h_batch_id;
+  ctx->rx_timestamp_ns = rx_timestamp_ns;
+  ctx->rx_timestamp_ns_valid = rx_timestamp_ns_valid;
   static_assert(sizeof(ReorderBurstInfo)
                 <= ADV_NETWORK_HEADER_SIZE_BYTES - sizeof(void*) - sizeof(BurstHeaderParams),
                 "ReorderBurstInfo must fit in BurstHeader::custom_burst_data");
@@ -987,6 +1037,8 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
 
   if (batch->packet_count == 0) {
     batch->first_packet_cycles = 0;
+    batch->first_packet_rx_timestamp_ns = 0;
+    batch->first_packet_rx_timestamp_ns_valid = false;
     batch->input_payload_len = 0;
     batch->payload_len = 0;
     return Status::SUCCESS;
@@ -1148,6 +1200,8 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
                                        output_batch_id,
                                        output_batch_id_ready,
                                        output_batch_id_host,
+                                       batch->first_packet_rx_timestamp_ns,
+                                       batch->first_packet_rx_timestamp_ns_valid,
                                        copy_done,
                                        timeout_flush,
                                        out_burst);
@@ -1166,6 +1220,8 @@ Status DpdkMgr::flush_reorder_batch(ReorderPlanRuntime& plan,
   }
 
   batch->first_packet_cycles = 0;
+  batch->first_packet_rx_timestamp_ns = 0;
+  batch->first_packet_rx_timestamp_ns_valid = false;
   batch->input_payload_len = 0;
   batch->payload_len = 0;
   batch->packet_count = 0;
@@ -1544,38 +1600,135 @@ void DpdkMgr::adjust_memory_regions() {
 }
 
 
-void DpdkMgr::setup_accurate_send_scheduling_mask() {
+bool DpdkMgr::setup_rx_timestamp_dynfield() {
   static bool done = false;
-  if (done) { return; }
+  static int registered_offset = -1;
+  static uint64_t registered_mask = 0;
 
-  static const rte_mbuf_dynfield dynfield_desc = {
-      RTE_MBUF_DYNFIELD_TIMESTAMP_NAME,
-      sizeof(uint64_t),
-      .align = __alignof__(uint64_t),
-  };
-
-  static const rte_mbuf_dynflag dynflag_desc = {
-      RTE_MBUF_DYNFLAG_TX_TIMESTAMP_NAME,
-  };
-
-  timestamp_offset_ = rte_mbuf_dynfield_register(&dynfield_desc);
-  if (timestamp_offset_ < 0) {
-    DAQIRI_LOG_CRITICAL(
-        "{} registration error: {}", RTE_MBUF_DYNFIELD_TIMESTAMP_NAME, rte_strerror(rte_errno));
-    return;
+  if (!done) {
+    if (rte_mbuf_dyn_rx_timestamp_register(&registered_offset, &registered_mask) < 0) {
+      DAQIRI_LOG_CRITICAL("RX timestamp dynamic field registration error: {}",
+                          rte_strerror(rte_errno));
+      return false;
+    }
+    done = true;
   }
 
-  int32_t dynflag_bitnum = rte_mbuf_dynflag_register(&dynflag_desc);
-  if (dynflag_bitnum == -1) {
-    DAQIRI_LOG_CRITICAL(
-        "{} registration error: {}", RTE_MBUF_DYNFLAG_TX_TIMESTAMP_NAME, rte_strerror(rte_errno));
-    return;
+  if (timestamp_dynfield_offset_ >= 0 && timestamp_dynfield_offset_ != registered_offset) {
+    DAQIRI_LOG_CRITICAL("RX timestamp field offset {} does not match existing offset {}",
+                        registered_offset,
+                        timestamp_dynfield_offset_);
+    return false;
   }
 
-  auto dynflag_shift = static_cast<uint8_t>(dynflag_bitnum);
-  timestamp_mask_ = 1ULL << dynflag_shift;
-  DAQIRI_LOG_INFO("Done setting up accurate send scheduling with mask {:x}", timestamp_mask_);
-  done = true;
+  timestamp_dynfield_offset_ = registered_offset;
+  rx_timestamp_dynflag_mask_ = registered_mask;
+  DAQIRI_LOG_INFO("Done setting up RX timestamping with mask {:x}", rx_timestamp_dynflag_mask_);
+  return true;
+}
+
+bool DpdkMgr::calibrate_rx_timestamp_clock(uint16_t port_id) {
+  uint64_t start_clock = 0;
+  int ret = rte_eth_read_clock(port_id, &start_clock);
+  if (ret < 0) {
+    rte_eth_dev_info dev_info{};
+    const int info_ret = rte_eth_dev_info_get(port_id, &dev_info);
+    const std::string driver_name =
+        (info_ret == 0 && dev_info.driver_name != nullptr) ? dev_info.driver_name : "";
+    if (ret == -ENOTSUP && driver_name.find("mlx5") != std::string::npos) {
+      rx_timestamp_conversions_[port_id].valid = true;
+      rx_timestamp_conversions_[port_id].ticks_per_second = 1000000000ULL;
+      DAQIRI_LOG_WARN(
+          "rte_eth_read_clock() is not supported on mlx5 port {}; treating PMD-provided "
+          "RX hardware timestamps as nanoseconds",
+          port_id);
+      return true;
+    }
+
+    DAQIRI_LOG_CRITICAL(
+        "RX hardware timestamps require rte_eth_read_clock() for nanosecond conversion, "
+        "but port {} returned err={} ({})",
+        port_id,
+        ret,
+        rte_strerror(-ret));
+    return false;
+  }
+
+  const auto start_time = std::chrono::steady_clock::now();
+  rte_delay_us_block(100000);
+
+  uint64_t end_clock = 0;
+  ret = rte_eth_read_clock(port_id, &end_clock);
+  if (ret < 0) {
+    DAQIRI_LOG_CRITICAL(
+        "RX hardware timestamp clock calibration failed on port {}: err={} ({})",
+        port_id,
+        ret,
+        rte_strerror(-ret));
+    return false;
+  }
+
+  const auto elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                              std::chrono::steady_clock::now() - start_time)
+                              .count();
+  if (elapsed_ns <= 0 || end_clock <= start_clock) {
+    DAQIRI_LOG_CRITICAL(
+        "RX hardware timestamp clock calibration produced an invalid sample on port {} "
+        "(start={}, end={}, elapsed_ns={})",
+        port_id,
+        start_clock,
+        end_clock,
+        elapsed_ns);
+    return false;
+  }
+
+  const uint64_t delta_ticks = end_clock - start_clock;
+  const auto ticks_per_second =
+      (static_cast<unsigned __int128>(delta_ticks) * 1000000000ULL +
+       static_cast<uint64_t>(elapsed_ns / 2)) /
+      static_cast<uint64_t>(elapsed_ns);
+  if (ticks_per_second == 0 ||
+      ticks_per_second > static_cast<unsigned __int128>(std::numeric_limits<uint64_t>::max())) {
+    DAQIRI_LOG_CRITICAL(
+        "RX hardware timestamp clock calibration produced an invalid frequency on port {}",
+        port_id);
+    return false;
+  }
+
+  rx_timestamp_conversions_[port_id].valid = true;
+  rx_timestamp_conversions_[port_id].ticks_per_second = static_cast<uint64_t>(ticks_per_second);
+  DAQIRI_LOG_INFO("Calibrated RX timestamp clock for port {} at {} ticks/second",
+                  port_id,
+                  rx_timestamp_conversions_[port_id].ticks_per_second);
+  return true;
+}
+
+bool DpdkMgr::setup_tx_timestamp_dynfield() {
+  static bool done = false;
+  static int registered_offset = -1;
+  static uint64_t registered_mask = 0;
+
+  if (!done) {
+    if (rte_mbuf_dyn_tx_timestamp_register(&registered_offset, &registered_mask) < 0) {
+      DAQIRI_LOG_CRITICAL("TX timestamp dynamic field registration error: {}",
+                          rte_strerror(rte_errno));
+      return false;
+    }
+    done = true;
+  }
+
+  if (timestamp_dynfield_offset_ >= 0 && timestamp_dynfield_offset_ != registered_offset) {
+    DAQIRI_LOG_CRITICAL("TX timestamp field offset {} does not match existing offset {}",
+                        registered_offset,
+                        timestamp_dynfield_offset_);
+    return false;
+  }
+
+  timestamp_dynfield_offset_ = registered_offset;
+  tx_timestamp_dynflag_mask_ = registered_mask;
+  DAQIRI_LOG_INFO("Done setting up accurate send scheduling with mask {:x}",
+                  tx_timestamp_dynflag_mask_);
+  return true;
 }
 
 
@@ -1920,6 +2073,9 @@ void DpdkMgr::initialize() {
 
         q_backend->rxconf_qsplit.offloads =
             RTE_ETH_RX_OFFLOAD_SCATTER | RTE_ETH_RX_OFFLOAD_BUFFER_SPLIT;
+        if (rx.hardware_timestamps_) {
+          q_backend->rxconf_qsplit.offloads |= RTE_ETH_RX_OFFLOAD_TIMESTAMP;
+        }
         q_backend->rxconf_qsplit.rx_nseg = q.common_.mrs_.size();
 
         q_backend->rx_useg.resize(q.common_.mrs_.size());
@@ -1946,6 +2102,26 @@ void DpdkMgr::initialize() {
     }
 
     local_port_conf[intf.port_id_].rxmode.offloads |= RTE_ETH_RX_OFFLOAD_CHECKSUM;
+
+    if (rx.hardware_timestamps_) {
+      if (loopback_ == LoopbackType::LOOPBACK_TYPE_SW) {
+        DAQIRI_LOG_CRITICAL(
+            "RX hardware timestamps are enabled for interface '{}', but software loopback "
+            "does not support hardware timestamping",
+            intf.name_);
+        return;
+      }
+      if ((dev_info.rx_offload_capa & RTE_ETH_RX_OFFLOAD_TIMESTAMP) == 0) {
+        DAQIRI_LOG_CRITICAL(
+            "RX hardware timestamps are enabled for interface '{}', but port {} does not "
+            "support RTE_ETH_RX_OFFLOAD_TIMESTAMP",
+            intf.name_,
+            intf.port_id_);
+        return;
+      }
+      if (!setup_rx_timestamp_dynfield()) { return; }
+      local_port_conf[intf.port_id_].rxmode.offloads |= RTE_ETH_RX_OFFLOAD_TIMESTAMP;
+    }
 
     // TX now
     // For now make a single queue. Support more sophisticated TX on next release
@@ -2033,18 +2209,18 @@ void DpdkMgr::initialize() {
     }
 
     if (loopback_ != LoopbackType::LOOPBACK_TYPE_SW && tx.accurate_send_) {
-      setup_accurate_send_scheduling_mask();
+      if (!setup_tx_timestamp_dynfield()) { return; }
 
       if (ret != 0) {
         DAQIRI_LOG_CRITICAL("Failed to get device info for port {}", intf.port_id_);
         return;
       } else {
-        if ((dev_info.tx_offload_capa & RTE_ETH_RX_OFFLOAD_TIMESTAMP) == 0) {
+        if ((dev_info.tx_offload_capa & RTE_ETH_TX_OFFLOAD_SEND_ON_TIMESTAMP) == 0) {
           DAQIRI_LOG_CRITICAL(
               "Accurate send scheduling enabled in config, but not supported by NIC!");
           return;
         } else {
-          local_port_conf[intf.port_id_].txmode.offloads |= RTE_ETH_RX_OFFLOAD_TIMESTAMP;
+          local_port_conf[intf.port_id_].txmode.offloads |= RTE_ETH_TX_OFFLOAD_SEND_ON_TIMESTAMP;
         }
       }
     }
@@ -2185,6 +2361,8 @@ void DpdkMgr::initialize() {
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[3],
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[4],
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[5]);
+
+      if (rx.hardware_timestamps_ && !calibrate_rx_timestamp_clock(intf.port_id_)) { return; }
 
       // Start flows
       int flow_num = 0;
@@ -3180,6 +3358,13 @@ void DpdkMgr::run() {
   int icore;
 
   DAQIRI_LOG_INFO("Starting DAQIRI workers");
+  const auto hardware_timestamps_enabled = [this](uint16_t port_id) {
+    for (const auto& intf : cfg_.ifs_) {
+      if (intf.port_id_ == port_id) { return intf.rx_.hardware_timestamps_; }
+    }
+    return false;
+  };
+
   // determine the correct process types for input/output
   int (*rx_worker)(void*);
   int (*tx_worker)(void*);
@@ -3220,6 +3405,10 @@ void DpdkMgr::run() {
       params->batch_size = q->common_.batch_size_;
       params->timeout_us = q->timeout_us_;
       params->rx_meta_pool_size = cfg_.rx_meta_buffers_;
+      params->hardware_timestamps = hardware_timestamps_enabled(port_id);
+      params->timestamp_offset = timestamp_dynfield_offset_;
+      params->timestamp_mask = rx_timestamp_dynflag_mask_;
+      params->timestamp_conversion = rx_timestamp_conversions_[port_id];
       rte_eal_remote_launch(
         rx_worker, (void*)params, strtol(q->common_.cpu_core_.c_str(), NULL, 10));
     } else {
@@ -3236,8 +3425,17 @@ void DpdkMgr::run() {
         const auto &q    = rx_cfg_q_map_[key];
         struct rte_ring* ring_ptr = rx_rings[key];
 
-        params->q_params.push_back({port_id, q_id,
-                    (int)q->common_.mrs_.size(), q->common_.batch_size_, q->timeout_us_, ring_ptr});
+        params->q_params.push_back({port_id,
+                                    q_id,
+                                    (int)q->common_.mrs_.size(),
+                                    q->common_.batch_size_,
+                                    q->timeout_us_,
+                                    hardware_timestamps_enabled(port_id),
+                                    timestamp_dynfield_offset_,
+                                    rx_timestamp_dynflag_mask_,
+                                    rx_timestamp_conversions_[port_id],
+                                    ring_ptr,
+                                    nullptr});
       }
 
       params->rx_burst_pool = rx_burst_buffer;
@@ -3448,14 +3646,23 @@ int DpdkMgr::rx_core_multi_q_worker(void* arg) {
                   &mbuf_arr[cur_idx][cur_pkt_in_batch[cur_idx]], sizeof(rte_mbuf*) * to_copy);
 
     ExtraRxPacketInfo* pkt_info =
-                          reinterpret_cast<ExtraRxPacketInfo*>(bursts[cur_idx]->pkt_extra_info);
+                              reinterpret_cast<ExtraRxPacketInfo*>(bursts[cur_idx]->pkt_extra_info);
     for (int p = 0; p < to_copy; p++) {
-      if (mbuf_arr[cur_idx][cur_pkt_in_batch[cur_idx] + p]->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
-        pkt_info[bursts[cur_idx]->hdr.hdr.num_pkts + p].flow_id =
-                              mbuf_arr[cur_idx][cur_pkt_in_batch[cur_idx] + p]->hash.fdir.hi;
+      auto* mbuf = mbuf_arr[cur_idx][cur_pkt_in_batch[cur_idx] + p];
+      auto& info = pkt_info[bursts[cur_idx]->hdr.hdr.num_pkts + p];
+      if (mbuf->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
+        info.flow_id = mbuf->hash.fdir.hi;
       } else {
-        pkt_info[bursts[cur_idx]->hdr.hdr.num_pkts + p].flow_id = 0;
+        info.flow_id = 0;
       }
+      info.rx_timestamp_ns = 0;
+      info.rx_timestamp_ns_valid =
+          tparams->q_params[cur_idx].hardware_timestamps
+          && extract_mbuf_rx_timestamp_ns(mbuf,
+                                          tparams->q_params[cur_idx].timestamp_offset,
+                                          tparams->q_params[cur_idx].timestamp_mask,
+                                          tparams->q_params[cur_idx].timestamp_conversion,
+                                          &info.rx_timestamp_ns);
     }
 
     if (cur_segs > 1) {  // Extra work when buffers are scattered
@@ -3634,12 +3841,21 @@ int DpdkMgr::rx_core_worker(void* arg) {
                                         &mbuf_arr[cur_pkt_in_batch], sizeof(rte_mbuf*) * to_copy);
 
     for (int p = 0; p < to_copy; p++) {
-      if (mbuf_arr[cur_pkt_in_batch + p]->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
-        pkt_info[burst->hdr.hdr.num_pkts + p].flow_id =
-                                          mbuf_arr[cur_pkt_in_batch + p]->hash.fdir.hi;
+      auto* mbuf = mbuf_arr[cur_pkt_in_batch + p];
+      auto& info = pkt_info[burst->hdr.hdr.num_pkts + p];
+      if (mbuf->ol_flags & RTE_MBUF_F_RX_FDIR_ID) {
+        info.flow_id = mbuf->hash.fdir.hi;
       } else {
-        pkt_info[burst->hdr.hdr.num_pkts + p].flow_id = 0;
+        info.flow_id = 0;
       }
+      info.rx_timestamp_ns = 0;
+      info.rx_timestamp_ns_valid =
+          tparams->hardware_timestamps
+          && extract_mbuf_rx_timestamp_ns(mbuf,
+                                          tparams->timestamp_offset,
+                                          tparams->timestamp_mask,
+                                          tparams->timestamp_conversion,
+                                          &info.rx_timestamp_ns);
     }
 
     if (tparams->num_segs > 1) {  // Extra work when buffers are scattered
@@ -3709,6 +3925,7 @@ int DpdkMgr::rx_lb_worker(void* arg) {
     meta_burst->hdr.hdr.q_id = tparams->queue;
     meta_burst->hdr.hdr.port_id = tparams->port;
     meta_burst->hdr.hdr.num_segs = tparams->num_segs;
+    meta_burst->pkt_extra_info = nullptr;
 
     for (int seg = 0; seg < tparams->num_segs; seg++) {
       if (rte_mempool_get(
@@ -3915,10 +4132,40 @@ uint16_t DpdkMgr::get_packet_flow_id(BurstParams* burst, int idx) {
   return info[idx].flow_id;
 }
 
+Status DpdkMgr::get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) {
+  if (burst == nullptr || timestamp_ns == nullptr) { return Status::NULL_PTR; }
+  *timestamp_ns = 0;
+  if (idx < 0 || idx >= static_cast<int>(burst->hdr.hdr.num_pkts)) {
+    return Status::INVALID_PARAMETER;
+  }
+
+  if ((burst->hdr.hdr.burst_flags & kBurstFlagDpdkReordered) != 0U) {
+    if (idx != 0 || burst->custom_pkt_data == nullptr) { return Status::INVALID_PARAMETER; }
+    auto ctx = std::static_pointer_cast<ReorderBurstContext>(burst->custom_pkt_data);
+    if (!ctx || !ctx->rx_timestamp_ns_valid) { return Status::NOT_SUPPORTED; }
+    *timestamp_ns = ctx->rx_timestamp_ns;
+    return Status::SUCCESS;
+  }
+
+  const ExtraRxPacketInfo* info = reinterpret_cast<ExtraRxPacketInfo*>(burst->pkt_extra_info);
+  if (info == nullptr || !info[idx].rx_timestamp_ns_valid) { return Status::NOT_SUPPORTED; }
+  *timestamp_ns = info[idx].rx_timestamp_ns;
+  return Status::SUCCESS;
+}
+
 Status DpdkMgr::set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp) {
-  reinterpret_cast<struct rte_mbuf**>(burst->pkts[0])[idx]->ol_flags |= timestamp_mask_;
+  if (burst == nullptr) { return Status::NULL_PTR; }
+  if (idx < 0 || idx >= static_cast<int>(burst->hdr.hdr.num_pkts)) {
+    return Status::INVALID_PARAMETER;
+  }
+  if (timestamp_dynfield_offset_ < 0 || tx_timestamp_dynflag_mask_ == 0) {
+    return Status::NOT_SUPPORTED;
+  }
+  reinterpret_cast<struct rte_mbuf**>(burst->pkts[0])[idx]->ol_flags |= tx_timestamp_dynflag_mask_;
   *RTE_MBUF_DYNFIELD(
-      reinterpret_cast<rte_mbuf**>(burst->pkts[0])[idx], timestamp_offset_, uint64_t*) = timestamp;
+      reinterpret_cast<rte_mbuf**>(burst->pkts[0])[idx],
+      timestamp_dynfield_offset_,
+      uint64_t*) = timestamp;
 
   return Status::SUCCESS;
 }

--- a/src/managers/dpdk/daqiri_dpdk_mgr.h
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.h
@@ -71,6 +71,11 @@ struct DropTrafficConfig {
   struct rte_flow *drop;
 };
 
+struct RxTimestampConversion {
+  bool valid = false;
+  uint64_t ticks_per_second = 0;
+};
+
 class DpdkMgr : public Manager {
  public:
   static_assert(MAX_INTERFACES <= RTE_MAX_ETHPORTS, "Too many interfaces configured");
@@ -100,6 +105,7 @@ class DpdkMgr : public Manager {
   uint32_t get_segment_packet_length(BurstParams* burst, int seg, int idx) override;
   uint32_t get_packet_length(BurstParams* burst, int idx) override;
   uint16_t get_packet_flow_id(BurstParams* burst, int idx) override;
+  Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) override;
   void* get_packet_extra_info(BurstParams* burst, int idx) override;
   Status get_tx_packet_burst(BurstParams* burst) override;
   Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) override;
@@ -152,7 +158,9 @@ class DpdkMgr : public Manager {
   static int rx_lb_worker(void* arg);
   static int tx_lb_worker(void* arg);
   static void flush_packets(int port);
-  void setup_accurate_send_scheduling_mask();
+  bool setup_rx_timestamp_dynfield();
+  bool setup_tx_timestamp_dynfield();
+  bool calibrate_rx_timestamp_clock(uint16_t port_id);
   int setup_pools_and_rings(int max_rx_batch, int max_tx_batch);
   struct rte_flow* add_flow(int port, const FlowConfig& cfg);
   void create_dummy_rx_q();
@@ -168,9 +176,11 @@ class DpdkMgr : public Manager {
 
   struct ReorderBatchState {
     uint64_t first_packet_cycles = 0;
+    uint64_t first_packet_rx_timestamp_ns = 0;
     uint32_t input_payload_len = 0;
     uint32_t payload_len = 0;
     uint32_t packet_count = 0;
+    bool first_packet_rx_timestamp_ns_valid = false;
   };
 
   struct ReorderOutputBufferState {
@@ -248,6 +258,8 @@ class DpdkMgr : public Manager {
     std::array<uint32_t, 1> pkt_lens{};
     ReorderBurstInfo info{};
     const uint64_t* h_batch_id = nullptr;
+    uint64_t rx_timestamp_ns = 0;
+    bool rx_timestamp_ns_valid = false;
     bool released = false;
   };
 
@@ -286,6 +298,8 @@ class DpdkMgr : public Manager {
                                      uint64_t batch_id,
                                      bool batch_id_ready,
                                      const uint64_t* h_batch_id,
+                                     uint64_t rx_timestamp_ns,
+                                     bool rx_timestamp_ns_valid,
                                      cudaEvent_t event,
                                      bool timeout_flush,
                                      BurstParams** out_burst);
@@ -319,8 +333,10 @@ class DpdkMgr : public Manager {
   std::unordered_map<uint32_t, ReorderQueueState> reorder_queue_states_;
   std::mutex reorder_lock_;
   std::array<DropTrafficConfig, RTE_MAX_ETHPORTS> drop_all_traffic_flow;
-  uint64_t timestamp_mask_{0};
-  uint64_t timestamp_offset_{0};
+  int timestamp_dynfield_offset_{-1};
+  uint64_t rx_timestamp_dynflag_mask_{0};
+  uint64_t tx_timestamp_dynflag_mask_{0};
+  std::array<RxTimestampConversion, RTE_MAX_ETHPORTS> rx_timestamp_conversions_{};
   std::array<struct rte_eth_conf, MAX_INTERFACES> local_port_conf;
   DpdkStats stats_;
   struct rte_ring* loopback_ring;

--- a/src/managers/rdma/daqiri_rdma_mgr.h
+++ b/src/managers/rdma/daqiri_rdma_mgr.h
@@ -100,6 +100,12 @@ class RdmaMgr : public Manager {
   void* get_packet_ptr(BurstParams* burst, int idx) override;
   uint32_t get_packet_length(BurstParams* burst, int idx) override;
   uint16_t get_packet_flow_id(BurstParams* burst, int idx) override { return 0; }
+  Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) override {
+    (void)burst;
+    (void)idx;
+    (void)timestamp_ns;
+    return Status::NOT_SUPPORTED;
+  }
   void* get_packet_extra_info(BurstParams* burst, int idx) override { return nullptr; }
   void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) override;
   uint32_t get_segment_packet_length(BurstParams* burst, int seg, int idx) override;

--- a/src/managers/socket/daqiri_socket_mgr.cpp
+++ b/src/managers/socket/daqiri_socket_mgr.cpp
@@ -202,6 +202,13 @@ uint16_t SocketMgr::get_packet_flow_id(BurstParams* burst, int idx) {
   return 0;
 }
 
+Status SocketMgr::get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) {
+  (void)burst;
+  (void)idx;
+  (void)timestamp_ns;
+  return Status::NOT_SUPPORTED;
+}
+
 void* SocketMgr::get_packet_extra_info(BurstParams* burst, int idx) {
   return nullptr;
 }

--- a/src/managers/socket/daqiri_socket_mgr.h
+++ b/src/managers/socket/daqiri_socket_mgr.h
@@ -48,6 +48,7 @@ class SocketMgr : public Manager {
   void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) override;
   uint32_t get_segment_packet_length(BurstParams* burst, int seg, int idx) override;
   uint16_t get_packet_flow_id(BurstParams* burst, int idx) override;
+  Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) override;
   void* get_packet_extra_info(BurstParams* burst, int idx) override;
 
   Status get_tx_packet_burst(BurstParams* burst) override;

--- a/src/types.h
+++ b/src/types.h
@@ -764,7 +764,8 @@ struct ReorderConfig {
 };
 
 struct RxConfig {
-  bool flow_isolation_;
+  bool flow_isolation_ = false;
+  bool hardware_timestamps_ = false;
   std::vector<RxQueueConfig> queues_;
   std::vector<FlowConfig> flows_;
   std::vector<FlexItemConfig> flex_items_;


### PR DESCRIPTION
The ConnectX and Bluefield cards have the capability of stamping the current timestamp either from the ASIC clock or PTP in each packet. These changes exposes it to the user.