### PR TITLE
base torch image option on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,12 @@ ARG DAQIRI_BASE_TARGET=dpdk
 ARG DAQIRI_MGR="dpdk socket"
 ARG DAQIRI_BUILD_PYTHON=OFF
 ARG BUILD_SHARED_LIBS=ON
+ARG DAQIRI_OS_BASE_IMAGE=nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04
 
 # ============================================================
 # base: Base layer
 # ============================================================
-FROM nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04 AS base
+FROM ${DAQIRI_OS_BASE_IMAGE} AS base
 SHELL ["/bin/bash", "-eou", "pipefail", "-c"]
 
 # Basic system dependencies
@@ -31,7 +32,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         ca-certificates \
         infiniband-diags \
-        mft \
         gnupg \
         python3-pip \
         git \
@@ -60,10 +60,33 @@ FROM base AS base-deps
 ARG TARGETARCH
 ARG CACHEBUST=1
 ARG DEBIAN_FRONTEND=noninteractive
+ARG DOCA_VERSION=3.2.1
 
 WORKDIR /opt
 
-# APT installs for base dependencies (no DOCA/GPUNetIO packages)
+# Configure the DOCA APT repository so libibverbs / librdmacm / libmlx5
+# (and later mft, mlnx-ofed-kernel-utils in the dpdk stage) resolve to
+# MLNX OFED packages with intact -dev symlinks. Required because some
+# upstream base images (notably nvcr.io/nvidia/pytorch) ship the stock
+# Ubuntu packages with files stripped, leaving dpkg's database in a state
+# where the package is "installed" but the -dev symlinks are missing on
+# disk and the .deb is not re-downloadable.
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        DOCA_ARCH="x86_64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        DOCA_ARCH="arm64-sbsa"; \
+    else \
+        echo "Unknown architecture: $TARGETARCH"; \
+        exit 1; \
+    fi \
+    && DISTRO=$(. /etc/os-release && echo ${ID}${VERSION_ID}) \
+    && DOCA_REPO_LINK=https://linux.mellanox.com/public/repo/doca/${DOCA_VERSION}/${DISTRO}/${DOCA_ARCH} \
+    && echo "Using DOCA_REPO_LINK=${DOCA_REPO_LINK}" \
+    && LOCAL_GPG_KEY_PATH="/usr/share/keyrings/mellanox-archive-keyring.gpg" \
+    && curl -fsSL ${DOCA_REPO_LINK}/GPG-KEY-Mellanox.pub | gpg --dearmor | tee ${LOCAL_GPG_KEY_PATH} > /dev/null \
+    && echo "deb [signed-by=${LOCAL_GPG_KEY_PATH}] ${DOCA_REPO_LINK} ./" | tee /etc/apt/sources.list.d/mellanox.list
+
+# APT installs for base dependencies
 # - libibverbs-dev, librdmacm-dev: RDMA/ibverbs support for Mellanox NICs
 # - libmlx5-1: Mellanox ConnectX driver
 # - ibverbs-utils: utilities
@@ -95,13 +118,10 @@ FROM base-deps AS dpdk
 ARG DPDK_VERSION=25.11
 ARG DPDK_BUILD_DIR=/opt/dpdk-build
 ARG DPDK_INSTALL_PREFIX=/usr/local
-ARG DOCA_VERSION=3.2.1
 
 COPY dpdk_patches /tmp/dpdk_patches
 
 
-# - infiniband-diags for IB diagnostics
-# - mft for Mellanox Flex Transport
 # - ninja-build: for cmake build
 # - pkgconf: to import dpdk in CMake
 # - meson: for building DPDK
@@ -143,26 +163,12 @@ RUN curl -fsSL https://fast.dpdk.org/rel/dpdk-${DPDK_VERSION}.tar.xz -o /tmp/dpd
     && ldconfig \
     && rm -rf /tmp/dpdk-${DPDK_VERSION} /tmp/dpdk-${DPDK_VERSION}.tar.xz ${DPDK_BUILD_DIR} /tmp/dpdk_patches
 
-# Configure the DOCA APT repository for mlnx-ofed-kernel-utils
-# (needed for ibdev2netdev utility used by tune_system.py)
-RUN if [ "${TARGETARCH}" = "amd64" ]; then \
-        DOCA_ARCH="x86_64"; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-        DOCA_ARCH="arm64-sbsa"; \
-    else \
-        echo "Unknown architecture: $TARGETARCH"; \
-        exit 1; \
-    fi \
-    && DISTRO=$(. /etc/os-release && echo ${ID}${VERSION_ID}) \
-    && DOCA_REPO_LINK=https://linux.mellanox.com/public/repo/doca/${DOCA_VERSION}/${DISTRO}/${DOCA_ARCH} \
-    && echo "Using DOCA_REPO_LINK=${DOCA_REPO_LINK}" \
-    && LOCAL_GPG_KEY_PATH="/usr/share/keyrings/mellanox-archive-keyring.gpg" \
-    && curl -fsSL ${DOCA_REPO_LINK}/GPG-KEY-Mellanox.pub | gpg --dearmor | tee ${LOCAL_GPG_KEY_PATH} > /dev/null \
-    && echo "deb [signed-by=${LOCAL_GPG_KEY_PATH}] ${DOCA_REPO_LINK} ./" | tee /etc/apt/sources.list.d/mellanox.list
-
+# DOCA APT repository is configured in the base-deps stage above.
 # - mlnx-ofed-kernel-utils for utilities including ibdev2netdev used by tune_system.py
+# - mft for Mellanox Firmware Tools (mlxconfig, flint, etc.)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     mlnx-ofed-kernel-utils \
+    mft \
     && rm -rf /var/lib/apt/lists/*
 
 # ==============================================================

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Pick **one** of the two build paths below.
 BASE_TARGET=dpdk DAQIRI_MGR="dpdk socket rdma" scripts/build-container.sh
 ```
 
+Set `BASE_IMAGE=torch` to build on top of NGC PyTorch instead of the default CUDA base — useful for Torch / TensorRT inference workflows that ingest packets directly into GPU memory.
+
 **Bare-metal CMake build** — use if you have all dependencies installed on the host (see the [Dockerfile](Dockerfile) for the full list):
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,6 +76,12 @@ Then build the DAQIRI library:
     BASE_TARGET=dpdk DAQIRI_MGR="dpdk socket rdma" scripts/build-container.sh
     ```
 
+    Set `BASE_IMAGE=torch` to build on top of NGC PyTorch instead of the default CUDA base — useful for Torch / TensorRT inference workflows that ingest packets directly into GPU memory:
+
+    ```bash
+    BASE_IMAGE=torch BASE_TARGET=dpdk DAQIRI_MGR="dpdk socket rdma" scripts/build-container.sh
+    ```
+
 === "CMake build (bare-metal)"
 
     ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -340,7 +340,7 @@ cmake --install build --prefix /opt/daqiri</pre>
             <div class="gs-step-num">3</div>
             <div class="gs-step-body">
               <h4>Or Build the Container</h4>
-              <p>The Dockerfile builds DPDK from source with dmabuf patches — no peermem needed inside the container.</p>
+              <p>The Dockerfile builds DPDK from source with dmabuf patches — no peermem needed inside the container. Set <code>BASE_IMAGE=torch</code> to build on top of NGC PyTorch for Torch / TensorRT inference workflows.</p>
               <pre>BASE_TARGET=dpdk \
   DAQIRI_MGR=<span class="str">"dpdk socket rdma"</span> \
   scripts/build-container.sh</pre>

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -3,13 +3,28 @@ set -euo pipefail
 
 IMAGE_TAG="${IMAGE_TAG:-daqiri:local}"
 BASE_TARGET="${BASE_TARGET:-dpdk}"
+BASE_IMAGE="${BASE_IMAGE:-cuda}"
 DAQIRI_MGR="${DAQIRI_MGR:-dpdk socket}"
 DAQIRI_BUILD_PYTHON="${DAQIRI_BUILD_PYTHON:-OFF}"
 BUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-ON}"
 
+case "${BASE_IMAGE}" in
+  cuda)
+    DAQIRI_OS_BASE_IMAGE="nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04"
+    ;;
+  torch)
+    DAQIRI_OS_BASE_IMAGE="nvcr.io/nvidia/pytorch:26.01-py3"
+    ;;
+  *)
+    echo "ERROR: invalid BASE_IMAGE='${BASE_IMAGE}'. Choose from: cuda, torch" >&2
+    exit 1
+    ;;
+esac
+
 docker build \
   --target runtime \
   --build-arg DAQIRI_BASE_TARGET="${BASE_TARGET}" \
+  --build-arg DAQIRI_OS_BASE_IMAGE="${DAQIRI_OS_BASE_IMAGE}" \
   --build-arg DAQIRI_MGR="${DAQIRI_MGR}" \
   --build-arg DAQIRI_BUILD_PYTHON="${DAQIRI_BUILD_PYTHON}" \
   --build-arg BUILD_SHARED_LIBS="${BUILD_SHARED_LIBS}" \


### PR DESCRIPTION
## Summary

Adds a `BASE_IMAGE` env var to `scripts/build-container.sh` accepting
`cuda` (default, unchanged behavior) or `torch`. Setting `BASE_IMAGE=torch`
swaps the multi-stage Dockerfile's base image so the resulting container
ships Torch + Torch-TensorRT alongside DAQIRI, for downstream workflows
that ingest packets directly into GPU memory and run inference in the
same process.

| Knob | Resolves to |
|---|---|
| `BASE_IMAGE=cuda` (default) | `nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04` |
| `BASE_IMAGE=torch` | `nvcr.io/nvidia/pytorch:26.01-py3` |
| `BASE_IMAGE=<anything else>` | hard error, exits 1 |

## Why each Dockerfile change was needed

The PyTorch base does not ship the same pre-installed packages and apt
sources as the CUDA base. Three small changes make the Dockerfile work
on both bases instead of relying on what the CUDA image happens to
include:
1. **DOCA repository configured earlier.** The repo that provides the
   Mellanox networking libraries is now set up in the shared dependency
   stage instead of the DPDK stage. Same repo, same packages, just
   reachable from one stage higher.
2. **`mft` install moved.** `mft` is not in Ubuntu's default repos. It
   used to install in the very first stage and only succeeded because
   the CUDA image preconfigures NVIDIA's apt sources. It now installs
   in the same step as `mlnx-ofed-kernel-utils`, from the DOCA repo
   above, which works on any base.
3. **PyTorch tag pinned to `26.01-py3`.** This is the first NGC PyTorch
   release with CUDA 13, which the repo's `sm_121` (GB10 / DGX Spark)
   build target requires. Older tags fail to compile the GPUDirect
   benches on Blackwell hardware.

## Test plan

| # | What | Result |
|---|---|---|
| 1 | `BASE_IMAGE=cuda scripts/build-container.sh` (default path) | green |
| 2 | `IMAGE_TAG=daqiri-torch:local BASE_IMAGE=torch BASE_TARGET=dpdk DAQIRI_MGR="dpdk rdma socket" scripts/build-container.sh` | green |
| 3 | `docker run --rm --gpus all daqiri-torch:local python3 -c "import torch; print(torch.__version__, torch.cuda.is_available()); print(torch.cuda.get_device_name(0))"` on a GB10 host | `2.10.0a0+a36e1d39eb.nv26.01.42222806 True / NVIDIA GB10` |
| 4 | `daqiri_bench_socket` UDP loopback inside `daqiri-torch:local` (5s) | `tx_pkts=2000 rx_pkts=1984`, `1000/992` each direction |
| 5 | Same bench inside `daqiri-cuda:local` (regression) | identical numbers |
| 6 | `daqiri_bench_raw_gpudirect sw_loopback` inside `daqiri-torch:local` (5s) | 215,429,120 pkts TX = 215,429,120 pkts RX, zero loss, ~366 Gbps |
| 7 | `BASE_IMAGE=bogus scripts/build-container.sh` | `ERROR: invalid BASE_IMAGE='bogus'. Choose from: cuda, torch`, exit 1, no docker invocation |

## Doc impact

Per `.claude/rules/docs-sync.md`, the user-facing build command grew a
new option, so `README.md`, `docs/getting-started.md`, and
`docs/index.html` each get a one-line mention of `BASE_IMAGE=torch`.

Closes #52