### PR TITLE
#53 - Clean up legacy Holoscan/Holohub references in docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,7 +71,7 @@ Then build the DAQIRI library:
     The container bundles all user-space libraries for each networking backend, avoiding dependency issues on the host:
 
     ```bash
-    git clone git@github.com:nvidia-holoscan/daqiri.git
+    git clone git@github.com:NVIDIA/daqiri.git
     cd daqiri
     BASE_TARGET=dpdk DAQIRI_MGR="dpdk socket rdma" scripts/build-container.sh
     ```
@@ -85,7 +85,7 @@ Then build the DAQIRI library:
 === "CMake build (bare-metal)"
 
     ```bash
-    git clone git@github.com:nvidia-holoscan/daqiri.git
+    git clone git@github.com:NVIDIA/daqiri.git
     cd daqiri
     cmake -S . -B build -DBUILD_SHARED_LIBS=ON -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_MGR="dpdk socket rdma"
     cmake --build build -j

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -138,7 +138,7 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
                                 link_layer:             InfiniBand
         ```
 
-    **For Holoscan Networking, we want the NIC to use the ETH link layer.** To switch the link layer mode, there are two possible options:
+    **For DAQIRI, we want the NIC to use the ETH link layer.** To switch the link layer mode, there are two possible options:
 
     1. On IGX Orin developer kits, you can switch that setting through the BIOS: [see IGX Orin documentation](https://docs.nvidia.com/igx-orin/user-guide/latest/switch-network-link.html).
     2. On any system with a NVIDIA NIC (including the IGX Orin developer kits), you can run the commands below from a terminal:
@@ -234,7 +234,7 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
         [ 3712.267103] mlx5_core 0005:03:00.1: Port module event: module 1, Cable plugged
         ```
 
-    The next step is to set a static IP on the interface you'd like to use so you can refer to it in your Holoscan applications. First, check if you already have any addresses configured using the ethernet interface names identified above (in our case, `eth0` and `eth1`):
+    The next step is to set a static IP on the interface you'd like to use so you can refer to it in your DAQIRI applications. First, check if you already have any addresses configured using the ethernet interface names identified above (in our case, `eth0` and `eth1`):
 
     ```bash
     ip -f inet addr show eth0
@@ -299,19 +299,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     === "tune_system.py"
 
-        === "Debian installation"
-
-            ```bash
-            sudo /opt/nvidia/holoscan/bin/tune_system.py --check topo
-            ```
-
-        === "From source"
-
-            ```bash
-            cd holohub
-            sudo ./operators/advanced_network/python/tune_system.py --check topo
-
-            ```
+        ```bash
+        sudo ./python/tune_system.py --check topo
+        ```
 
         ??? abstract "See an example output"
 
@@ -386,24 +376,15 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
         Several steps below require adding flags to the kernel bootline in `/etc/default/grub` (hugepages in [Enable Huge pages](#step-4-enable-huge-pages), CPU isolation in [Isolate CPU cores](#step-5-isolate-cpu-cores)). We recommend reading through both sections first and adding all the flags at once to avoid multiple reboots. Other items like MRRS, GPU clocks, and MTU can be applied at runtime but reset on reboot — consider scripting them or using a systemd service for persistence.
 
-    Before diving in each of the setups below, we provide a utility script as part of the DAQIRI library which provides an overview of the configurations that potentially need to be tuned on your system.
+    Before diving in each of the setups below, we provide a utility script as part of the DAQIRI library which provides an overview of the configurations that potentially need to be tuned on your system. The script (`python/tune_system.py`) is run on the host from a clone of the DAQIRI repo — it touches host PCIe/sysfs and is not intended to run inside the build container.
 
     ??? example "Work In Progress"
 
         This utility script is under active development and will be updated in future releases with additional checks, more actionable recommendations, and automated tuning.
 
-    === "Debian installation"
-
-        ```bash
-        sudo /opt/nvidia/holoscan/bin/tune_system.py --check all
-        ```
-
-    === "From source"
-
-        ```bash
-        cd holohub
-        sudo ./operators/advanced_network/python/tune_system.py --check all
-        ```
+    ```bash
+    sudo ./python/tune_system.py --check all
+    ```
 
     ??? abstract "See an example output"
 
@@ -453,18 +434,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     === "tune_system.py"
 
-        === "Debian installation"
-
-            ```bash
-            sudo /opt/nvidia/holoscan/bin/tune_system.py --check topo
-            ```
-
-        === "From source"
-
-            ```bash
-            cd holohub
-            sudo ./operators/advanced_network/python/tune_system.py --check topo
-            ```
+        ```bash
+        sudo ./python/tune_system.py --check topo
+        ```
 
         ??? abstract "See an example output"
 
@@ -546,18 +518,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     === "tune_system.py"
 
-        === "Debian installation"
-
-            ```bash
-            sudo /opt/nvidia/holoscan/bin/tune_system.py --check mps
-            ```
-
-        === "From source"
-
-            ```bash
-            cd holohub
-            sudo ./operators/advanced_network/python/tune_system.py --check mps
-            ```
+        ```bash
+        sudo ./python/tune_system.py --check mps
+        ```
 
         ??? abstract "See an example output"
 
@@ -648,18 +611,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     === "tune_system.py"
 
-        === "Debian installation"
-
-            ```bash
-            sudo /opt/nvidia/holoscan/bin/tune_system.py --check mrrs
-            ```
-
-        === "From source"
-
-            ```bash
-            cd holohub
-            sudo ./operators/advanced_network/python/tune_system.py --check mrrs
-            ```
+        ```bash
+        sudo ./python/tune_system.py --check mrrs
+        ```
 
     === "manual"
 
@@ -687,18 +641,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     Update MRRS:
 
-    === "Debian installation"
-
-        ```bash
-        sudo /opt/nvidia/holoscan/bin/tune_system.py --set mrrs
-        ```
-
-    === "From source"
-
-        ```bash
-        cd holohub
-        sudo ./operators/advanced_network/python/tune_system.py --set mrrs
-        ```
+    ```bash
+    sudo ./python/tune_system.py --set mrrs
+    ```
 
     !!! note
 
@@ -881,18 +826,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     === "tune_system.py"
 
-        === "Debian installation"
-
-            ```bash
-            sudo /opt/nvidia/holoscan/bin/tune_system.py --check cmdline
-            ```
-
-        === "From source"
-
-            ```bash
-            cd holohub
-            sudo ./operators/advanced_network/python/tune_system.py --check cmdline
-            ```
+        ```bash
+        sudo ./python/tune_system.py --check cmdline
+        ```
 
     === "manual"
 
@@ -967,18 +903,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     === "tune_system.py"
 
-        === "Debian installation"
-
-            ```bash
-            sudo /opt/nvidia/holoscan/bin/tune_system.py --check cpu-freq
-            ```
-
-        === "From source"
-
-            ```bash
-            cd holohub
-            sudo ./operators/advanced_network/python/tune_system.py --check cpu-freq
-            ```
+        ```bash
+        sudo ./python/tune_system.py --check cpu-freq
+        ```
 
         ??? abstract "See an example output"
 
@@ -1157,18 +1084,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     === "tune_system.py"
 
-        === "Debian installation"
-
-            ```bash
-            sudo /opt/nvidia/holoscan/bin/tune_system.py --check bar1-size
-            ```
-
-        === "From source"
-
-            ```bash
-            cd holohub
-            sudo ./operators/advanced_network/python/tune_system.py --check bar1-size
-            ```
+        ```bash
+        sudo ./python/tune_system.py --check bar1-size
+        ```
 
         ??? abstract "See an example output"
 
@@ -1317,18 +1235,9 @@ The two tabs below are linked across the page (mkdocs-material `content.tabs.lin
 
     === "tune_system.py"
 
-        === "Debian installation"
-
-            ```bash
-            sudo /opt/nvidia/holoscan/bin/tune_system.py --check mtu
-            ```
-
-        === "From source"
-
-            ```bash
-            cd holohub
-            sudo ./operators/advanced_network/python/tune_system.py --check mtu
-            ```
+        ```bash
+        sudo ./python/tune_system.py --check mtu
+        ```
 
         ??? abstract "See an example output"
 


### PR DESCRIPTION
## Summary

Closes #53.

- Update both `git clone` URLs in `docs/getting-started.md` from `nvidia-holoscan/daqiri.git` to `NVIDIA/daqiri.git`.
- In the IGX Orin tab of `docs/tutorials/system_configuration.md`, replace 10 `tune_system.py` blocks that referenced the legacy Holoscan SDK install path (`/opt/nvidia/holoscan/bin/`) and HoloHub source layout (`cd holohub; ./operators/advanced_network/python/...`). The `"Installed"` tab was dropped — the default container build sets `DAQIRI_BUILD_PYTHON=OFF`, so the install rule for `tune_system.py` does not run, and the script targets host PCIe/sysfs anyway. A short note up front clarifies the script is run on the host from a clone of the DAQIRI repo.
- Two prose references ("Holoscan Networking" → "DAQIRI"; "Holoscan applications" → "DAQIRI applications") cleaned up while in the file.

Net change: +35 / −126 lines across 2 files.

## Test plan

- [x] `mkdocs build --strict` passes (CI gate).
- [x] Local `mkdocs serve` renders correctly: spot-check `getting-started/` clone commands and `tutorials/system_configuration/` IGX Orin `tune_system.py` blocks (verified locally).
- [x] `grep -ri 'holoscan\|holohub\|advanced_network\|nvidia-holoscan' docs/` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)