### PR TITLE
#56, #44 - Restore DPDK bench paths broken on main

### DIFF
--- a/src/managers/dpdk/daqiri_dpdk_mgr.cpp
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.cpp
@@ -1581,8 +1581,19 @@ void DpdkMgr::adjust_memory_regions() {
   const uint32_t deadlock_threshold = (ring_size * 3) / 2;  // 1.5x ring size
   const uint32_t bumped_num_bufs    = ring_size * 3;        // 3x ring size
 
+  std::unordered_set<std::string> queue_backed_mrs;
+  for (const auto& intf : cfg_.ifs_) {
+    for (const auto& q : intf.rx_.queues_) {
+      for (const auto& n : q.common_.mrs_) { queue_backed_mrs.insert(n); }
+    }
+    for (const auto& q : intf.tx_.queues_) {
+      for (const auto& n : q.common_.mrs_) { queue_backed_mrs.insert(n); }
+    }
+  }
+
   for (auto& mr : cfg_.mrs_) {
-    if (mr.second.num_bufs_ < deadlock_threshold) {
+    if (queue_backed_mrs.count(mr.second.name_) &&
+        mr.second.num_bufs_ < deadlock_threshold) {
       DAQIRI_LOG_WARN(
           "MR '{}' had num_bufs={} which is below the {} threshold (1.5x the {} NIC descriptors) "
           "and would deadlock the worker once the ring fills. Bumping to {} (3x ring).",

--- a/src/types.h
+++ b/src/types.h
@@ -517,8 +517,8 @@ struct MemoryRegionConfig {
   uint16_t affinity_;
   uint32_t access_;
   size_t buf_size_;
-  size_t adj_size_;  // Populated by driver
-  size_t ttl_size_;  // Populated by driver
+  size_t adj_size_ = 0;  // Populated by driver
+  size_t ttl_size_ = 0;  // Populated by driver
   size_t num_bufs_;
   bool owned_;
 };


### PR DESCRIPTION
## Summary

`origin/main` regresses several DPDK benches due to two independent issues introduced by recent merges. Three of the six `examples/daqiri_bench_raw_*` configs (`*_hds`, `*_reorder_seq*`, `*_reorder_quantize*`) fail to initialize on a fresh build — anything that places a CPU-side `kind: huge` memory region or a small-`num_bufs` reorder target. With these two commits, every `raw_*` bench runs end-to-end again. Refs #56, #44.

### Commit 1 — `#56 - Default-init MemoryRegionConfig::adj_size_ and ttl_size_ to 0`

The hugepage preflight added by #58 reads `MemoryRegionConfig::adj_size_` before any backend populates it (`src/manager.cpp:188`), falling back to `buf_size_` only when `adj_size_ == 0`. The struct had no default initializer for `adj_size_` or `ttl_size_`, so default construction left them with indeterminate values and the fallback rarely fired. On configs with `kind: huge` memory regions, the preflight multiplied `num_bufs` by garbage and asked for petabytes of hugepages, aborting init before `rte_eal_init()`:

```
[CRITICAL] Insufficient free hugepages: 3072 MiB free,
           ~9895495553363 MiB required for this config.
```

Default-initing both fields to 0 makes the existing fallback in `estimate_required_hugepages()` work as intended.

### Commit 2 — `#44 - Gate num_bufs auto-bump to queue-backed memory regions`

The `num_bufs` auto-bump added by #48 (`DpdkMgr::adjust_memory_regions()`) iterates every `MemoryRegionConfig` and bumps `num_bufs` to `3 × ring` (24576) whenever it falls below `1.5 × ring`. The intent is correct for MRs that back an RX or TX queue's mempool — undersizing those deadlocks the worker once the ring fills, which is exactly what #44 set out to prevent. But the bump fires unconditionally, including on MRs that aren't bound to any queue.

The reorder configs intentionally use `num_bufs: 128` × `buf_size: 2 MiB` for the reorder target — each buffer holds one fully reordered batch and the region isn't a queue mempool. The bump inflates the allocation to ~50 GiB and DMA mapping fails:

```
[WARN]     MR 'Reorder_RX_GPU' had num_bufs=128 ... Bumping to 24576
[CRITICAL] Could not DMA map EXT memory: -1 err=Invalid argument
```

Restrict the bump to MRs that appear in some RX/TX queue's `mrs_` list. Reorder targets and any future auxiliary MRs are left at the user-configured `num_bufs`.

## Test plan

Verified on aarch64 / Tegra IGX / CX7 100 GbE / 3 × 1 GiB hugepages, this branch only:

- [x] `daqiri_bench_raw_gpudirect` + `daqiri_bench_raw_tx_rx.yaml`, 10 s — 13.97M TX ≈ 13.97M RX, ~90 Gbps. Confirms no regression on the GPU-only path (this config exercises neither bug on main).
- [x] `daqiri_bench_raw_hds` + `daqiri_bench_raw_tx_rx_hds.yaml`, 10 s — broken by commit 1's bug on main; preflight now logs `OK: 3072 MiB free, ~831 MiB required (2 kind:HUGE MRs=6 MiB, …)`, init completes, 69.7M TX → 20.4M RX. The RX-side `rx_out_of_buffer` count is pre-existing config-level behaviour (HDS RX is slower than line-rate TX with these batch sizes) and unrelated to either fix.
- [x] `daqiri_bench_raw_reorder_seq` + `daqiri_bench_raw_tx_rx_reorder_seq_1024.yaml`, 10 s — broken by both bugs on main; init now completes, 88.6M TX ≈ 88.6M RX, 86471 aggregated batches, 0 timeouts.
- [x] `daqiri_bench_raw_reorder_quantize` + `daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml`, 10 s — broken by both bugs on main; 3 batches verified end-to-end (int4 → fp32), 0 failures.
- [x] `daqiri_bench_socket` UDP and TCP, 5 s each — TX 2000, RX 1984 (UDP) / 1987 (TCP). Confirms no impact on the socket backend.

YAML configs with `<…>` placeholders had this host's PCIe/MAC/IPs substituted out-of-tree; the in-tree YAMLs are untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)