### PR TITLE
#70 - Pin cmake-data alongside cmake in Dockerfile base stage

### DIFF
--- a/.github/workflows/docker-base.yml
+++ b/.github/workflows/docker-base.yml
@@ -1,0 +1,59 @@
+name: Docker base stage
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-base.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/docker-base.yml'
+  schedule:
+    # Daily 06:00 UTC drift check against upstream apt repos (Kitware, Ubuntu).
+    # Runs no-cache so cmake / cmake-data and similar pinning regressions are
+    # caught within ~24 hours of an upstream re-upload.
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build base (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build base stage (cached, PR/push)
+        if: github.event_name != 'schedule'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: base
+          push: false
+          build-args: |
+            DAQIRI_OS_BASE_IMAGE=nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04
+          cache-from: type=gha,scope=base-${{ matrix.runner }}
+          cache-to: type=gha,mode=max,scope=base-${{ matrix.runner }}
+
+      - name: Build base stage (no-cache, scheduled drift check)
+        if: github.event_name == 'schedule'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: base
+          push: false
+          no-cache: true
+          build-args: |
+            DAQIRI_OS_BASE_IMAGE=nvcr.io/nvidia/cuda:13.1.0-devel-ubuntu24.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install --no-install-recommends -y \
         kitware-archive-keyring \
         "cmake=${CMAKE_VERSION}" \
+        "cmake-data=${CMAKE_VERSION}" \
     && rm -rf /var/lib/apt/lists/*
 
 # ==============================================================


### PR DESCRIPTION
Fixes #70.

## Summary
- Pin `cmake-data` to the same version as `cmake` in the `base` stage so the Kitware-pinned install stays resolvable when Kitware respins a package.
- Add `.github/workflows/docker-base.yml` so a future regression of this kind is caught automatically (cached PR build + daily no-cache drift check on both `ubuntu-24.04` and `ubuntu-24.04-arm`).

## Why this broke now
Previously, `apt-cache madison cmake | awk '$3 ~ /^3[.]/'` resolved to `cmake 3.31.12-0kitware1ubuntu24.04.1`, which only had `Replaces: cmake-data (<< 4.3)` — no hard dependency — so installing just `cmake` worked.

On **2026-05-06** Kitware re-uploaded the same upstream version as `3.31.12-0kitware2ubuntu24.04.1`. That respin (re-)introduces `Depends: cmake-data (= 3.31.12-0kitware2ubuntu24.04.1)`. The madison query now selects the `kitware2` revision, and without a matching pin on `cmake-data` apt cannot resolve the dependency (Ubuntu noble's own `cmake-data` is 3.28.x), so the `base` stage fails with:

```
cmake : Depends: cmake-data (= 3.31.12-0kitware2ubuntu24.04.1)
E: Unable to correct problems, you have held broken packages.
```

## Test plan
- [x] `docker build --no-cache --target base ...` reproduces the failure on `main` (arm64 / Ubuntu 24.04).
- [x] After the one-line change, the same build succeeds and installs `cmake 3.31.12-0kitware2ubuntu24.04.1` + matching `cmake-data`.
- [x] **arm64 (IGX):** full no-cache build through `runtime` target (`DAQIRI_BASE_TARGET=dpdk`, `DAQIRI_MGR="dpdk socket"`) succeeds end-to-end. Stage timing: base 32s · base-deps 22s · dpdk 864s · daqiri-build 77s · runtime 4s → image `daqiri:repro-runtime` (8.41 GB).
- [x] **arm64 (Spark):** full downstream build also succeeds (independently verified on a second arm64 host).
- [x] New `Docker base stage` workflow passes on this PR (cached build on `ubuntu-24.04` and `ubuntu-24.04-arm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
