### PR TITLE
#57 - Add Greptile PR review config

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -2,10 +2,12 @@
   "strictness": 2,
   "commentTypes": ["logic", "syntax", "style", "info"],
   "triggerOnUpdates": true,
+  "triggerOnDrafts": false,
   "statusCheck": true,
   "fileChangeLimit": 200,
   "excludeAuthors": ["dependabot[bot]", "*-bot"],
   "excludeBranches": ["gh-pages"],
+  "ignoreKeywords": "[WIP]\n[wip]\nWIP:\nwip:",
   "ignorePatterns": "build/**\nlogs/**\nsite/**\nthird_party/**\ndpdk_patches/**\n**/*.svg\n**/*.png\n**/*.log\n**/*.pcap\n**/*.generated.*",
   "summarySection": {
     "included": true,

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,92 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style", "info"],
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "fileChangeLimit": 200,
+  "excludeAuthors": ["dependabot[bot]", "*-bot"],
+  "excludeBranches": ["gh-pages"],
+  "ignorePatterns": "build/**\nlogs/**\nsite/**\nthird_party/**\ndpdk_patches/**\n**/*.svg\n**/*.png\n**/*.log\n**/*.pcap\n**/*.generated.*",
+  "summarySection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": false
+  },
+  "issuesTableSection": {
+    "included": true,
+    "collapsible": false
+  },
+  "instructions": "DAQIRI is a single C++/CUDA shared library (libdaqiri.so) for GPU-direct packet I/O over DPDK, RDMA, and sockets. The full reviewer context lives in .greptile/rules.md and the linked context files in .greptile/files.json (AGENTS.md, CONTRIBUTING.md, .claude/rules/docs-sync.md, src/common.h, src/manager.h, src/types.h). Always read them before commenting. Prefer few high-signal comments over many nits; this is a low-level networking library where idiomatic-looking code is often deliberate.",
+  "rules": [
+    {
+      "id": "dco-signoff",
+      "rule": "Every commit in the PR must contain a 'Signed-off-by: Name <email>' trailer (DCO). If any commit is missing the trailer, flag it and tell the contributor to amend with `git commit -s --amend` or to rebase with `git rebase --signoff`. See CONTRIBUTING.md 'Signing Your Work'.",
+      "severity": "high"
+    },
+    {
+      "id": "commit-title-format",
+      "rule": "Commit titles must use imperative mood and be prefixed with the GitHub issue number, e.g. `#123 - Add X`. PRs without an associated approved issue should be flagged. See CONTRIBUTING.md 'Coding Guidelines'.",
+      "severity": "medium"
+    },
+    {
+      "id": "clang-format",
+      "rule": "C/C++/CUDA changes (.c, .cc, .cpp, .h, .hpp, .cu, .cuh) must be clang-format clean against the repo's .clang-format. If diff hunks contain obvious style violations (indentation, brace placement, line length, trailing whitespace, mixed tabs/spaces), tell the contributor to run `git-clang-format --style file` or `clang-format -style=file -i -fallback-style=none <files>`.",
+      "scope": ["**/*.c", "**/*.cc", "**/*.cpp", "**/*.h", "**/*.hpp", "**/*.cu", "**/*.cuh"],
+      "severity": "medium"
+    },
+    {
+      "id": "burstparams-free-contract",
+      "rule": "BurstParams is a zero-copy batch — the caller MUST explicitly free every burst it receives or sends, otherwise the mempool drains and the NIC reports NO_FREE_BURST_BUFFERS / NO_FREE_PACKET_BUFFERS and starts dropping packets. In any new code path that calls get_rx_burst, get_tx_burst, create_burst_params, or create_tx_burst_params, verify there is a matching free on every exit path (success, error, early return, exception). Flag missing frees as high severity. See docs/api-guide.md and src/common.h.",
+      "scope": ["src/**", "examples/**", "python/**"],
+      "severity": "high"
+    },
+    {
+      "id": "manager-vtable",
+      "rule": "All packet I/O flows through the daqiri::Manager virtual interface in src/manager.h, dispatched by ManagerFactory. New backends or capabilities must be added by extending Manager and a src/managers/<name>/ directory, NOT by branching on backend type at call sites or by reaching into backend-specific structs from common code. Application code must only touch the BurstParams/free-function API in src/common.h.",
+      "scope": ["src/**", "examples/**"],
+      "severity": "high"
+    },
+    {
+      "id": "daqiri-mgr-socket-rdma",
+      "rule": "The socket backend reuses the RoCE transport from the rdma backend, so src/CMakeLists.txt must always prepend `rdma` to DAQIRI_MGR_LIST whenever `socket` is requested (the reverse is not required). If a change touches the DAQIRI_MGR handling block in src/CMakeLists.txt (around the `DAQIRI_HAS_SOCKET_IDX` / `DAQIRI_HAS_RDMA_IDX` logic), confirm this invariant still holds and that DAQIRI_MGR_<NAME>=1 compile definitions are still emitted for every selected backend.",
+      "scope": ["src/CMakeLists.txt", "CMakeLists.txt", "src/managers/**"],
+      "severity": "high"
+    },
+    {
+      "id": "cmake-option-not-ifdef",
+      "rule": "Per CONTRIBUTING.md, new optional features should be gated behind a new CMake option with a backward-compatible default; whole-file inclusion/exclusion is done in CMakeLists.txt rather than wrapping entire files in `#if` guards. Use `#if` only for minor in-file changes. Flag PRs that wrap entire bodies in `#ifdef` blocks instead of using CMake.",
+      "scope": ["src/**", "examples/**", "CMakeLists.txt", "**/CMakeLists.txt"],
+      "severity": "medium"
+    },
+    {
+      "id": "doc-sync",
+      "rule": "DAQIRI has no automated doc-sync gate beyond mkdocs/strict link checks. When a PR changes any of the files listed in .claude/rules/docs-sync.md, the matching docs must be updated in the same PR. Specifically: src/common.h | src/types.h | src/manager.h => docs/api-guide.md + docs/daqiri-api.html + AGENTS.md (Architecture); src/managers/* => docs/getting-started.md + docs/configuration.md + docs/tutorials/configuration-walkthrough.md + README.md (Backends) + AGENTS.md; src/CMakeLists.txt => docs/getting-started.md + AGENTS.md (Build & run) + README.md (Quick Start); src/kernels.cu => docs/tutorials/benchmarking_examples.md + AGENTS.md; examples/*.{cpp,yaml} => docs/tutorials/benchmarking_examples.md + docs/tutorials/configuration-walkthrough.md + AGENTS.md (benchmark table). If the PR touches code in these paths but does not update the matching docs, flag it as medium severity and list the specific docs to update.",
+      "scope": ["src/**", "examples/**", "mkdocs.yml", "README.md", "AGENTS.md", "docs/**"],
+      "severity": "medium"
+    },
+    {
+      "id": "third-party-vendored",
+      "rule": "third_party/yaml-cpp and third_party/spdlog are git submodules. Direct edits to files inside third_party/ are almost always a mistake — the right fix is either upstreaming a patch or wrapping the dependency. Flag any in-place edits inside third_party/ as high severity and ask the contributor to confirm the intent.",
+      "scope": ["third_party/**"],
+      "severity": "high"
+    },
+    {
+      "id": "cuda-arch-list",
+      "rule": "src/CMakeLists.txt hardcodes CUDA architectures to `80;90;121` (A100, H100, GB10). If a PR touches the CUDA arch list, requires a newer arch (e.g. for new PTX intrinsics), or adds a kernel that won't compile on these targets, call it out so reviewers can decide whether to bump the list or document the new requirement.",
+      "scope": ["src/**/*.cu", "src/**/*.cuh", "src/CMakeLists.txt"],
+      "severity": "medium"
+    },
+    {
+      "id": "tx-fill-udp-only",
+      "rule": "Per AGENTS.md 'Current limitations', set_udp_header / TX header-fill helpers currently support UDP only. If a PR extends TX header fill to TCP/IP/etc., the limitations section in both AGENTS.md and README.md should be updated in the same PR.",
+      "scope": ["src/common.cpp", "src/common.h", "src/managers/**"],
+      "severity": "low"
+    },
+    {
+      "id": "yaml-config-placeholders",
+      "rule": "examples/*.yaml configs contain `<angle-bracket>` placeholders (PCIe addresses, CPU cores, MACs, IPs) that the user must replace per host. New example YAMLs should follow the same convention (placeholders, not hard-coded production values), and any new placeholder key should be documented in docs/configuration.md or docs/tutorials/configuration-walkthrough.md.",
+      "scope": ["examples/*.yaml"],
+      "severity": "low"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,47 @@
+{
+  "files": [
+    {
+      "path": "AGENTS.md",
+      "description": "Authoritative developer onboarding for DAQIRI: build commands, the benchmarks-as-tests model, the Manager/BurstParams architecture, the DPDK build dependency, the CMake socket->rdma rule, current public-API limitations, and the doc-sync drift hotspots. Read this first."
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "description": "Project contribution rules: clang-format, DCO sign-off, '#<Issue Number> - <Title>' commit format, prefer-CMake-over-ifdef policy, narrow PRs, fork-and-PR workflow."
+    },
+    {
+      "path": ".claude/rules/docs-sync.md",
+      "description": "Source-of-truth mapping from source-file changes to the docs that must be updated in the same PR. Use this to decide whether a code-change PR also needs doc updates.",
+      "scope": ["src/**", "examples/**", "mkdocs.yml", "README.md", "AGENTS.md", "docs/**"]
+    },
+    {
+      "path": "src/common.h",
+      "description": "Public C++ free-function API (get_rx_burst, get_tx_burst, get_packet_ptr, set_udp_header, free helpers, ...) operating on the opaque BurstParams* batch type. Application code should only ever touch this surface and src/types.h.",
+      "scope": ["src/**", "examples/**", "python/**"]
+    },
+    {
+      "path": "src/types.h",
+      "description": "Public types: BurstParams, Status, NetworkConfig, MemoryKind, Direction, SocketProtocol. Field changes / new enum values are an API change and trigger doc-sync against docs/api-guide.md, docs/daqiri-api.html, and AGENTS.md.",
+      "scope": ["src/**", "examples/**", "python/**"]
+    },
+    {
+      "path": "src/manager.h",
+      "description": "daqiri::Manager virtual interface and ManagerFactory singleton. Every backend lives behind this vtable. Adding a new backend means adding a src/managers/<name>/ subclass, NOT branching on backend type at call sites.",
+      "scope": ["src/**", "examples/**"]
+    },
+    {
+      "path": "src/CMakeLists.txt",
+      "description": "Build system for the common library and the per-backend libraries. Owns DAQIRI_MGR, the socket->rdma prepend rule (around DAQIRI_HAS_SOCKET_IDX), the DAQIRI_MGR_<NAME>=1 compile definitions, and the hardcoded CUDA arch list (80;90;121).",
+      "scope": ["src/**", "CMakeLists.txt", "**/CMakeLists.txt", "examples/CMakeLists.txt"]
+    },
+    {
+      "path": "docs/api-guide.md",
+      "description": "Markdown reference for the public C++ API and the BurstParams free contract. Update in sync with src/common.h, src/types.h, src/manager.h.",
+      "scope": ["src/common.h", "src/common.cpp", "src/types.h", "src/manager.h"]
+    },
+    {
+      "path": "README.md",
+      "description": "Top-level project overview: Quick Start build commands, Backends table, Documentation table, Features list, Limitations. Update in sync with src/managers/*, src/CMakeLists.txt, src/common.h, and any docs/* renames.",
+      "scope": ["src/**", "examples/**", "docs/**", "mkdocs.yml"]
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,163 @@
+# Greptile reviewer rules — DAQIRI
+
+These notes are the long-form context that pairs with the structured rules in
+`.greptile/config.json`. Read both before commenting on a PR.
+
+## What DAQIRI is
+
+DAQIRI is a single C++/CUDA shared library (`libdaqiri.so`) that provides
+GPU-direct packet I/O for RF / scientific instrument capture. It exposes a flat
+free-function C++ API (in `src/common.h`) on top of an opaque `BurstParams*`
+batch type, and dispatches to one of three backends (DPDK, RDMA, sockets) via
+the `daqiri::Manager` virtual interface in `src/manager.h`. Applications never
+touch backend types directly.
+
+This is a low-level networking library with hardware dependencies — be biased
+toward fewer, higher-confidence comments. Pieces of code that look "wrong" by
+generic best-practice standards (manual pool management, raw pointers, locked
+memory layouts, platform-specific defines, custom alignment) are usually load-
+bearing on purpose. When in doubt, ask rather than block.
+
+## The four invariants worth blocking on
+
+### 1. BurstParams is zero-copy and the caller frees
+
+A `BurstParams` is a batch of packets whose payload buffers live in DMA-capable
+memory the NIC wrote (RX) or will read (TX). Pointers — never copies — flow
+between NIC, library, and application.
+
+Because nothing else owns the batch, **the caller must explicitly free every
+burst**. A missed free does not leak silently — the underlying mempool drains,
+`get_*_burst` starts returning `NO_FREE_BURST_BUFFERS` /
+`NO_FREE_PACKET_BUFFERS`, and the NIC drops packets. By the time the operator
+sees it, it usually looks like a NIC/driver problem rather than an application
+bug.
+
+When reviewing any new code path that calls `get_rx_burst`, `get_tx_burst`,
+`create_burst_params`, or `create_tx_burst_params`, walk every exit path
+(success, error, early return, exception, `goto cleanup`) and verify there is
+a matching free. This is high-severity. See `docs/api-guide.md` and
+`src/common.h`.
+
+### 2. Backend selection lives behind the Manager vtable
+
+The active backend is chosen at `daqiri_init()` time from `NetworkConfig`, and
+`ManagerFactory` instantiates exactly one `daqiri::Manager` per process. Every
+piece of packet logic — RX/TX dequeue, header fill, segment access, RDMA
+connection setup — is dispatched through that vtable.
+
+Reject PRs that:
+
+- Branch on backend type in common code (`if (backend == "dpdk") …`).
+- Reach into a backend-specific struct (`DpdkManager*`, `RdmaManager*`,
+  `SocketManager*`) from `src/common*` or from application code.
+- Add a new backend by extending `src/common.cpp` instead of adding a
+  `src/managers/<name>/` directory and a new `Manager` subclass.
+- Expose backend types in the public API surface in `src/common.h`.
+
+The point of the abstraction is that an application written against the
+free-function API can switch backends with a config change. New code must
+preserve that.
+
+### 3. `DAQIRI_MGR` socket → rdma rule
+
+The socket backend reuses the RoCE transport from the rdma backend. As a
+result, `src/CMakeLists.txt` always prepends `rdma` to `DAQIRI_MGR_LIST`
+whenever `socket` is requested:
+
+```cmake
+list(FIND DAQIRI_MGR_LIST "socket" DAQIRI_HAS_SOCKET_IDX)
+if(NOT DAQIRI_HAS_SOCKET_IDX EQUAL -1)
+  list(FIND DAQIRI_MGR_LIST "rdma" DAQIRI_HAS_RDMA_IDX)
+  if(DAQIRI_HAS_RDMA_IDX EQUAL -1)
+    list(APPEND DAQIRI_MGR_LIST "rdma")
+  endif()
+  list(REMOVE_ITEM DAQIRI_MGR_LIST "rdma")
+  list(INSERT DAQIRI_MGR_LIST 0 "rdma")
+endif()
+```
+
+The reverse is **not** true — listing `rdma` alone does not pull in `socket`.
+The `rdma` entry must be first in the list so it builds first.
+
+If a PR touches this block, or refactors how `DAQIRI_MGR_LIST` is consumed
+later (the `foreach` that emits `DAQIRI_MGR_<NAME>=1` compile definitions),
+verify the invariant still holds. A regression here turns into a confusing
+link error in the socket backend that won't reproduce on a `dpdk socket`
+build because the developer happened to have rdma enabled.
+
+DPDK is also load-bearing for the common library itself — `src/common.cpp`
+uses `rte_ring` / `rte_mbuf` directly, so DPDK is a build dependency even of
+`rdma`-only or `socket`-only configurations. Do not "remove DPDK" without
+removing those uses.
+
+### 4. Doc-sync on code changes
+
+There is no automated doc-sync gate beyond `mkdocs --strict` link checks. If
+the code in a PR changes but the corresponding docs don't, drift goes
+unnoticed until the next external user files an issue.
+
+The mapping (mirrored from `.claude/rules/docs-sync.md`):
+
+| Source path | Docs to update in the same PR |
+| --- | --- |
+| `src/common.h` | `docs/api-guide.md`, `docs/daqiri-api.html`, `AGENTS.md` (Architecture / API summary) |
+| `src/types.h` | `docs/api-guide.md`, `docs/daqiri-api.html`, `AGENTS.md` (Architecture / BurstParams) |
+| `src/manager.h` | `docs/api-guide.md`, `AGENTS.md` (Manager abstraction) |
+| `src/managers/*/` | `docs/getting-started.md`, `docs/configuration.md`, `docs/tutorials/configuration-walkthrough.md`, `README.md` (Backends), `AGENTS.md` |
+| `src/CMakeLists.txt` (CMake options, `DAQIRI_MGR` default, CUDA arch) | `docs/getting-started.md`, `AGENTS.md` (Build & run), `README.md` (Quick Start) |
+| `src/kernels.cu` / `src/kernels.h` | `docs/tutorials/benchmarking_examples.md`, `AGENTS.md` (Reorder & quantize kernels) |
+| `examples/*.cpp`, `examples/*.yaml` (new bench, new CLI flag, new YAML key) | `docs/tutorials/benchmarking_examples.md`, `docs/tutorials/configuration-walkthrough.md`, `AGENTS.md` (benchmark table) |
+| `mkdocs.yml` nav | `docs/index.html` (landing page links) |
+| Any `docs/*` rename or move | `README.md` (Documentation table), `AGENTS.md` (Documentation section), `mkdocs.yml`, `docs/index.html` |
+
+When a PR touches a source path on the left but does not touch the matching
+docs on the right, post a single comment listing the specific docs to update.
+One consolidated comment, not one per file.
+
+## CONTRIBUTING.md essentials
+
+These are the contributor-facing rules that show up most often as PR review
+findings. Greptile should catch them so a human reviewer doesn't have to.
+
+- **DCO sign-off on every commit.** `Signed-off-by: Name <email>` trailer is
+  required on every commit (CONTRIBUTING.md "Signing Your Work"). Missing
+  trailer → ask the contributor to amend with `git commit -s --amend` or
+  rebase with `git rebase --signoff`. Unsigned commits will be rejected, so
+  flagging this early saves a round trip.
+
+- **Commit title format.** Imperative mood, prefixed with the GitHub issue
+  number: `#<Issue Number> - <Title>` (e.g. `#42 - Add socket TCP backend`).
+  An issue must exist and be approved before coding starts; PRs without a
+  referenced issue should be flagged.
+
+- **clang-format clean.** Run `git-clang-format --style file` (staged
+  changes) or `clang-format -style=file -i -fallback-style=none <files>`
+  (specific files). The `.clang-format` in the repo root is the source of
+  truth — do not introduce a different style.
+
+- **Prefer CMake options over `#ifdef`-walling whole files.** New optional
+  features should land as a CMake option with a backward-compatible default
+  (typically the existing behavior). Whole-file inclusion/exclusion is done
+  by editing `CMakeLists.txt`. Use `#if` only for minor in-file changes.
+
+- **Narrow PRs, single concern.** If a PR mixes refactor + feature + doc
+  reorganization, ask the contributor to split it. Note dependencies in the
+  PR description rather than bundling.
+
+- **Builds clean.** No new warnings. No commented-out code. Each new
+  component ships with a README and an accompanying test/benchmark.
+
+## Things to *not* nit on
+
+- Manual pool / mempool management, explicit free calls, raw pointers passed
+  through the API. This is the BurstParams contract — that's the point.
+- Hardcoded CUDA arch list (`80;90;121`). It's intentional; there's a
+  separate rule for callouts when a PR actually requires bumping it.
+- `#if DAQIRI_MGR_<NAME>` guards in backend-specific files. They're how
+  per-backend code is selected at compile time.
+- DPDK-style header-fill APIs (`set_udp_header`, etc.) only supporting UDP.
+  Documented limitation; flag only if a PR claims to fix it but forgets to
+  update `AGENTS.md` / `README.md`.
+- `<angle-bracket>` placeholders in `examples/*.yaml`. They're meant to be
+  filled in per-host by the operator.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Workflow expectations:
 - Greptile runs on every push to a PR (`triggerOnUpdates: true`), so you can iterate and watch its comments update.
 - It posts a GitHub status check rather than a "X files reviewed, no comments" message — a green check means it ran and had nothing critical to say.
 - Greptile comments are advisory. A human DAQIRI engineer still owns merge approval. If you disagree with a Greptile comment, reply on the thread and a maintainer will arbitrate.
-- If you want to skip Greptile on a particular PR (e.g. a pure docs typo), open it as a draft — by default Greptile does not review draft PRs.
+- To suppress Greptile while a PR is in flight, use the existing `[WIP]` title prefix from the Pull Requests section above — `.greptile/config.json` lists `[WIP]` / `WIP:` (case variants) under `ignoreKeywords`, so titled PRs are skipped until the prefix is removed. Draft PRs are also skipped (`triggerOnDrafts: false`) for contributors who prefer GitHub's draft mechanism.
 
 If you are adding a new project-wide convention, please update `.greptile/rules.md` (or add a structured rule to `.greptile/config.json`) in the same PR so the bot keeps up with the humans.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,30 @@ git push -u origin <local-branch>:<remote-branch>
 
 4. Since there is no CI/CD process in place yet, the PR will be accepted and the corresponding issue closed only after adequate testing has been completed, manually, by the developer and/or DAQIRI engineer reviewing the code.
 
+#### Automated PR Review (Greptile)
+
+Every pull request to `NVIDIA/daqiri` is reviewed automatically by [Greptile](https://www.greptile.com/) before a human reviewer picks it up. Greptile reads the project rules in `.greptile/` (`config.json`, `rules.md`, `files.json`) and posts inline review comments and a summary on the PR.
+
+What Greptile is configured to flag (non-exhaustive — see `.greptile/config.json` and `.greptile/rules.md` for the full list):
+
+- Commits missing a `Signed-off-by:` trailer (DCO).
+- Commit titles that do not follow `#<Issue Number> - <Title>`.
+- C/C++/CUDA changes that are not `clang-format` clean against the repo's `.clang-format`.
+- Code paths that allocate a `BurstParams` (`get_rx_burst`, `get_tx_burst`, `create_*_burst_params`) but miss a matching free on some exit path — this drains the mempool and causes silent NIC drops.
+- New backend logic that branches on backend type or reaches into backend-specific structs from `src/common*` instead of going through the `daqiri::Manager` virtual interface.
+- Changes to the `DAQIRI_MGR` socket → rdma rule in `src/CMakeLists.txt` that break the invariant.
+- New optional features wrapped in whole-file `#ifdef` blocks instead of being gated behind a CMake option (per the rule above in this file).
+- Code changes under `src/`, `examples/`, or `mkdocs.yml` that do not also update the matching docs (the mapping comes from `.claude/rules/docs-sync.md`).
+
+Workflow expectations:
+
+- Greptile runs on every push to a PR (`triggerOnUpdates: true`), so you can iterate and watch its comments update.
+- It posts a GitHub status check rather than a "X files reviewed, no comments" message — a green check means it ran and had nothing critical to say.
+- Greptile comments are advisory. A human DAQIRI engineer still owns merge approval. If you disagree with a Greptile comment, reply on the thread and a maintainer will arbitrate.
+- If you want to skip Greptile on a particular PR (e.g. a pure docs typo), open it as a draft — by default Greptile does not review draft PRs.
+
+If you are adding a new project-wide convention, please update `.greptile/rules.md` (or add a structured rule to `.greptile/config.json`) in the same PR so the bot keeps up with the humans.
+
 #### Signing Your Work
 
 * We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.


### PR DESCRIPTION
## Summary

Adds `.greptile/` config (rules + context files) and a `CONTRIBUTING.md` note so external contributors expect Greptile review comments.

- `.greptile/config.json` — review settings + structured rules (DCO, commit-title format, clang-format, BurstParams free contract, Manager vtable, `DAQIRI_MGR` socket→rdma rule, doc-sync, etc.) with per-rule scope and severity.
- `.greptile/rules.md` — long-form architectural context paired with the structured rules.
- `.greptile/files.json` — points the reviewer at `AGENTS.md`, `CONTRIBUTING.md`, `.claude/rules/docs-sync.md`, and the key public headers.
- `CONTRIBUTING.md` — new "Automated PR Review (Greptile)" section so contributors know what to expect.

## Activation (org Admin action)

An org Admin in Greptile needs to onboard the repo from [app.greptile.com](https://app.greptile.com/):

<img width="1595" height="870" alt="image" src="https://github.com/user-attachments/assets/df67f7ce-ad2a-464b-a1f0-b5b68d38b4a7" />

### Reviewer checklist

- [x] Confirm you have the **Admin** role in the NVIDIA org within Greptile (if not, ask an existing Admin to grant it — without it, the repo list will be empty / unmanageable).
- [x] Open [app.greptile.com](https://app.greptile.com/) and find `NVIDIA/daqiri` in the public-repo list (only public repos appear).
- [x] Select `NVIDIA/daqiri` to onboard it.
- [x] Wait for initial indexing to complete — Greptile will start posting reviews automatically on new PRs once it's done.
- [x] (Optional) Use this PR to confirm Greptile posts a status check + review comment using the rules in this PR.

## Tuning later

Strictness, ignored paths, and rule severities are easy to tune later in `.greptile/config.json` — no redeploy needed, settings are read from the source branch of each PR.