### PR TITLE
#75 - Fix Socket UDP --mode both; error spam impacts startup

### DIFF
--- a/examples/socket_bench.cpp
+++ b/examples/socket_bench.cpp
@@ -96,7 +96,12 @@ void socket_worker(const SocketBenchConfig& cfg, std::atomic<bool>& stop, Socket
     const bool recv_done = !cfg.receive || stats.received_packets >= static_cast<uint64_t>(cfg.iterations);
     if (send_done && recv_done) { break; }
 
-    if (cfg.send && !send_done) {
+    // UDP servers must learn the peer address from an inbound packet before
+    // they can transmit, so withhold the server's first send until at least
+    // one RX packet has arrived. The client always transmits eagerly.
+    const bool waiting_for_peer = cfg.server && cfg.receive && stats.received_packets == 0;
+
+    if (cfg.send && !send_done && !waiting_for_peer) {
       auto* msg = daqiri::create_tx_burst_params();
       daqiri::set_header(msg, port, queue, 1, 1);
 

--- a/src/managers/socket/daqiri_socket_mgr.cpp
+++ b/src/managers/socket/daqiri_socket_mgr.cpp
@@ -739,7 +739,10 @@ bool SocketMgr::send_udp_burst(EndpointState& ep, BurstParams* burst, size_t* se
   if (ep.socket_cfg.mode_ == SocketMode::SERVER) {
     std::lock_guard<std::mutex> lock(state_mutex_);
     if (!ep.udp_peer_valid) {
-      DAQIRI_LOG_ERROR("UDP server has no learned peer yet; cannot transmit");
+      if (!ep.udp_peer_missing_logged) {
+        DAQIRI_LOG_DEBUG("UDP server has no learned peer yet; cannot transmit");
+        ep.udp_peer_missing_logged = true;
+      }
       return false;
     }
     peer = ep.udp_peer_addr;
@@ -1285,6 +1288,7 @@ void SocketMgr::udp_rx_loop(int if_index) {
       std::lock_guard<std::mutex> lock(state_mutex_);
       ep->udp_peer_addr = peers[static_cast<size_t>(received - 1)];
       ep->udp_peer_valid = true;
+      ep->udp_peer_missing_logged = false;
     }
 
     for (int i = 0; i < received; ++i) {

--- a/src/managers/socket/daqiri_socket_mgr.h
+++ b/src/managers/socket/daqiri_socket_mgr.h
@@ -146,6 +146,7 @@ class SocketMgr : public Manager {
     std::shared_ptr<RxQueueState> rx_queue_state;
     sockaddr_in udp_peer_addr{};
     bool udp_peer_valid = false;
+    bool udp_peer_missing_logged = false;
     uintptr_t primary_conn_id = 0;
   };
 


### PR DESCRIPTION
  Fixes #75.

_**NOTE TO REVIEWER:** the original Git issue implies that this caused a throughput cliff in benchmarks for socket UDP. In reality, this was a red herring and it was an issue with the benchmark test. So, this is more of a cosmetic change to fix some error-spamming that also leads some sluggishness on startup (see below)._

  The server thread, when invoked in `--mode both`, tries to send before any inbound packet has arrived. With no learned peer, each `send_udp_burst` returns false after logging `UDP server has no learned peer yet; cannot transmit` at
  ERROR. The spam stops once the first inbound packet teaches the server its peer (typically within ~30 attempts), but each ERROR write through spdlog→stderr is a synchronous syscall that holds `state_mutex_` and contends with the
  client's first packets.

  Two changes:
  1. **`examples/socket_bench.cpp`** — gate the server worker's TX path on having received at least one packet (only when `receive` is enabled), so the client transmits eagerly and the server learns the peer before it tries to send.
  2. **`src/managers/socket/daqiri_socket_mgr.{h,cpp}`** — throttle the "no learned peer" log to fire once per missing-peer episode and demote it from ERROR to DEBUG. A new `udp_peer_missing_logged` latch on `EndpointState` is cleared
  when the RX loop learns/relearns a peer.

  In pathological cases where the server never receives an inbound packet (one-way flow, mis-bound RX queue), the original code would spam ERROR forever; the latch makes those scenarios survivable too.

  ## Test plan

  UDP loopback (`127.0.0.1`), `--seconds 30 --mode both`, message_size=1024, iterations bumped to 100M so the wall-clock cap dominates. `bench-results/` runs on a DGX Spark in container build.

  - [x] **Revert + reproduce** — checked out `main`'s versions of the three modified files, rebuilt, ran the bench. Confirmed 33 `no learned peer` ERROR lines on the broken side.
  - [x] **Re-apply + verify symptom gone** — restored the fix, rebuilt, re-ran. ERROR count: **33 → 0**.
  - [x] **N=3 throughput, total tx_pkts / 30s, both endpoints:**

    |          | Trial 1 | Trial 2 | Trial 3 | Min | Max | **Mean** |
    |----------|--------:|--------:|--------:|----:|----:|---------:|
    | Broken   | 17.67M  | 16.57M  | 17.44M  | 16.57M | 17.67M | **17.23M** |
    | Fixed    | 18.89M  | 18.47M  | 18.50M  | 18.47M | 18.89M | **18.62M** |

    Mean delta: **+1.39M pkts / 30s (+8.1%)**. Ranges do not overlap — slowest fixed trial still beats fastest broken trial.

  - [x] Code audit of `udp_peer_valid` in `main`'s `daqiri_socket_mgr.cpp`: set true once in the RX loop after the first `recvmmsg`, never cleared — so the broken-side spam is bounded by time-to-first-inbound-packet, not run length.
  Matches the observed ~33 ERROR count being identical in iter=1000 and iter=100M runs.