### PR TITLE
#89 - Make Manager::shutdown() idempotent to prevent post-finalize log crash

### DIFF
--- a/src/managers/dpdk/daqiri_dpdk_mgr.cpp
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.cpp
@@ -4403,6 +4403,11 @@ Status DpdkMgr::send_tx_burst(BurstParams* burst) {
 }
 
 void DpdkMgr::shutdown() {
+  // Idempotency guard: shutdown() may be invoked a second time via ~DpdkMgr
+  // during C++ __cxa_finalize, by which point the spdlog default logger has
+  // already been destroyed and any DAQIRI_LOG_INFO here crashes inside
+  // spdlog::sink_it_. Skip the body (and the log calls) if already torn down.
+  if (!initialized_) { return; }
   DAQIRI_LOG_INFO("daqiri DPDK manager shutdown called {}", num_init);
 
   if (--num_init == 0) {

--- a/src/managers/rdma/daqiri_rdma_mgr.cpp
+++ b/src/managers/rdma/daqiri_rdma_mgr.cpp
@@ -1508,6 +1508,12 @@ void RdmaMgr::initialize() {
 }
 
 void RdmaMgr::shutdown() {
+  // Idempotency guard: shutdown() runs explicitly from the caller AND again
+  // from ~RdmaMgr / ~SocketMgr during C++ __cxa_finalize. By the second call
+  // the spdlog default logger (a function-local static created lazily on the
+  // first DAQIRI_LOG_INFO) has already been destroyed, so any logging here
+  // crashes inside spdlog::sink_it_. Skip the whole body on subsequent calls.
+  if (!initialized_) { return; }
   DAQIRI_LOG_INFO("RDMA manager shutting down");
   rdma_force_quit.store(true);
 

--- a/src/managers/socket/daqiri_socket_mgr.cpp
+++ b/src/managers/socket/daqiri_socket_mgr.cpp
@@ -471,7 +471,16 @@ void SocketMgr::shutdown() {
   // has been destroyed. Any DAQIRI_LOG_INFO from the cascade (here, the
   // RoCE branch, or the manager method this delegates to) would then crash
   // inside spdlog::sink_it_. Skip the whole body on subsequent calls.
-  if (!initialized_) { return; }
+  //
+  // The guard checks BOTH flags because initialize() sets initialized_=false
+  // and running_=true before running setup, then sets initialized_=true on
+  // success. If setup throws, the catch block calls shutdown() with
+  // initialized_=false and running_=true to clean up any threads/sockets
+  // that were spawned partway. Guarding on initialized_ alone would skip
+  // that cleanup. Both flags are only cleared together after a successful
+  // shutdown() body, so the post-shutdown re-entry from __cxa_finalize is
+  // the only case where the guard fires.
+  if (!initialized_ && !running_.load()) { return; }
   if (is_roce_protocol()) {
 #if DAQIRI_MGR_RDMA
     if (roce_mgr_ != nullptr) {
@@ -481,8 +490,6 @@ void SocketMgr::shutdown() {
 #endif
     return;
   }
-
-  if (!initialized_ && !running_.load()) { return; }
 
   running_.store(false);
 

--- a/src/managers/socket/daqiri_socket_mgr.cpp
+++ b/src/managers/socket/daqiri_socket_mgr.cpp
@@ -466,6 +466,12 @@ void SocketMgr::clear_rx_queues() {
 }
 
 void SocketMgr::shutdown() {
+  // Idempotency guard: shutdown() may be invoked a second time via
+  // ~SocketMgr during C++ __cxa_finalize, after the spdlog default logger
+  // has been destroyed. Any DAQIRI_LOG_INFO from the cascade (here, the
+  // RoCE branch, or the manager method this delegates to) would then crash
+  // inside spdlog::sink_it_. Skip the whole body on subsequent calls.
+  if (!initialized_) { return; }
   if (is_roce_protocol()) {
 #if DAQIRI_MGR_RDMA
     if (roce_mgr_ != nullptr) {


### PR DESCRIPTION
Fixes #89. \`Manager::shutdown()\` was being invoked twice in the bench lifecycle, and the second call's top \`DAQIRI_LOG_INFO\` crashed because spdlog's default logger had already been destroyed by \`__cxa_finalize\`.

  Adds a 1-line idempotency guard (\`if (!initialized_) return;\`) at the top of \`RdmaMgr::shutdown()\`, \`DpdkMgr::shutdown()\`, and \`SocketMgr::shutdown()\`. Same log-first body-second pattern in all three managers, same fix.
  \`DpdkMgr\`'s existing \`num_init\` reference-counted body is preserved — the guard only activates after the body has cleared \`initialized_\` on the final shutdown.

  ## Test plan

  - [x] **A/B verified on a clean fix-branch base (off \`origin/main\`):**
    - With fix → \`daqiri_bench_rdma --mode both\` exits 0.
    - Without fix (reset to \`origin/main\`) → bench segfaults during \`__cxa_finalize\` (exit 139). Confirms the fix is necessary on plain main, not just under the perf-report branch's bench changes.
  - [x] DPDK / Socket benches still shut down cleanly (no regression — \`num_init\` ref counting in DpdkMgr preserved).

  Discovered while tackling PR #72.