### PR TITLE
#91 - Point README doc links at the live docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ DAQIRI provides direct NIC hardware access in userspace, bypassing the Linux ker
 
 📖 **Live documentation: [nvidia.github.io/daqiri](https://nvidia.github.io/daqiri/)**
 
-**Requires** an NVIDIA SmartNIC (ConnectX-6 Dx or later) and a GPUDirect-capable NVIDIA GPU. Tested on the NVIDIA DGX Spark, NVIDIA IGX platform, and an x86_64 RTX Pro server. See [Getting Started](docs/getting-started.md) for the full requirements list.
+**Requires** an NVIDIA SmartNIC (ConnectX-6 Dx or later) and a GPUDirect-capable NVIDIA GPU. Tested on the NVIDIA DGX Spark, NVIDIA IGX platform, and an x86_64 RTX Pro server. See [Getting Started](https://nvidia.github.io/daqiri/getting-started/) for the full requirements list.
 
 ## Features
 
@@ -71,26 +71,26 @@ Container build:
 BASE_TARGET=dpdk DAQIRI_MGR="dpdk rdma" scripts/build-container.sh
 ```
 
-See [Getting Started](docs/getting-started.md) for requirements, CMake options, and
+See [Getting Started](https://nvidia.github.io/daqiri/getting-started/) for requirements, CMake options, and
 running the benchmarks.
 
 ## Documentation
 
 Reference material for the DAQIRI codebase:
 
-- [Getting Started](docs/getting-started.md) — System requirements, build/install instructions, and CMake options
-- [Configuration Reference](docs/configuration.md) — Full YAML config reference for all backends
-- [API Guide](docs/api-guide.md) — BurstParams, RX/TX workflows, buffer lifecycle, status codes
+- [Getting Started](https://nvidia.github.io/daqiri/getting-started/) — System requirements, build/install instructions, and CMake options
+- [Configuration Reference](https://nvidia.github.io/daqiri/configuration/) — Full YAML config reference for all backends
+- [API Guide](https://nvidia.github.io/daqiri/api-guide/) — BurstParams, RX/TX workflows, buffer lifecycle, status codes
 - [Contributing](CONTRIBUTING.md) — Contribution guidelines, coding standards, DCO sign-off
 
 ## Tutorials
 
 Step-by-step walkthroughs to get hands-on:
 
-- [Background](docs/tutorials/background.md) — Kernel-bypass and GPUDirect concepts
-- [System Configuration](docs/tutorials/system_configuration.md) — NIC drivers, link layers, GPUDirect, hugepages, CPU isolation, GPU clocks
-- [Benchmarking Examples](docs/tutorials/benchmarking_examples.md) — run `daqiri_bench_raw_gpudirect` with a loopback test
-- [Understanding the Configuration File](docs/tutorials/configuration-walkthrough.md) — annotated YAML walkthrough
+- [Background](https://nvidia.github.io/daqiri/tutorials/background/) — Kernel-bypass and GPUDirect concepts
+- [System Configuration](https://nvidia.github.io/daqiri/tutorials/system_configuration/) — NIC drivers, link layers, GPUDirect, hugepages, CPU isolation, GPU clocks
+- [Benchmarking Examples](https://nvidia.github.io/daqiri/tutorials/benchmarking_examples/) — run `daqiri_bench_raw_gpudirect` with a loopback test
+- [Understanding the Configuration File](https://nvidia.github.io/daqiri/tutorials/configuration-walkthrough/) — annotated YAML walkthrough
 
 ## License
 


### PR DESCRIPTION
## Summary
- Switch README **Documentation**, **Tutorials**, and the two inline "See [Getting Started]" links to their `nvidia.github.io/daqiri/...` URLs so readers land on the Material-rendered pages with search and nav.
- Leave `CONTRIBUTING.md` and `LICENSE` as repo-relative — they aren't part of the docs site.

Closes #91.

## Test plan
- [x] On the rendered README at github.com/NVIDIA/daqiri, click each of the 9 changed links and confirm they land on the corresponding page on nvidia.github.io/daqiri.
- [x] Confirm `CONTRIBUTING.md` and `LICENSE` links still resolve in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)