### PR TITLE
Avoid double-returning TX metadata on enqueue failure

### DIFF
--- a/src/managers/dpdk/daqiri_dpdk_mgr.cpp
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.cpp
@@ -4394,7 +4394,6 @@ Status DpdkMgr::send_tx_burst(BurstParams* burst) {
 
   if (rte_ring_enqueue(ring->second, reinterpret_cast<void*>(burst)) != 0) {
     free_tx_burst(burst);
-    free_tx_metadata(burst);
     DAQIRI_LOG_CRITICAL("Failed to enqueue TX work");
     return Status::NO_SPACE_AVAILABLE;
   }

--- a/src/managers/rdma/daqiri_rdma_mgr.cpp
+++ b/src/managers/rdma/daqiri_rdma_mgr.cpp
@@ -353,7 +353,6 @@ Status RdmaMgr::send_tx_burst(BurstParams* burst) {
 
   if (rte_ring_enqueue(ring, reinterpret_cast<void*>(burst)) != 0) {
     free_tx_burst(burst);
-    free_tx_metadata(burst);
     DAQIRI_LOG_CRITICAL("Failed to enqueue TX work");
     return Status::NO_SPACE_AVAILABLE;
   }
@@ -449,7 +448,6 @@ void RdmaMgr::rdma_thread(bool is_server, rdma_thread_params* tparams) {
       if (rte_ring_enqueue(rx_ring, reinterpret_cast<void*>(msg)) != 0) {
         DAQIRI_LOG_CRITICAL("Failed to enqueue RX completion message");
         free_tx_burst(msg);
-        free_tx_metadata(msg);
         return;
       }
     }
@@ -505,7 +503,6 @@ void RdmaMgr::rdma_thread(bool is_server, rdma_thread_params* tparams) {
       if (rte_ring_enqueue(rx_ring, reinterpret_cast<void*>(msg)) != 0) {
         DAQIRI_LOG_CRITICAL("Failed to enqueue RX completion message");
         free_tx_burst(msg);
-        free_tx_metadata(msg);
         return;
       }
     }


### PR DESCRIPTION
## Summary
This removes redundant `free_tx_metadata()` calls from the DPDK and RDMA enqueue-failure paths.

In both backends, `free_tx_burst()` already returns the TX metadata object to its mempool. Calling `free_tx_metadata()` immediately afterwards puts the same object back twice, which risks freelist corruption on error paths.

This patch keeps the existing ownership contract and just removes the duplicate metadata return in the affected call sites:
- `DpdkMgr::send_tx_burst()`
- `RdmaMgr::send_tx_burst()`
- the two RDMA completion-message enqueue failure paths in `rdma_thread()`

Fixes #101.

## Testing
- `git diff --check`
- `cmake -S . -B build-pr-check -DDAQIRI_BUILD_PYTHON=OFF -DDAQIRI_BUILD_EXAMPLES=OFF -DDAQIRI_MGR="dpdk rdma"` *(fails locally because `nvcc` is not installed in this environment)*
