### PR TITLE
#15 #77 - Fix DGX Spark example to a true over-the-wire loopback (TX/…

### DIFF
--- a/docs/tutorials/benchmarking_examples.md
+++ b/docs/tutorials/benchmarking_examples.md
@@ -51,7 +51,7 @@ docker run --rm -it --privileged \
 
     For systems configured per the [DGX Spark profile](system_configuration.md#dgx-spark-profile), use these configs to skip the PCIe/IP/CPU-core edits below:
 
-    - [`daqiri_bench_raw_tx_rx_spark.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_raw_tx_rx_spark.yaml) for `daqiri_bench_raw_gpudirect` — still set `eth_dst_addr` to the RX MAC. The rx_port is `0002:01:00.1` (physical port p1), so read its MAC: `cat /sys/class/net/enP2p1s0f1np1/address`.
+    - [`daqiri_bench_raw_tx_rx_spark.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_raw_tx_rx_spark.yaml) for `daqiri_bench_raw_gpudirect` — still set `eth_dst_addr` to the RX MAC. The rx_port is `0002:01:00.1` (physical port p1), so read its MAC: `cat /sys/class/net/enP2p1s0f1np1/address`. This p0-to-p1 pairing is intentional for an over-the-wire single-machine loopback; using two PFs that map to the same physical port exercises the on-chip eswitch path instead.
     - [`daqiri_bench_rdma_tx_rx_spark.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_rdma_tx_rx_spark.yaml) for `daqiri_bench_rdma` — no further edits needed.
 
 The benchmark executables and example YAML configurations are located at:
@@ -323,6 +323,8 @@ To inspect the speed the data is moving through the NIC, run `mlnx_perf` on one 
 ```bash
 sudo mlnx_perf -i $if_name
 ```
+
+The `*_packets_phy` and `*_bytes_phy` counters are physical-link counters. They increase when packets cross the wire through the QSFP/SerDes side of the NIC. If a DGX Spark same-machine loopback uses two PFs that map to the same physical port, traffic can be switched on-chip and the vport counters may rise while the physical counters stay flat.
 
 ??? abstract "See an example output"
 

--- a/docs/tutorials/benchmarking_examples.md
+++ b/docs/tutorials/benchmarking_examples.md
@@ -51,7 +51,7 @@ docker run --rm -it --privileged \
 
     For systems configured per the [DGX Spark profile](system_configuration.md#dgx-spark-profile), use these configs to skip the PCIe/IP/CPU-core edits below:
 
-    - [`daqiri_bench_raw_tx_rx_spark.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_raw_tx_rx_spark.yaml) for `daqiri_bench_raw_gpudirect` — still set `eth_dst_addr` to the RX MAC: `cat /sys/class/net/enP2p1s0f0np0/address`.
+    - [`daqiri_bench_raw_tx_rx_spark.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_raw_tx_rx_spark.yaml) for `daqiri_bench_raw_gpudirect` — still set `eth_dst_addr` to the RX MAC. The rx_port is `0002:01:00.1` (physical port p1), so read its MAC: `cat /sys/class/net/enP2p1s0f1np1/address`.
     - [`daqiri_bench_rdma_tx_rx_spark.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_rdma_tx_rx_spark.yaml) for `daqiri_bench_rdma` — no further edits needed.
 
 The benchmark executables and example YAML configurations are located at:

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -1319,7 +1319,7 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
 
     ### Port topology: 4 PFs, 2 ports, tied chassis sockets
 
-    `lspci -d 15b3:` on Spark shows **four** CX-7 PFs across **two** PCIe domains. This is **one** ConnectX-7 ASIC with **two physical ports** (p0, p1); each port is dual-homed across both PCIe segments (socket-direct), which is why a single card appears as four PFs:
+    `lspci -d 15b3:` on Spark shows **four** CX-7 PFs across **two** PCIe domains. This is **one** ConnectX-7 ASIC with **two physical ports** (p0, p1); each port is dual-homed across both PCIe segments (socket-direct), which is why a single card appears as four PFs. The PCIe address is also called a BDF (bus-device-function); in the examples below, `0002:01:00.1` is PCI domain `0002`, bus `01`, device `00`, function `1`.
 
     ```text
     0000:01:00.0  →  mlx5_0  →  enp1s0f0np0
@@ -1336,7 +1336,9 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
     done
     ```
 
-    !!! important "Same physical port = on-chip test; different ports = over-the-wire test"
+    !!! important "Single-machine loopback: same physical port = on-chip test; different ports = over-the-wire test"
+
+        This distinction matters when you run a loopback benchmark within one DGX Spark, where TX and RX are two PFs on the same integrated CX-7. For two-device tests, pick ports according to the external cabling and the peer system's topology; the on-chip shortcut described here is specific to same-machine loopback.
 
         Which PF pair you choose decides **what you are actually measuring**. Because each physical port is exposed over both PCIe segments, two of the four BDFs map to the *same* physical port. Identify them on your own system with `phys_port_name`:
 
@@ -1361,7 +1363,7 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
         - **Same physical port** (e.g. `mlx5_0` ↔ `mlx5_2`, both p0) → TX/RX loop **on-chip** through the eswitch; traffic never reaches the cable. `tx_phy_packets` / `rx_phy_packets` stay flat while the vport counters (`tx_good_packets` / `rx_good_packets`) run at line rate. This is a software-path test.
         - **Different physical ports** (e.g. `mlx5_0` p0 ↔ `mlx5_3` p1 `0002:01:00.1`, or `mlx5_0` ↔ `mlx5_1`) → TX/RX loop **over the wire**; `tx_phy_packets` / `rx_phy_packets` rise to match the TX/RX counts. This is an over-the-wire test.
 
-        Confirm which case you got from the **`tx_phy_packets` / `rx_phy_packets`** lines in the [daqiri bench](benchmarking_examples.md)'s "Extended Stats" output: near zero for on-chip, matching the TX/RX packet counts for over-the-wire. (`ethtool -S` lists the same wire counters as `tx_packets_phy` / `rx_packets_phy`.)
+        Confirm which case you got from the **`tx_phy_packets` / `rx_phy_packets`** lines in the [daqiri bench](benchmarking_examples.md)'s "Extended Stats" output: near zero for on-chip, matching the TX/RX packet counts for over-the-wire. These are physical-link counters, so they count packets that reached the SerDes/QSFP side of the NIC rather than packets switched internally by the eswitch. (`ethtool -S` lists the same wire counters as `tx_packets_phy` / `rx_packets_phy`; `mlnx_perf` reports them as `tx_packets_phy` / `rx_packets_phy`.)
 
     `ethtool -m` reports identical `Connector: 0x23 No separable connector` on all 4 PFs and is **not** useful for distinguishing them; use `phys_port_name` above (the cable-yank carrier test confirms a cable is present but does **not** distinguish ports).
 
@@ -1587,4 +1589,3 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
     **Next:** [Benchmarking Examples](benchmarking_examples.md) — run your first DAQIRI benchmark
 
 </div>
-

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -1317,9 +1317,9 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
 
     The hotplug behavior is implemented as a power/thermal management policy and coordinates with `nvidia-spark-mlnx-firmware-manager.service`. If you need the NIC alive without a cable for software-only testing, the override point is the scripts under `/opt/nvidia/dgx-spark-mlnx-hotplug` — read them before disabling.
 
-    ### Port topology: 4 PFs, 2 chips, tied chassis sockets
+    ### Port topology: 4 PFs, 2 ports, tied chassis sockets
 
-    `lspci -d 15b3:` on Spark shows **four** CX-7 PFs across **two** PCIe domains, fronting two chips that share a single internal fabric:
+    `lspci -d 15b3:` on Spark shows **four** CX-7 PFs across **two** PCIe domains. This is **one** ConnectX-7 ASIC with **two physical ports** (p0, p1); each port is dual-homed across both PCIe segments (socket-direct), which is why a single card appears as four PFs:
 
     ```text
     0000:01:00.0  →  mlx5_0  →  enp1s0f0np0
@@ -1328,7 +1328,7 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
     0002:01:00.1  →  mlx5_3  →  enP2p1s0f1np1
     ```
 
-    The two chassis QSFPs are **tied** through the internal fabric. Pulling **just one end** of a loopback cable drops `carrier` to 0 on **all four** PFs simultaneously, which is the reliable diagnostic for confirming the topology:
+    The two chassis QSFPs are bridged by a single loopback cable. Pulling **just one end** drops `carrier` to 0 on **all four** PFs simultaneously, confirming the cable is present and the loop is intact:
 
     ```bash
     for i in /sys/class/net/{enp1s0f0np0,enp1s0f1np1,enP2p1s0f0np0,enP2p1s0f1np1}; do
@@ -1336,9 +1336,34 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
     done
     ```
 
-    Practical consequence for daqiri loopback benchmarks: any pair of PFs forms a working loopback. There is no "wrong pair" — pick TX/RX based on what your YAML expects. The Spark example YAMLs use `mlx5_0` (TX) ↔ `mlx5_2` (RX), so traffic crosses the cable.
+    !!! important "Same physical port = on-chip test; different ports = over-the-wire test"
 
-    `ethtool -m` reports identical `Connector: 0x23 No separable connector` on all 4 PFs and is **not** useful for distinguishing them; use the cable-yank test.
+        Which PF pair you choose decides **what you are actually measuring**. Because each physical port is exposed over both PCIe segments, two of the four BDFs map to the *same* physical port. Identify them on your own system with `phys_port_name`:
+
+        ```bash
+        for d in /sys/class/net/*/device; do n=${d%/device}; n=${n##*/}; \
+            printf '%-16s port=%s pci=%s\n' "$n" \
+            "$(cat /sys/class/net/$n/phys_port_name 2>/dev/null)" \
+            "$(basename "$(readlink "$d")")"; done
+        ```
+
+        Example output:
+
+        ```text
+        enp1s0f0np0      port=p0  pci=0000:01:00.0   # mlx5_0
+        enp1s0f1np1      port=p1  pci=0000:01:00.1   # mlx5_1
+        enP2p1s0f0np0    port=p0  pci=0002:01:00.0   # mlx5_2
+        enP2p1s0f1np1    port=p1  pci=0002:01:00.1   # mlx5_3
+        ```
+
+        Here two BDFs share each physical port (`mlx5_0` and `mlx5_2` are both **p0**). The two pairings measure different things:
+
+        - **Same physical port** (e.g. `mlx5_0` ↔ `mlx5_2`, both p0) → TX/RX loop **on-chip** through the eswitch; traffic never reaches the cable. `tx_phy_packets` / `rx_phy_packets` stay flat while the vport counters (`tx_good_packets` / `rx_good_packets`) run at line rate. This is a software-path test.
+        - **Different physical ports** (e.g. `mlx5_0` p0 ↔ `mlx5_3` p1 `0002:01:00.1`, or `mlx5_0` ↔ `mlx5_1`) → TX/RX loop **over the wire**; `tx_phy_packets` / `rx_phy_packets` rise to match the TX/RX counts. This is an over-the-wire test.
+
+        Confirm which case you got from the **`tx_phy_packets` / `rx_phy_packets`** lines in the [daqiri bench](benchmarking_examples.md)'s "Extended Stats" output: near zero for on-chip, matching the TX/RX packet counts for over-the-wire. (`ethtool -S` lists the same wire counters as `tx_packets_phy` / `rx_packets_phy`.)
+
+    `ethtool -m` reports identical `Connector: 0x23 No separable connector` on all 4 PFs and is **not** useful for distinguishing them; use `phys_port_name` above (the cable-yank carrier test confirms a cable is present but does **not** distinguish ports).
 
     ## System Setup for DAQIRI
 

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -1360,10 +1360,10 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
 
         Here two BDFs share each physical port (`mlx5_0` and `mlx5_2` are both **p0**). The two pairings measure different things:
 
-        - **Same physical port** (e.g. `mlx5_0` ↔ `mlx5_2`, both p0) → TX/RX loop **on-chip** through the eswitch; traffic never reaches the cable. `tx_phy_packets` / `rx_phy_packets` stay flat while the vport counters (`tx_good_packets` / `rx_good_packets`) run at line rate. This is a software-path test.
-        - **Different physical ports** (e.g. `mlx5_0` p0 ↔ `mlx5_3` p1 `0002:01:00.1`, or `mlx5_0` ↔ `mlx5_1`) → TX/RX loop **over the wire**; `tx_phy_packets` / `rx_phy_packets` rise to match the TX/RX counts. This is an over-the-wire test.
+        - **Same physical port** (e.g. `mlx5_0` ↔ `mlx5_2`, both p0) → TX/RX loop **on-chip** through the eswitch; traffic never reaches the cable. Physical-link packet counters stay flat while the vport counters (`tx_good_packets` / `rx_good_packets`) run at line rate. This is a software-path test.
+        - **Different physical ports** (e.g. `mlx5_0` p0 ↔ `mlx5_3` p1 `0002:01:00.1`, or `mlx5_0` ↔ `mlx5_1`) → TX/RX loop **over the wire**; physical-link packet counters rise to match the TX/RX counts. This is an over-the-wire test.
 
-        Confirm which case you got from the **`tx_phy_packets` / `rx_phy_packets`** lines in the [daqiri bench](benchmarking_examples.md)'s "Extended Stats" output: near zero for on-chip, matching the TX/RX packet counts for over-the-wire. These are physical-link counters, so they count packets that reached the SerDes/QSFP side of the NIC rather than packets switched internally by the eswitch. (`ethtool -S` lists the same wire counters as `tx_packets_phy` / `rx_packets_phy`; `mlnx_perf` reports them as `tx_packets_phy` / `rx_packets_phy`.)
+        Confirm which case you got from the physical-link packet counters: near zero for on-chip, matching the TX/RX packet counts for over-the-wire. These counters count packets that reached the SerDes/QSFP side of the NIC rather than packets switched internally by the eswitch. The [daqiri bench](benchmarking_examples.md)'s DPDK "Extended Stats" output reports them as `tx_phy_packets` / `rx_phy_packets`; `ethtool -S` and `mlnx_perf` report the same wire counters as `tx_packets_phy` / `rx_packets_phy`.
 
     `ethtool -m` reports identical `Connector: 0x23 No separable connector` on all 4 PFs and is **not** useful for distinguishing them; use `phys_port_name` above (the cable-yank carrier test confirms a cable is present but does **not** distinguish ports).
 

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -1391,13 +1391,13 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
 
     ### Configure the IP addresses of the NIC ports
 
-    Spark uses NetworkManager. Create persistent `daqiri-tx` / `daqiri-rx` profiles that pin both the IP and the MTU (so [Step 9: Jumbo frames](#step-9-enable-jumbo-frames-already-covered) is folded in here):
+    Spark uses NetworkManager. Create persistent `daqiri-tx` / `daqiri-rx` profiles that pin both the IP and the MTU (so [Step 9: Jumbo frames](#step-9-enable-jumbo-frames-already-covered) is folded in here). `daqiri-tx` is p0 (`enp1s0f0np0`) and `daqiri-rx` is p1 (`enP2p1s0f1np1`) — different physical ports, matching the over-the-wire benchmark example:
 
     ```bash
     sudo nmcli connection add type ethernet ifname enp1s0f0np0   con-name daqiri-tx \
         ipv4.addresses 1.1.1.1/24 ipv4.method manual ethernet.mtu 9000 \
         ipv4.gateway "" ipv6.method ignore
-    sudo nmcli connection add type ethernet ifname enP2p1s0f0np0 con-name daqiri-rx \
+    sudo nmcli connection add type ethernet ifname enP2p1s0f1np1 con-name daqiri-rx \
         ipv4.addresses 2.2.2.2/24 ipv4.method manual ethernet.mtu 9000 \
         ipv4.gateway "" ipv6.method ignore
     sudo nmcli connection up daqiri-tx
@@ -1408,9 +1408,9 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
 
     ```bash
     ip -f inet addr show enp1s0f0np0
-    ip -f inet addr show enP2p1s0f0np0
+    ip -f inet addr show enP2p1s0f1np1
     ip link show enp1s0f0np0   | grep -oE "mtu [0-9]+"
-    ip link show enP2p1s0f0np0 | grep -oE "mtu [0-9]+"
+    ip link show enP2p1s0f1np1 | grep -oE "mtu [0-9]+"
     ```
 
     ### Enable GPUDirect
@@ -1580,7 +1580,7 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
 
     ```bash
     ip link show enp1s0f0np0   | grep -oE "mtu [0-9]+"
-    ip link show enP2p1s0f0np0 | grep -oE "mtu [0-9]+"
+    ip link show enP2p1s0f1np1 | grep -oE "mtu [0-9]+"
     ```
 
     ---

--- a/examples/daqiri_bench_raw_tx_rx_spark.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_spark.yaml
@@ -3,9 +3,12 @@
 # daqiri_bench_raw_tx_rx.yaml.
 #
 # Spark substitutions baked in here:
-#   - PCIe addresses: 0000:01:00.0 (TX, mlx5_0) / 0002:01:00.0 (RX, mlx5_2),
-#     traffic crosses the chassis QSFP loop; see docs/tutorials/system_configuration.md
-#     "DGX Spark" tab for the 4-PFs/2-chips/tied-ports topology.
+#   - PCIe addresses: this file is configured for an over-the-wire loopback --
+#     tx_port (0000:01:00.0) and rx_port (0002:01:00.1) are different physical
+#     ports (p0 / p1) cross-cabled by the chassis QSFP loop, so traffic crosses
+#     the cable. To verify the port topology or set up a different loopback
+#     (e.g. on-chip), see the "Port topology" section of the "DGX Spark" tab in
+#     docs/tutorials/system_configuration.md.
 #   - kind: host_pinned, NOT device. GB10 has unified memory; nvidia_peermem
 #     does not load and CUDA reports DMA_BUF_SUPPORTED=0. PR #41 made
 #     host_pinned the working GPUDirect path on Spark (~94 Gbps unicast).
@@ -14,8 +17,8 @@
 #   - master_core: 8 (a non-isolated big core; any 0-15 works).
 #   - bench_tx ip_src/ip_dst: match the daqiri-tx / daqiri-rx nmcli profiles
 #     (1.1.1.1/24 and 2.2.2.2/24, MTU 9000).
-#   - eth_dst_addr: per-system, fill from the RX interface MAC:
-#       cat /sys/class/net/enP2p1s0f0np0/address
+#   - eth_dst_addr: your rx_port's own MAC; fill per-system, e.g.:
+#       cat /sys/class/net/enP2p1s0f1np1/address
 #
 %YAML 1.2
 ---
@@ -54,7 +57,10 @@ daqiri:
           offloads:
             - "tx_eth_src"
     - name: "rx_port"
-      address: 0002:01:00.0
+      # p1 -- a DIFFERENT physical port than tx_port (p0), cross-cabled to it, so
+      # traffic crosses the wire. The same physical port (e.g. 0002:01:00.0, also
+      # p0) would loop on-chip instead. Verify your p0/p1 mapping (see header).
+      address: 0002:01:00.1
       rx:
         flow_isolation: true
         queues:
@@ -82,7 +88,8 @@ bench_tx:
   batch_size: 10240
   payload_size: 8000
   header_size: 64
-  eth_dst_addr: <00:00:00:00:00:00>  # cat /sys/class/net/enP2p1s0f0np0/address
+  # rx_port's (p1) own MAC; fill per-system, e.g. cat /sys/class/net/enP2p1s0f1np1/address
+  eth_dst_addr: <00:00:00:00:00:00>
   ip_src_addr: 1.1.1.1
   ip_dst_addr: 2.2.2.2
   udp_src_port: 4096


### PR DESCRIPTION
…RX on different physical ports)

daqiri_bench_raw_tx_rx_spark.yaml set rx_port to 0002:01:00.0, the SAME physical port (p0) as tx_port 0000:01:00.0: the two BDFs are PCIe-segment views of one CX-7 port (socket-direct), so TX/RX looped on-chip in the eswitch and never reached the wire (tx/rx_packets_phy stayed flat), despite the comment claiming traffic crosses the cable.

Set rx_port to 0002:01:00.1 (physical port p1, cross-cabled to p0) so traffic crosses the wire. eth_dst_addr must be the rx_port's own MAC (kept as a placeholder); a foreign MAC crosses the wire but is dropped at RX ingress.

Also correct the port-topology section of system_configuration.md, which claimed any PF pair forms a working loopback and that mlx5_0<->mlx5_2 crosses the cable. Add a phys_port_name verification command and explain same-port (on-chip) vs different-port (over-the-wire) pairings.