### PR TITLE
Tune Greptile review output

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -5,7 +5,6 @@
   "triggerOnDrafts": false,
   "statusCheck": true,
   "updateSummaryOnly": true,
-  "fixWithAI": true,
   "fileChangeLimit": 200,
   "excludeAuthors": ["dependabot[bot]", "*-bot"],
   "excludeBranches": ["gh-pages"],

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,9 +1,11 @@
 {
-  "strictness": 2,
-  "commentTypes": ["logic", "syntax", "style", "info"],
+  "strictness": 3,
+  "commentTypes": ["logic", "syntax", "info"],
   "triggerOnUpdates": true,
   "triggerOnDrafts": false,
   "statusCheck": true,
+  "updateSummaryOnly": true,
+  "fixWithAI": true,
   "fileChangeLimit": 200,
   "excludeAuthors": ["dependabot[bot]", "*-bot"],
   "excludeBranches": ["gh-pages"],
@@ -17,6 +19,12 @@
   "issuesTableSection": {
     "included": true,
     "collapsible": false
+  },
+  "sequenceDiagramSection": {
+    "included": false
+  },
+  "confidenceScoreSection": {
+    "included": true
   },
   "instructions": "DAQIRI is a single C++/CUDA shared library (libdaqiri.so) for GPU-direct packet I/O over DPDK, RDMA, and sockets. The full reviewer context lives in .greptile/rules.md and the linked context files in .greptile/files.json (AGENTS.md, CONTRIBUTING.md, .claude/rules/docs-sync.md, src/common.h, src/manager.h, src/types.h). Always read them before commenting. Prefer few high-signal comments over many nits; this is a low-level networking library where idiomatic-looking code is often deliberate.",
   "rules": [


### PR DESCRIPTION
- Disable auto-generated sequence/ER/class/flow diagrams (sequenceDiagramSection.included = false) (they add a large image block to every review that was not helpful for any reviewed PRs)
- Raise strictness from 2 to 3 (only the most critical issues)
- Drop "style" from commentTypes (keep logic, syntax, info)
- updateSummaryOnly: true -- post one summary instead of many inline comments.
- Add confidenceScoreSection.included = true so reviewers can see how sure Greptile is about each call-out

No code or behavior changes outside the bot configuriation updates