### PR TITLE
#131 - Fix DPDK TX enqueue mbuf leak

### DIFF
--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -241,6 +241,13 @@ daqiri::send_tx_burst(burst);
 
 The burst is enqueued to the TX worker thread, which sends it to the NIC via DMA.
 
+`send_tx_burst()` takes ownership of the burst on success and on a full-ring
+failure: on `SUCCESS` the TX worker owns it, and on `NO_SPACE_AVAILABLE` (the TX
+ring is full) it has already freed the packets and the burst internally. In both
+cases the application must **not** free or otherwise access the burst afterwards.
+`NO_SPACE_AVAILABLE` is the only failure a correctly-configured sender encounters
+at runtime.
+
 ### Timed Transmission
 
 For precise packet scheduling (requires ConnectX-7+):

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -336,12 +336,15 @@ for idx in range(daqiri.get_num_packets(burst)):
 
 ```python
 status = daqiri.send_tx_burst(burst)
-if status != daqiri.Status.SUCCESS:
-    daqiri.free_all_packets_and_burst_tx(burst)
+# Do not free `burst` after a SUCCESS or NO_SPACE_AVAILABLE return — see the ownership note below.
 ```
 
-After a successful `send_tx_burst()`, the worker thread owns the burst and the
-application must not access it again.
+`send_tx_burst()` takes ownership of the burst on success and on a full-ring
+failure: on `SUCCESS` the worker thread owns it, and on `NO_SPACE_AVAILABLE` (the
+TX ring is full) it has already freed the packets and the burst internally. In
+both cases the application must **not** free or otherwise access the burst
+afterwards. `NO_SPACE_AVAILABLE` is the only failure a correctly-configured
+sender encounters at runtime.
 
 ### Timed Transmission
 
@@ -396,9 +399,9 @@ if status == daqiri.Status.SUCCESS:
     if daqiri.get_tx_packet_burst(tx_burst) == daqiri.Status.SUCCESS:
         daqiri.copy_buffer_to_packet(tx_burst, 0, b"hello")
         daqiri.set_packet_lengths(tx_burst, 0, [5])
-        status = daqiri.send_tx_burst(tx_burst)
-        if status != daqiri.Status.SUCCESS:
-            daqiri.free_all_packets_and_burst_tx(tx_burst)
+        # send_tx_burst() takes ownership of tx_burst on success and on a
+        # full-ring failure, so do not free it here.
+        daqiri.send_tx_burst(tx_burst)
     else:
         daqiri.free_tx_metadata(tx_burst)
 ```

--- a/examples/gds_write_example.cpp
+++ b/examples/gds_write_example.cpp
@@ -179,8 +179,10 @@ bool fill_and_send_one_burst(const daqiri::bench::RawBenchTxConfig &cfg,
   }
 
   if (daqiri::send_tx_burst(msg) != daqiri::Status::SUCCESS) {
+    // send_tx_burst() takes ownership of the burst: on success the TX worker
+    // owns it, and on a full-ring failure it has already freed the packets and
+    // burst. The caller must not free or otherwise touch `msg` afterwards.
     std::cerr << "Failed to send TX burst\n";
-    daqiri::free_all_packets_and_burst_tx(msg);
     return false;
   }
 

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -701,11 +701,19 @@ int get_port_id(const std::string &key);
 void set_num_packets(BurstParams *burst, int64_t num);
 
 /**
- * @brief Send a TX burst
+ * @brief Send a TX burst.
+ *
+ * Takes ownership of @p burst on SUCCESS and on NO_SPACE_AVAILABLE: on SUCCESS
+ * the TX worker owns it; on NO_SPACE_AVAILABLE (TX ring full) it has already
+ * freed the packets and the burst internally. In both cases the caller must
+ * NOT free or otherwise access @p burst afterwards. NO_SPACE_AVAILABLE is the
+ * only failure a correctly-configured sender hits at runtime.
  *
  * @param burst Burst structure
- * @return Status indicating status. Valid values are:
- *    SUCCESS: Burst sent successfully
+ * @return Status indicating result. Valid values are:
+ *    SUCCESS: burst enqueued to the TX worker (ownership transferred)
+ *    NO_SPACE_AVAILABLE: TX ring full; burst already freed (ownership consumed)
+ *    INVALID_PARAMETER: bad port/queue; burst NOT consumed (see issue #164)
  */
 Status send_tx_burst(BurstParams *burst);
 

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -91,7 +91,7 @@ static void free_unsubmitted_tx_packets(BurstParams* burst) {
     if (burst->pkts[seg] == nullptr) { continue; }
 
     auto** pkts = reinterpret_cast<rte_mbuf**>(burst->pkts[seg]);
-    for (int pkt = 0; pkt < burst->hdr.hdr.num_pkts; pkt++) {
+    for (size_t pkt = 0; pkt < burst->hdr.hdr.num_pkts; pkt++) {
       if (pkts[pkt] != nullptr) { rte_pktmbuf_free_seg(pkts[pkt]); }
     }
   }

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -82,6 +82,21 @@ static inline int get_queue_from_key(uint32_t key) {
     return static_cast<int>(key & 0xFFFF);
 }
 
+static void free_unsubmitted_tx_packets(BurstParams* burst) {
+  if (burst == nullptr) { return; }
+
+  // TX worker chains multi-segment mbufs only after enqueue succeeds.
+  // Before that point, every allocated segment must be freed directly.
+  for (int seg = 0; seg < burst->hdr.hdr.num_segs; seg++) {
+    if (burst->pkts[seg] == nullptr) { continue; }
+
+    auto** pkts = reinterpret_cast<rte_mbuf**>(burst->pkts[seg]);
+    for (int pkt = 0; pkt < burst->hdr.hdr.num_pkts; pkt++) {
+      if (pkts[pkt] != nullptr) { rte_pktmbuf_free_seg(pkts[pkt]); }
+    }
+  }
+}
+
 static inline bool is_cuda_accessible_packet_memory(MemoryKind kind) {
   return kind == MemoryKind::DEVICE || kind == MemoryKind::HOST_PINNED;
 }
@@ -4616,6 +4631,7 @@ Status DpdkEngine::send_tx_burst(BurstParams* burst) {
   }
 
   if (rte_ring_enqueue(ring->second, reinterpret_cast<void*>(burst)) != 0) {
+    free_unsubmitted_tx_packets(burst);
     free_tx_burst(burst);
     DAQIRI_LOG_CRITICAL("Failed to enqueue TX work");
     return Status::NO_SPACE_AVAILABLE;


### PR DESCRIPTION
## Summary
- Free unsubmitted DPDK TX packet mbufs when the TX work ring enqueue fails.
- Keep the existing burst metadata/pointer-array cleanup after packet buffers are released.

## Why
`free_tx_burst()` only returns TX burst metadata and pointer arrays. If `send_tx_burst()` hits a full ring after packet mbufs were allocated, releasing only the burst leaves the application without handles to free those mbufs.

For multi-segment TX bursts, the worker chains mbufs only after enqueue succeeds, so the failure path frees each allocated segment directly.

## Validation
- `git diff --check`
- `IMAGE_TAG=daqiri:tx-enqueue-leak BASE_TARGET=dpdk DAQIRI_MGR=dpdk DAQIRI_BUILD_PYTHON=OFF BUILD_SHARED_LIBS=ON scripts/build-container.sh`

Fixes #131