### PR TITLE
Validate MAC strings before formatting

### DIFF
--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -474,7 +474,7 @@ workflow sections above show the common call order and ownership rules.
 | Function | Purpose |
 | --- | --- |
 | `get_mac_addr(port, mac)` | Copy a port MAC address into a six-byte buffer. |
-| `format_eth_addr(dst, addr)` | Convert a MAC address string into a six-byte buffer. |
+| `format_eth_addr(dst, addr)` | Convert a `xx:xx:xx:xx:xx:xx` MAC string into a six-byte buffer; invalid input zeroes the buffer. |
 | `get_port_id(key)` | Resolve an interface name or PCIe address to a port ID. |
 | `get_num_rx_queues(port_id)` | Return the configured or backend-reported RX queue count. |
 | `drop_all_traffic(port)` | Install a high-priority drop rule on a port. |

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -572,7 +572,7 @@ The workflow sections above show the common call order and ownership rules.
 | Function | Purpose |
 | --- | --- |
 | `get_mac_addr(port)` | Return `(Status, "aa:bb:cc:dd:ee:ff")`. |
-| `format_eth_addr(addr)` | Return six MAC-address bytes. |
+| `format_eth_addr(addr)` | Return six MAC-address bytes from a `xx:xx:xx:xx:xx:xx` MAC string; invalid input returns zero bytes. |
 | `get_port_id(key)` | Resolve an interface name or PCIe address to a port ID. |
 | `get_num_rx_queues(port_id)` | Return configured RX queue count for a port. |
 | `drop_all_traffic(port)` | Install a high-priority drop rule on a port. |

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -694,10 +694,12 @@ void set_header(BurstParams *burst, uint16_t port, uint16_t q, int64_t num,
                 int segs);
 
 /**
- * @brief First MAC address string to char buffer
+ * @brief Format MAC address string to char buffer
  *
- * @param dst Destination buffer
- * @param addr MAC address as string in format xx:xx:xx:xx:xx:xx
+ * @param dst Destination buffer of at least six bytes. Invalid input zeroes
+ * the six-byte destination.
+ * @param addr MAC address as string in format xx:xx:xx:xx:xx:xx, with exactly
+ * two hexadecimal digits per octet.
  */
 void format_eth_addr(char *dst, std::string addr);
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -20,6 +20,7 @@
 #include <unordered_set>
 #include <arpa/inet.h>
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <filesystem>
 #include <limits>
@@ -40,6 +41,55 @@ namespace daqiri {
 
 // Declare a static global variable for the manager
 static Manager* g_daqiri_mgr = nullptr;
+
+namespace {
+
+constexpr size_t kEthAddrLength = 6;
+constexpr size_t kEthAddrOctetLength = 2;
+
+int hex_digit_value(char digit) {
+  const unsigned char c = static_cast<unsigned char>(digit);
+  if (c >= '0' && c <= '9') { return c - '0'; }
+  if (c >= 'a' && c <= 'f') { return c - 'a' + 10; }
+  if (c >= 'A' && c <= 'F') { return c - 'A' + 10; }
+  return -1;
+}
+
+Status parse_eth_addr(std::array<char, kEthAddrLength>* dst,
+                      const std::string& addr) {
+  if (dst == nullptr) { return Status::NULL_PTR; }
+
+  std::array<char, kEthAddrLength> parsed = {};
+  size_t offset = 0;
+
+  for (size_t octet = 0; octet < kEthAddrLength; ++octet) {
+    if (offset + kEthAddrOctetLength > addr.size()) {
+      return Status::INVALID_PARAMETER;
+    }
+
+    const int high = hex_digit_value(addr[offset]);
+    const int low = hex_digit_value(addr[offset + 1]);
+    if (high < 0 || low < 0) { return Status::INVALID_PARAMETER; }
+
+    parsed[octet] = static_cast<char>((high << 4) | low);
+    offset += kEthAddrOctetLength;
+
+    if (octet + 1 == kEthAddrLength) {
+      if (offset != addr.size()) { return Status::INVALID_PARAMETER; }
+      continue;
+    }
+
+    if (offset >= addr.size() || addr[offset] != ':') {
+      return Status::INVALID_PARAMETER;
+    }
+    ++offset;
+  }
+
+  *dst = parsed;
+  return Status::SUCCESS;
+}
+
+}  // namespace
 
 const std::unordered_map<LogLevel::Level, std::string> LogLevel::level_to_string_map = {
     {TRACE, "trace"},
@@ -152,19 +202,20 @@ void free_segment_packets_and_burst(BurstParams* burst, int seg) {
 }
 
 void format_eth_addr(char* dst, std::string addr) {
-  std::istringstream iss(addr);
-  std::string byteString;
-
-  uint8_t byte_cnt = 0;
-  while (std::getline(iss, byteString, ':')) {
-    if (byteString.length() == 2) {
-      uint16_t byte = std::stoi(byteString, nullptr, 16);
-      dst[byte_cnt++] = static_cast<char>(byte);
-    } else {
-      DAQIRI_LOG_ERROR("Invalid MAC address format: {}", addr);
-      dst[0] = 0x00;
-    }
+  if (dst == nullptr) {
+    DAQIRI_LOG_ERROR("Invalid MAC address destination buffer");
+    return;
   }
+
+  std::array<char, kEthAddrLength> parsed = {};
+  const Status status = parse_eth_addr(&parsed, addr);
+  if (status != Status::SUCCESS) {
+    DAQIRI_LOG_ERROR("Invalid MAC address format: {}", addr);
+    std::fill_n(dst, kEthAddrLength, 0x00);
+    return;
+  }
+
+  std::copy(parsed.begin(), parsed.end(), dst);
 }
 
 Status get_mac_addr(int port, char* mac) {


### PR DESCRIPTION
## Summary
- validate MAC strings as exactly six two-character hex octets before writing to the caller buffer
- replace `std::stoi` parsing with non-throwing hex conversion
- zero the six-byte destination on invalid input and document that behavior

## Validation
- `git diff --check`
- `IMAGE_TAG=daqiri:format-eth-addr-validation BASE_TARGET=dpdk DAQIRI_MGR=dpdk DAQIRI_BUILD_PYTHON=OFF BUILD_SHARED_LIBS=ON scripts/build-container.sh`
- container smoke test for valid, extra-octet, bad-hex, and short-octet inputs with sentinel bytes after the six-byte buffer

Fixes #133.