### PR TITLE
 #126 - Fix intermittent RoCE small-message throughput cliff (RNR timer)

### DIFF
--- a/docs/benchmarks/performance-dgx-spark.md
+++ b/docs/benchmarks/performance-dgx-spark.md
@@ -33,13 +33,14 @@ aggregate is shown.
 | Stream / Protocol | Best case | Throughput | Drops |
 | ----------------- | --------- | ---------: | ----- |
 | Raw Ethernet / GPUDirect | 4 KB packet | **106.4 Gb/s** (98.5 at 8 KB native) | 0 |
-| Socket / RoCE (SEND) | 8 MB message | **94.8 Gb/s** | 0 |
+| Socket / RoCE (SEND) | 8 MB message | **101.3 Gb/s** | 0 |
 | Socket / TCP | 8 KB × 4 pairs | **87.6 Gb/s** | ~0 (flow-controlled) |
 | Socket / UDP | 8 KB × 4 pairs | **34.0 Gb/s** goodput | unpaced, ~57% app-loss |
 
 Each transport is best read at its own native operation size (see the per-transport
 tables below); a single cross-transport unit of work isn't meaningful here, since
-RoCE collapses at 8 KB and TCP has no operation boundary.
+RoCE at 8 KB is op-rate-bound well below its large-message peak and TCP has no
+operation boundary.
 
 ## Raw Ethernet / GPUDirect (DPDK)
 
@@ -92,22 +93,22 @@ payload, not a compute engine.
 ## Socket / RoCE
 
 RoCE SEND over the netns wire loopback, single queue-pair, batch 1. Large
-messages saturate the path; below ~1 MB throughput falls off a small-message
-cliff (sweep below).
+messages saturate the path; smaller messages are bound by per-operation software
+overhead, but op-rate keeps climbing as they shrink.
 
 **Message-size sweep (single QP, batch 1, 0 drops)**
 
-| Message size | Gb/s |
-| ------------ | ---: |
-| 8 MB  | **94.8** |
-| 1 MB  | 94.4 |
-| 64 KB | 0.109 |
-| 8 KB  | 0.004 |
-| 4 KB  | 0.000 |
+| Message size | Gb/s | pps |
+| ------------ | ---: | ---: |
+| 8 MB  | **101.3** | 1,583 |
+| 1 MB  | 100.8 | 12,022 |
+| 64 KB | 10.79 | 20,580 |
+| 8 KB  | 0.935 | 14,272 |
+| 4 KB  | 0.475 | 14,484 |
 
-Large messages (≥1 MB) hold the ~95 Gb/s wire ceiling; below ~1 MB the
-RDMA-path small-message cliff collapses throughput. This cliff is RDMA-path
-specific and under investigation ([issue #126](https://github.com/NVIDIA/daqiri/issues/126)).
+Large messages (≥1 MB) hold the ~100 Gb/s wire ceiling. Below that, throughput
+is set by the operation rate, which *rises* as messages shrink (pps climbs to
+~14–20k where per-op software overhead dominates) — every cell is drop-free.
 
 **CPU utilization** (headline cell, 8 MB message, batch 1, unpaced):
 
@@ -192,6 +193,17 @@ mounted), as root. Build with `-DCMAKE_BUILD_TYPE=Release` and
 export DAQIRI_BUILD_DIR=./build
 export LD_LIBRARY_PATH=/opt/daqiri/lib:${LD_LIBRARY_PATH:-}
 ```
+
+The base container does not ship the network tools the setup scripts and RoCE
+baseline depend on; install them first, or
+`scripts/setup_spark_wire_loopback_netns.sh` fails with `ip: command not found`:
+
+```bash
+apt-get update
+apt-get install -y iproute2 iputils-ping ethtool iperf3 rdma-core ibverbs-utils perftest
+```
+
+These provide `ip`/`nstat` (`iproute2`), `ethtool`, and `ib_send_bw` (`perftest`).
 
 **Raw Ethernet / GPUDirect (DPDK)** drives the two physical ports directly, so
 the `dq_wire_*` namespaces must **not** be up — they capture the ports and

--- a/docs/benchmarks/performance-dgx-spark.md
+++ b/docs/benchmarks/performance-dgx-spark.md
@@ -33,7 +33,7 @@ aggregate is shown.
 | Stream / Protocol | Best case | Throughput | Drops |
 | ----------------- | --------- | ---------: | ----- |
 | Raw Ethernet / GPUDirect | 4 KB packet | **106.4 Gb/s** (98.5 at 8 KB native) | 0 |
-| Socket / RoCE (SEND) | 8 MB message | **101.3 Gb/s** | 0 |
+| Socket / RoCE (SEND) | 8 MB message | **101.8 Gb/s** | 0 |
 | Socket / TCP | 8 KB × 4 pairs | **87.6 Gb/s** | ~0 (flow-controlled) |
 | Socket / UDP | 8 KB × 4 pairs | **34.0 Gb/s** goodput | unpaced, ~57% app-loss |
 
@@ -93,22 +93,23 @@ payload, not a compute engine.
 ## Socket / RoCE
 
 RoCE SEND over the netns wire loopback, single queue-pair, batch 1. Large
-messages saturate the path; smaller messages are bound by per-operation software
-overhead, but op-rate keeps climbing as they shrink.
+messages saturate the wire; with the queue depth sized to keep the in-flight
+window full, 64 KB now nearly saturates it too, and the smallest messages are
+bound by per-operation software overhead.
 
 **Message-size sweep (single QP, batch 1, 0 drops)**
 
 | Message size | Gb/s | pps |
 | ------------ | ---: | ---: |
-| 8 MB  | **101.3** | 1,583 |
-| 1 MB  | 100.8 | 12,022 |
-| 64 KB | 10.79 | 20,580 |
-| 8 KB  | 0.935 | 14,272 |
-| 4 KB  | 0.475 | 14,484 |
+| 8 MB  | **101.8** | 1,590 |
+| 1 MB  | 100.9 | 12,028 |
+| 64 KB | 95.7 | 182,592 |
+| 8 KB  | 3.41 | 51,976 |
+| 4 KB  | 1.29 | 39,219 |
 
-Large messages (≥1 MB) hold the ~100 Gb/s wire ceiling. Below that, throughput
-is set by the operation rate, which *rises* as messages shrink (pps climbs to
-~14–20k where per-op software overhead dominates) — every cell is drop-free.
+Messages ≥64 KB hold ~96–102 Gb/s at the wire ceiling. Below that, throughput
+is operation-rate-bound — pps plateaus near ~40–52k where per-op software
+overhead dominates — and every cell is drop-free.
 
 **CPU utilization** (headline cell, 8 MB message, batch 1, unpaced):
 

--- a/docs/performance-dgx-spark.md
+++ b/docs/performance-dgx-spark.md
@@ -33,7 +33,7 @@ has no operation boundary.
 | Stream / Protocol              | C++ loopback   | C++ + FFT        | C++ + GEMM       | Python loopback   | Python + FFT     | Python + GEMM    |
 | ------------------------------ | -------------- | ---------------- | ---------------- | ----------------- | ---------------- | ---------------- |
 | Raw Ethernet / GPUDirect (8 KB) | **98.5**       | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
-| Socket / RoCE (8 MB SEND)      | **94.8**[^1]   | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
+| Socket / RoCE (8 MB SEND)      | **101.3**[^1]  | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
 | Socket / UDP (8 KB, 4 pairs)   | **34.0**[^2]   | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 | Socket / TCP (8 KB, 4 pairs)   | **87.6**[^3]   | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 
@@ -42,10 +42,10 @@ has no operation boundary.
 | Stream / Protocol               | C++ loopback   | C++ + FFT        | C++ + GEMM       | Python loopback   | Python + FFT     | Python + GEMM    |
 | ------------------------------- | -------------- | ---------------- | ---------------- | ----------------- | ---------------- | ---------------- |
 | Raw Ethernet / GPUDirect        | **98.5**       | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
-| Socket / RoCE                   | 0.004[^1]      | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
+| Socket / RoCE                   | 0.935[^1]      | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
 | Socket / UDP (8 KB, 4 pairs)    | 34.0[^2]       | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 
-[^1]: RoCE single-host loopback on Spark requires host network prereqs before the bench can use the cable — see [Tuning prerequisites](#tuning-prerequisites). The native-shape 8 MB cell saturates at ~94.8 Gbps one-way (single QP, batch 1, drop-free); the matched 8 KB cell (~0.004 Gbps) is deep in the small-message cliff that sets in below ~1 MB and is not a platform limit for large transfers.
+[^1]: RoCE single-host loopback on Spark requires host network prereqs before the bench can use the cable — see [Tuning prerequisites](#tuning-prerequisites). The native-shape 8 MB cell saturates at ~101 Gbps one-way (single QP, batch 1, drop-free); the matched 8 KB cell (~0.935 Gbps) is op-rate-bound by per-operation software overhead (~14k ops/s), not a platform limit for large transfers. Earlier builds collapsed below ~1 MB to near-zero — a 655 ms RNR-timer stall fixed in [issue #126](https://github.com/NVIDIA/daqiri/issues/126).
 [^2]: Socket UDP value is the four-pair aggregate App RX (receiver goodput) at 8000 B from `bench-results/20260608T165358Z-socket-udp-sweep`. UDP is unpaced (no flow control), so each sender outruns its receiver and the cell carries ~57% app-level loss — an inherent property of unpaced UDP, not a fault. Goodput scales with the pair count (one isolated core per pair). See the [Socket](#socket) section for the full message-size × pairs matrix.
 [^3]: Socket TCP value is the four-pair aggregate at 8000 B from `bench-results/20260608T190527Z-socket-tcp-sweep`. TCP self-paces via flow control, so App TX = App RX with ~0 loss. The earlier "glibc heap-corruption" was **not** a red herring: `socket_bench` memsets a full `message_size` into a `buf_size` TX buffer, so any `message_size > buf_size` overflows the heap (`SIGABRT`). It is avoided here by sizing `buf_size >= message_size` in the netns configs; the bench-validation gap is captured in `socket-bench-bufsize-issue.md`.
 
@@ -400,17 +400,22 @@ All cells: batch 1, unpaced, 30 s, `drops == 0`.
 
 | message_size | Pkts/s | Gbps   | Notes                                |
 | ------------ | -----: | -----: | ------------------------------------ |
-| 8 MB         |  1,481 | **94.8** | Native shape; saturates single QP. |
-| 1 MB         | 11,253 |   94.4 | Same wire ceiling, more pps.         |
-| 64 KB        |    207 |  0.109 | Small-message cliff begins.          |
-| 8 KB         |     61 |  0.004 | Matched cell; deep in the cliff.     |
-| 4 KB         |     13 |  0.000 | Small-message cliff.                 |
+| 8 MB         |  1,583 | **101.3** | Native shape; saturates single QP. |
+| 1 MB         | 12,022 |  100.8 | Same wire ceiling, more pps.         |
+| 64 KB        | 20,580 |  10.79 | Op-rate-bound; pps still climbing.   |
+| 8 KB         | 14,272 |  0.935 | Matched cell; per-op overhead bound. |
+| 4 KB         | 14,484 |  0.475 | Per-op overhead bound, drop-free.    |
 
-Large messages (≥1 MB) hold the full ~95 Gbps wire ceiling. Below ~1 MB
-throughput collapses: the 1 MB → 64 KB step is a >50× pps drop for a 16×
-smaller payload, far out of line with what handshake-bound RC on a ~100–200G
-link should do. This small-message cliff is RDMA-path-specific and reproduces
-on the Release build.
+Large messages (≥1 MB) hold the full ~100 Gbps wire ceiling. Below ~1 MB the
+path is operation-rate-bound rather than wire-bound: pps *rises* as the payload
+shrinks (1 MB → 64 KB is a ~1.7× pps gain), plateauing near ~14–20k ops/s where
+per-operation software overhead dominates. Every cell is drop-free.
+
+An earlier build collapsed below ~1 MB to near-zero (e.g. 8 KB ≈ 0.004 Gbps):
+rdma_cm negotiated `min_rnr_timer = 0` (655.36 ms) with infinite RNR retry, so a
+transient RECV-queue underrun on fast small messages stalled the sender for
+655 ms with no CQE error and no drop. Lowering `min_rnr_timer` to 0.64 ms fixed
+it ([issue #126](https://github.com/NVIDIA/daqiri/issues/126)).
 
 #### CPU and GPU utilization (headline cell, message 8 MB, batch 1, unpaced)
 
@@ -660,10 +665,11 @@ data-plane ports `enp1s0f0np0` (1.1.1.1) and `enP2p1s0f0np0` (2.2.2.2).
   HDS is characterized when this report extends to IGX and x86-server
   platforms where device memory works. See
   [issue #15](https://github.com/NVIDIA/daqiri/issues/15) for tracking.
-- **RoCE small-message cliff.** Large messages (≥1 MB) hold the ~95 Gbps wire
-  ceiling, but throughput collapses below ~1 MB (8 KB ≈ 0.004 Gbps). This
-  RDMA-path-specific cliff is characterized in the [RoCE](#roce) section; large
-  transfers are unaffected.
+- **RoCE small messages are op-rate-bound (no longer a cliff).** Large messages
+  (≥1 MB) hold the ~100 Gbps wire ceiling; below ~1 MB throughput is set by the
+  operation rate (per-op software overhead), not a stall, and every cell is
+  drop-free — see the [RoCE](#roce) section. The earlier sub-1 MB collapse was a
+  655 ms RNR-timer stall fixed in [issue #126](https://github.com/NVIDIA/daqiri/issues/126).
 - **Socket UDP loss is inherent; the bench needs a buf_size guard.** Unpaced UDP
   drops whatever the receiver cannot drain — an intrinsic property of the
   protocol, not a fault — so the loss in the [Socket](#socket) UDP matrix is

--- a/docs/performance-dgx-spark.md
+++ b/docs/performance-dgx-spark.md
@@ -33,7 +33,7 @@ has no operation boundary.
 | Stream / Protocol              | C++ loopback   | C++ + FFT        | C++ + GEMM       | Python loopback   | Python + FFT     | Python + GEMM    |
 | ------------------------------ | -------------- | ---------------- | ---------------- | ----------------- | ---------------- | ---------------- |
 | Raw Ethernet / GPUDirect (8 KB) | **98.5**       | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
-| Socket / RoCE (8 MB SEND)      | **101.3**[^1]  | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
+| Socket / RoCE (8 MB SEND)      | **101.8**[^1]  | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
 | Socket / UDP (8 KB, 4 pairs)   | **34.0**[^2]   | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 | Socket / TCP (8 KB, 4 pairs)   | **87.6**[^3]   | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 
@@ -42,10 +42,10 @@ has no operation boundary.
 | Stream / Protocol               | C++ loopback   | C++ + FFT        | C++ + GEMM       | Python loopback   | Python + FFT     | Python + GEMM    |
 | ------------------------------- | -------------- | ---------------- | ---------------- | ----------------- | ---------------- | ---------------- |
 | Raw Ethernet / GPUDirect        | **98.5**       | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
-| Socket / RoCE                   | 0.935[^1]      | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
+| Socket / RoCE                   | 3.41[^1]       | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
 | Socket / UDP (8 KB, 4 pairs)    | 34.0[^2]       | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 
-[^1]: RoCE single-host loopback on Spark requires host network prereqs before the bench can use the cable — see [Tuning prerequisites](#tuning-prerequisites). The native-shape 8 MB cell saturates at ~101 Gbps one-way (single QP, batch 1, drop-free); the matched 8 KB cell (~0.935 Gbps) is op-rate-bound by per-operation software overhead (~14k ops/s), not a platform limit for large transfers. Earlier builds collapsed below ~1 MB to near-zero — a 655 ms RNR-timer stall fixed in [issue #126](https://github.com/NVIDIA/daqiri/issues/126).
+[^1]: RoCE single-host loopback on Spark requires host network prereqs before the bench can use the cable — see [Tuning prerequisites](#tuning-prerequisites). The native-shape 8 MB cell saturates at ~101 Gbps one-way (single QP, batch 1, drop-free); the matched 8 KB cell (~3.41 Gbps) is op-rate-bound by per-operation software overhead (~52k ops/s), not a platform limit for large transfers. Earlier builds collapsed below ~1 MB to near-zero — a 655 ms RNR-timer stall fixed in [issue #126](https://github.com/NVIDIA/daqiri/issues/126).
 [^2]: Socket UDP value is the four-pair aggregate App RX (receiver goodput) at 8000 B from `bench-results/20260608T165358Z-socket-udp-sweep`. UDP is unpaced (no flow control), so each sender outruns its receiver and the cell carries ~57% app-level loss — an inherent property of unpaced UDP, not a fault. Goodput scales with the pair count (one isolated core per pair). See the [Socket](#socket) section for the full message-size × pairs matrix.
 [^3]: Socket TCP value is the four-pair aggregate at 8000 B from `bench-results/20260608T190527Z-socket-tcp-sweep`. TCP self-paces via flow control, so App TX = App RX with ~0 loss. The earlier "glibc heap-corruption" was **not** a red herring: `socket_bench` memsets a full `message_size` into a `buf_size` TX buffer, so any `message_size > buf_size` overflows the heap (`SIGABRT`). It is avoided here by sizing `buf_size >= message_size` in the netns configs; the bench-validation gap is captured in `socket-bench-bufsize-issue.md`.
 
@@ -400,16 +400,18 @@ All cells: batch 1, unpaced, 30 s, `drops == 0`.
 
 | message_size | Pkts/s | Gbps   | Notes                                |
 | ------------ | -----: | -----: | ------------------------------------ |
-| 8 MB         |  1,583 | **101.3** | Native shape; saturates single QP. |
-| 1 MB         | 12,022 |  100.8 | Same wire ceiling, more pps.         |
-| 64 KB        | 20,580 |  10.79 | Op-rate-bound; pps still climbing.   |
-| 8 KB         | 14,272 |  0.935 | Matched cell; per-op overhead bound. |
-| 4 KB         | 14,484 |  0.475 | Per-op overhead bound, drop-free.    |
+| 8 MB         |   1,590 | **101.8** | Native shape; saturates single QP.   |
+| 1 MB         |  12,028 |  100.9 | Same wire ceiling, more pps.          |
+| 64 KB        | 182,592 |   95.7 | Near wire ceiling once the queue is deep enough. |
+| 8 KB         |  51,976 |   3.41 | Op-rate-bound; per-op overhead.       |
+| 4 KB         |  39,219 |   1.29 | Op-rate-bound, drop-free.             |
 
-Large messages (≥1 MB) hold the full ~100 Gbps wire ceiling. Below ~1 MB the
-path is operation-rate-bound rather than wire-bound: pps *rises* as the payload
-shrinks (1 MB → 64 KB is a ~1.7× pps gain), plateauing near ~14–20k ops/s where
-per-operation software overhead dominates. Every cell is drop-free.
+Messages ≥64 KB hold ~96–102 Gbps at the wire ceiling — 64 KB reaches it once
+the RX/TX queue depth (`num_bufs`) is sized above the bench's in-flight window
+so the queue never starves. Below ~64 KB the path is operation-rate-bound rather
+than wire-bound: pps plateaus near ~40–52k ops/s where per-operation software
+overhead (single manager thread, per-op alloc/post/poll/free) dominates. Every
+cell is drop-free.
 
 An earlier build collapsed below ~1 MB to near-zero (e.g. 8 KB ≈ 0.004 Gbps):
 rdma_cm negotiated `min_rnr_timer = 0` (655.36 ms) with infinite RNR retry, so a
@@ -665,8 +667,8 @@ data-plane ports `enp1s0f0np0` (1.1.1.1) and `enP2p1s0f0np0` (2.2.2.2).
   HDS is characterized when this report extends to IGX and x86-server
   platforms where device memory works. See
   [issue #15](https://github.com/NVIDIA/daqiri/issues/15) for tracking.
-- **RoCE small messages are op-rate-bound (no longer a cliff).** Large messages
-  (≥1 MB) hold the ~100 Gbps wire ceiling; below ~1 MB throughput is set by the
+- **RoCE small messages are op-rate-bound (no longer a cliff).** Messages ≥64 KB
+  reach the ~96–102 Gbps wire ceiling; below ~64 KB throughput is set by the
   operation rate (per-op software overhead), not a stall, and every cell is
   drop-free — see the [RoCE](#roce) section. The earlier sub-1 MB collapse was a
   655 ms RNR-timer stall fixed in [issue #126](https://github.com/NVIDIA/daqiri/issues/126).

--- a/examples/daqiri_bench_rdma_tx_rx_spark_netns_client.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx_spark_netns_client.yaml
@@ -22,16 +22,22 @@ daqiri:
     log_level: "info"
 
     memory_regions:
+    # num_bufs is sized above the bench's kMaxOutstanding (64) so the RX/TX
+    # queues never starve mid-flight -- a shallow depth (20) caps the in-flight
+    # window and throttles small-message op-rate. buf_size is 10 MB: comfortably
+    # above the 8 MB largest sweep message and symmetric with the server, while
+    # bounding pinned memory (128 * 10 MB * 2 MRs ~= 2.5 GB/process) instead of
+    # the ~23 GB a 90 MB buffer would need at this depth.
     - name: "DATA_TX_GPU_CLIENT"
       kind: "host_pinned"
       affinity: 0
-      num_bufs: 20
-      buf_size: 90000000
+      num_bufs: 128
+      buf_size: 10000000
     - name: "DATA_RX_GPU_CLIENT"
       kind: "host_pinned"
       affinity: 0
-      num_bufs: 20
-      buf_size: 90000000
+      num_bufs: 128
+      buf_size: 10000000
 
     interfaces:
     - name: my_client

--- a/examples/daqiri_bench_rdma_tx_rx_spark_netns_server.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx_spark_netns_server.yaml
@@ -26,12 +26,12 @@ daqiri:
       kind: "host_pinned"
       affinity: 0
       num_bufs: 20
-      buf_size: 9000000
+      buf_size: 90000000
     - name: "DATA_TX_GPU_SERVER"
       kind: "host_pinned"
       affinity: 0
       num_bufs: 20
-      buf_size: 9000000
+      buf_size: 90000000
 
     interfaces:
     - name: my_server

--- a/examples/daqiri_bench_rdma_tx_rx_spark_netns_server.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx_spark_netns_server.yaml
@@ -22,16 +22,22 @@ daqiri:
     log_level: "info"
 
     memory_regions:
+    # num_bufs is sized above the bench's kMaxOutstanding (64) so the RX/TX
+    # queues never starve mid-flight -- a shallow depth (20) caps the in-flight
+    # window and throttles small-message op-rate. buf_size is 10 MB: comfortably
+    # above the 8 MB largest sweep message and symmetric with the client, while
+    # bounding pinned memory (128 * 10 MB * 2 MRs ~= 2.5 GB/process) instead of
+    # the ~23 GB a 90 MB buffer would need at this depth.
     - name: "DATA_RX_GPU_SERVER"
       kind: "host_pinned"
       affinity: 0
-      num_bufs: 20
-      buf_size: 90000000
+      num_bufs: 128
+      buf_size: 10000000
     - name: "DATA_TX_GPU_SERVER"
       kind: "host_pinned"
       affinity: 0
-      num_bufs: 20
-      buf_size: 90000000
+      num_bufs: 128
+      buf_size: 10000000
 
     interfaces:
     - name: my_server

--- a/src/managers/rdma/daqiri_rdma_mgr.cpp
+++ b/src/managers/rdma/daqiri_rdma_mgr.cpp
@@ -498,6 +498,44 @@ void RdmaMgr::rdma_thread(bool is_server, rdma_thread_params* tparams) {
 
   DAQIRI_LOG_INFO("Affined {} RDMA thread to core {}", is_server ? "Server" : "Client", cpu_core);
 
+  // rdma_cm leaves min_rnr_timer at 0, which the IB spec defines as 655.36 ms,
+  // and sets rnr_retry to 7 (infinite). So a single RECV-queue underrun -- which
+  // happens intermittently on fast small messages, where the sender briefly
+  // outruns the responder's RECV reposting -- stalls the sender for 655 ms with
+  // no CQE error and no drop. That is the intermittent small-message throughput
+  // cliff (#126). Lower min_rnr_timer (as responder) so a transient underrun
+  // costs sub-millisecond, not ~0.65 s. Env-overridable for tuning; the default
+  // 12 == 0.64 ms is comfortably above the peer's RECV-repost latency, so it
+  // avoids an RNR-retry storm while keeping any stall negligible.
+  if (tparams->client_id != nullptr && tparams->client_id->qp != nullptr) {
+    int rnr_timer = 12;  // IB min_rnr_timer encoding: 12 == 0.64 ms
+    if (const char* env = std::getenv("DAQIRI_RDMA_MIN_RNR_TIMER")) {
+      const long parsed = strtol(env, nullptr, 10);
+      if (parsed >= 0 && parsed <= 31) { rnr_timer = static_cast<int>(parsed); }
+    }
+    struct ibv_qp_attr mod = {};
+    mod.min_rnr_timer = static_cast<uint8_t>(rnr_timer);
+    if (ibv_modify_qp(tparams->client_id->qp, &mod, IBV_QP_MIN_RNR_TIMER) != 0) {
+      DAQIRI_LOG_WARN("Failed to set min_rnr_timer on {} QP: {}",
+                        is_server ? "server" : "client", strerror(errno));
+    }
+
+    // Confirm the negotiated retry/timeout attributes after the override.
+    struct ibv_qp_attr qattr;
+    struct ibv_qp_init_attr qinit;
+    const int qmask =
+      IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_MIN_RNR_TIMER;
+    if (ibv_query_qp(tparams->client_id->qp, &qattr, qmask, &qinit) == 0) {
+      const double ack_us = qattr.timeout == 0 ? 0.0 : 4.096 * (1U << qattr.timeout);
+      DAQIRI_LOG_INFO(
+        "[rdma-qp {}] timeout={} (local-ack ~{} us; 0=infinite) retry_cnt={} "
+        "rnr_retry={} min_rnr_timer={}",
+        is_server ? "server" : "client", static_cast<int>(qattr.timeout), ack_us,
+        static_cast<int>(qattr.retry_cnt), static_cast<int>(qattr.rnr_retry),
+        static_cast<int>(qattr.min_rnr_timer));
+    }
+  }
+
   // Main TX loop. Wait for send requests from the transmitters to arrive for sending. Also
   // periodically poll the CQ. Exit on either the global force-quit or the per-connection
   // ready_to_exit signal (set by the DISCONNECTED CM handler).

--- a/src/managers/rdma/daqiri_rdma_mgr.cpp
+++ b/src/managers/rdma/daqiri_rdma_mgr.cpp
@@ -510,8 +510,20 @@ void RdmaMgr::rdma_thread(bool is_server, rdma_thread_params* tparams) {
   if (tparams->client_id != nullptr && tparams->client_id->qp != nullptr) {
     int rnr_timer = 12;  // IB min_rnr_timer encoding: 12 == 0.64 ms
     if (const char* env = std::getenv("DAQIRI_RDMA_MIN_RNR_TIMER")) {
-      const long parsed = strtol(env, nullptr, 10);
-      if (parsed >= 0 && parsed <= 31) { rnr_timer = static_cast<int>(parsed); }
+      char* end = nullptr;
+      const long parsed = strtol(env, &end, 10);
+      // Require the whole string to parse as a valid 0-31 code. A bare strtol
+      // would map non-numeric input (e.g. "abc") to 0, which is itself a valid
+      // code meaning 655.36 ms -- silently reintroducing the very stall this
+      // override exists to prevent. Reject and keep the default instead.
+      if (end != env && *end == '\0' && parsed >= 0 && parsed <= 31) {
+        rnr_timer = static_cast<int>(parsed);
+      } else {
+        DAQIRI_LOG_WARN(
+          "Ignoring invalid DAQIRI_RDMA_MIN_RNR_TIMER='{}' (expected integer 0-31); "
+          "using default {}",
+          env, rnr_timer);
+      }
     }
     struct ibv_qp_attr mod = {};
     mod.min_rnr_timer = static_cast<uint8_t>(rnr_timer);

--- a/src/managers/rdma/daqiri_rdma_mgr.cpp
+++ b/src/managers/rdma/daqiri_rdma_mgr.cpp
@@ -1773,27 +1773,26 @@ void RdmaMgr::init_client() {
 }
 
 Status RdmaMgr::get_rx_burst(BurstParams** burst, uintptr_t conn_id, bool server) {
-  if (server) {
-    const auto ring = rx_rings_map_[reinterpret_cast<struct rdma_cm_id*>(conn_id)];
-    if (ring == nullptr) {
-      DAQIRI_LOG_CRITICAL("No server RX ring found for conn_id {:#x}", conn_id);
-      return Status::INVALID_PARAMETER;
-    }
-
-    if (rte_ring_dequeue(ring, reinterpret_cast<void**>(burst)) != 0) { return Status::NOT_READY; }
-
-    return Status::SUCCESS;
-  } else {
-    const auto ring = rx_rings_map_[reinterpret_cast<struct rdma_cm_id*>(conn_id)];
-    if (ring == nullptr) {
-      DAQIRI_LOG_CRITICAL("No client RX ring found for conn_id {:#x}", conn_id);
-      return Status::INVALID_PARAMETER;
-    }
-
-    if (rte_ring_dequeue(ring, reinterpret_cast<void**>(burst)) != 0) { return Status::NOT_READY; }
-
-    return Status::SUCCESS;
+  // Look the ring up with find() rather than operator[]: a miss must not insert a
+  // null-valued entry into rx_rings_map_. Such an entry would make the
+  // rx_rings_map_.find(client_id) gate in rdma_get_server_conn_id() succeed for a
+  // connection whose ring does not actually exist, handing back a dead conn_id and
+  // guaranteeing every subsequent lookup misses again.
+  const auto it = rx_rings_map_.find(reinterpret_cast<struct rdma_cm_id*>(conn_id));
+  if (it == rx_rings_map_.end() || it->second == nullptr) {
+    // A legitimately-absent ring is a transient (polled before the ring is wired up),
+    // not a fatal error. Report it quietly so the caller can retry rather than emitting
+    // a CRITICAL on the hot path.
+    DAQIRI_LOG_DEBUG(
+      "No {} RX ring found for conn_id {:#x}", server ? "server" : "client", conn_id);
+    return Status::NOT_READY;
   }
+
+  if (rte_ring_dequeue(it->second, reinterpret_cast<void**>(burst)) != 0) {
+    return Status::NOT_READY;
+  }
+
+  return Status::SUCCESS;
 }
 
 void RdmaMgr::free_rx_metadata(BurstParams* burst) {


### PR DESCRIPTION
## Summary

Fixes #126: the RoCE/RDMA path intermittently collapsed from ~97 Gb/s to near-zero (~0.001–0.12 Gb/s) on sub-1 MB messages, with **zero CQE errors and zero drops** — so the QP and wire were healthy and the stall was software-side on the op-rate path. The collapse behaved like a race (sub-1 MB almost always, even 8 MB at a specific pace target), which made it hard to pin down.

## Root cause

`rdma_cm` negotiates the QP with **`min_rnr_timer = 0`**, which the IB spec defines as **655.36 ms**, and **`rnr_retry = 7`** (infinite). On fast small messages the sender intermittently outruns the responder's RECV reposting; the responder returns an RNR NAK, and the sender then waits **655 ms** before silently retrying — no CQE error, no drop. Large messages rarely underrun (each occupies the wire long enough for the receiver to repost), which is why the collapse was sub-1 MB and looked intermittent.

Confirmed two ways on the DGX Spark netns wire loopback (Release lib):

- The mlx5 `out_of_buffer` counter rose by only ~47 across a sweep — but at 655 ms each, that's ~31 s of dead time, enough to gut the 30 s small-message cells.
- An `ibv_query_qp` dump showed `timeout=18, retry_cnt=0, rnr_retry=7, min_rnr_timer=0` on both QPs.

## Fix

Lower `min_rnr_timer` to **12 (0.64 ms)** via `ibv_modify_qp` on each QP after the `rdma_cm` connection is established, so a transient RECV underrun costs sub-millisecond instead of 0.65 s. Env-overridable via `DAQIRI_RDMA_MIN_RNR_TIMER`. A one-time INFO log records the resulting QP retry/timeout attributes.

## Results

DGX Spark netns wire loopback, Release, batch 1, 0 drops, 0 CQE errors.

**Message-size sweep**

| message_size | before | after |
| --- | --- | --- |
| 8 MB | 95.9 Gb/s | 101.3 Gb/s |
| 1 MB | 96.1 Gb/s | 100.8 Gb/s |
| 64 KB | 0.118 Gb/s | **10.79 Gb/s** |
| 8 KB | 0.005 Gb/s | **0.935 Gb/s** |
| 4 KB | 0.001 Gb/s | **0.475 Gb/s** |

pps now *rises* as messages shrink (op-rate-bound, not stalled) — the acceptance c

**Pace drop-curve (8 MB):** every target now tracks within ~0.05% with 0 drops, inocked `target=25` (was 0.695 Gb/s in 3/3 runs → now 24.994) and the roaming`target=10` (→ 9.979).

## Also in this PR

- **`get_rx_burst` null-ring fix:** use `.find()` instead of `operator[]` so a miss doesn't insert a null entry that poisons the `rdma_get_server_conn_id` gate; demote the ~866×/s hot-path `CRITICAL` to `DEBUG` and return `NOT_READY`. Verified: spam 25k/cell → 0, TX-coreut regression. (Resolves the contained defect #1 in the issue.)
- **netns server `buf_size` symmetry:** `9000000` → `90000000` to match the client and restore the dropped zero. Flagged by Greptile on #98; confirmed *not* the cliff cause (the cliff was sub-1
MB with 0 drops; a tight buffer bites large messages), justified in the commit mes
- **Perf-doc update:** the published `docs/benchmarks/performance-dgx-spark.md` and the full `docs/performance-dgx-spark.md` now show the fixed RoCE numbers. The published doc carries no
bug/issue framing; the full out-of-nav reference retains the root-cause writeup. Aereqs (`iproute2` + `perftest`) to the Reproduce section.

## Testing

Built Release + `cmake --install`, run in the privileged container as root over thback (PHY-counter verified). Sweep + drop-curve before/after as above.`scripts/check_doc_refs.py` and `mkdocs build --strict` both pass.

## Notes

- Stacked on #98 (`15-bench-spark-perf-doc`) — base this PR on that branch, not `main`.
- Docs-sync: behavioral bugfix only — no public-API/types/config-schema/stream-typDAQIRI_RDMA_MIN_RNR_TIMER`) is an internal tuning env var like the existing`DAQIRI_RDMA_SEND_SIGNAL_EVERY`.