### PR TITLE
#126 - Deepen RoCE netns queue depth for small-message throughput

### DIFF
--- a/docs/benchmarks/performance-dgx-spark.md
+++ b/docs/benchmarks/performance-dgx-spark.md
@@ -33,7 +33,7 @@ aggregate is shown.
 | Stream / Protocol | Best case | Throughput | Drops |
 | ----------------- | --------- | ---------: | ----- |
 | Raw Ethernet / GPUDirect | 4 KB packet | **106.4 Gb/s** (98.5 at 8 KB native) | 0 |
-| Socket / RoCE (SEND) | 8 MB message | **101.3 Gb/s** | 0 |
+| Socket / RoCE (SEND) | 8 MB message | **101.8 Gb/s** | 0 |
 | Socket / TCP | 8 KB × 4 pairs | **87.6 Gb/s** | ~0 (flow-controlled) |
 | Socket / UDP | 8 KB × 4 pairs | **34.0 Gb/s** goodput | unpaced, ~57% app-loss |
 
@@ -93,22 +93,23 @@ payload, not a compute engine.
 ## Socket / RoCE
 
 RoCE SEND over the netns wire loopback, single queue-pair, batch 1. Large
-messages saturate the path; smaller messages are bound by per-operation software
-overhead, but op-rate keeps climbing as they shrink.
+messages saturate the wire; with the queue depth sized to keep the in-flight
+window full, 64 KB now nearly saturates it too, and the smallest messages are
+bound by per-operation software overhead.
 
 **Message-size sweep (single QP, batch 1, 0 drops)**
 
 | Message size | Gb/s | pps |
 | ------------ | ---: | ---: |
-| 8 MB  | **101.3** | 1,583 |
-| 1 MB  | 100.8 | 12,022 |
-| 64 KB | 10.79 | 20,580 |
-| 8 KB  | 0.935 | 14,272 |
-| 4 KB  | 0.475 | 14,484 |
+| 8 MB  | **101.8** | 1,590 |
+| 1 MB  | 100.9 | 12,028 |
+| 64 KB | 95.7 | 182,592 |
+| 8 KB  | 3.41 | 51,976 |
+| 4 KB  | 1.29 | 39,219 |
 
-Large messages (≥1 MB) hold the ~100 Gb/s wire ceiling. Below that, throughput
-is set by the operation rate, which *rises* as messages shrink (pps climbs to
-~14–20k where per-op software overhead dominates) — every cell is drop-free.
+Messages ≥64 KB hold ~96–102 Gb/s at the wire ceiling. Below that, throughput
+is operation-rate-bound — pps plateaus near ~40–52k where per-op software
+overhead dominates — and every cell is drop-free.
 
 **CPU utilization** (headline cell, 8 MB message, batch 1, unpaced):
 

--- a/docs/performance-dgx-spark.md
+++ b/docs/performance-dgx-spark.md
@@ -33,7 +33,7 @@ has no operation boundary.
 | Stream / Protocol              | C++ loopback   | C++ + FFT        | C++ + GEMM       | Python loopback   | Python + FFT     | Python + GEMM    |
 | ------------------------------ | -------------- | ---------------- | ---------------- | ----------------- | ---------------- | ---------------- |
 | Raw Ethernet / GPUDirect (8 KB) | **98.5**       | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
-| Socket / RoCE (8 MB SEND)      | **101.3**[^1]  | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
+| Socket / RoCE (8 MB SEND)      | **101.8**[^1]  | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
 | Socket / UDP (8 KB, 4 pairs)   | **34.0**[^2]   | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 | Socket / TCP (8 KB, 4 pairs)   | **87.6**[^3]   | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 
@@ -42,10 +42,10 @@ has no operation boundary.
 | Stream / Protocol               | C++ loopback   | C++ + FFT        | C++ + GEMM       | Python loopback   | Python + FFT     | Python + GEMM    |
 | ------------------------------- | -------------- | ---------------- | ---------------- | ----------------- | ---------------- | ---------------- |
 | Raw Ethernet / GPUDirect        | **98.5**       | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
-| Socket / RoCE                   | 0.935[^1]      | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
+| Socket / RoCE                   | 3.41[^1]       | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ | _TBD (follow-up)_ |
 | Socket / UDP (8 KB, 4 pairs)    | 34.0[^2]       | n/a              | n/a              | _TBD (follow-up)_ | n/a              | n/a              |
 
-[^1]: RoCE single-host loopback on Spark requires host network prereqs before the bench can use the cable — see [Tuning prerequisites](#tuning-prerequisites). The native-shape 8 MB cell saturates at ~101 Gbps one-way (single QP, batch 1, drop-free); the matched 8 KB cell (~0.935 Gbps) is op-rate-bound by per-operation software overhead (~14k ops/s), not a platform limit for large transfers. Earlier builds collapsed below ~1 MB to near-zero — a 655 ms RNR-timer stall fixed in [issue #126](https://github.com/NVIDIA/daqiri/issues/126).
+[^1]: RoCE single-host loopback on Spark requires host network prereqs before the bench can use the cable — see [Tuning prerequisites](#tuning-prerequisites). The native-shape 8 MB cell saturates at ~101 Gbps one-way (single QP, batch 1, drop-free); the matched 8 KB cell (~3.41 Gbps) is op-rate-bound by per-operation software overhead (~52k ops/s), not a platform limit for large transfers. Earlier builds collapsed below ~1 MB to near-zero — a 655 ms RNR-timer stall fixed in [issue #126](https://github.com/NVIDIA/daqiri/issues/126).
 [^2]: Socket UDP value is the four-pair aggregate App RX (receiver goodput) at 8000 B from `bench-results/20260608T165358Z-socket-udp-sweep`. UDP is unpaced (no flow control), so each sender outruns its receiver and the cell carries ~57% app-level loss — an inherent property of unpaced UDP, not a fault. Goodput scales with the pair count (one isolated core per pair). See the [Socket](#socket) section for the full message-size × pairs matrix.
 [^3]: Socket TCP value is the four-pair aggregate at 8000 B from `bench-results/20260608T190527Z-socket-tcp-sweep`. TCP self-paces via flow control, so App TX = App RX with ~0 loss. The earlier "glibc heap-corruption" was **not** a red herring: `socket_bench` memsets a full `message_size` into a `buf_size` TX buffer, so any `message_size > buf_size` overflows the heap (`SIGABRT`). It is avoided here by sizing `buf_size >= message_size` in the netns configs; the bench-validation gap is captured in `socket-bench-bufsize-issue.md`.
 
@@ -400,16 +400,18 @@ All cells: batch 1, unpaced, 30 s, `drops == 0`.
 
 | message_size | Pkts/s | Gbps   | Notes                                |
 | ------------ | -----: | -----: | ------------------------------------ |
-| 8 MB         |  1,583 | **101.3** | Native shape; saturates single QP. |
-| 1 MB         | 12,022 |  100.8 | Same wire ceiling, more pps.         |
-| 64 KB        | 20,580 |  10.79 | Op-rate-bound; pps still climbing.   |
-| 8 KB         | 14,272 |  0.935 | Matched cell; per-op overhead bound. |
-| 4 KB         | 14,484 |  0.475 | Per-op overhead bound, drop-free.    |
+| 8 MB         |   1,590 | **101.8** | Native shape; saturates single QP.   |
+| 1 MB         |  12,028 |  100.9 | Same wire ceiling, more pps.          |
+| 64 KB        | 182,592 |   95.7 | Near wire ceiling once the queue is deep enough. |
+| 8 KB         |  51,976 |   3.41 | Op-rate-bound; per-op overhead.       |
+| 4 KB         |  39,219 |   1.29 | Op-rate-bound, drop-free.             |
 
-Large messages (≥1 MB) hold the full ~100 Gbps wire ceiling. Below ~1 MB the
-path is operation-rate-bound rather than wire-bound: pps *rises* as the payload
-shrinks (1 MB → 64 KB is a ~1.7× pps gain), plateauing near ~14–20k ops/s where
-per-operation software overhead dominates. Every cell is drop-free.
+Messages ≥64 KB hold ~96–102 Gbps at the wire ceiling — 64 KB reaches it once
+the RX/TX queue depth (`num_bufs`) is sized above the bench's in-flight window
+so the queue never starves. Below ~64 KB the path is operation-rate-bound rather
+than wire-bound: pps plateaus near ~40–52k ops/s where per-operation software
+overhead (single manager thread, per-op alloc/post/poll/free) dominates. Every
+cell is drop-free.
 
 An earlier build collapsed below ~1 MB to near-zero (e.g. 8 KB ≈ 0.004 Gbps):
 rdma_cm negotiated `min_rnr_timer = 0` (655.36 ms) with infinite RNR retry, so a
@@ -665,8 +667,8 @@ data-plane ports `enp1s0f0np0` (1.1.1.1) and `enP2p1s0f0np0` (2.2.2.2).
   HDS is characterized when this report extends to IGX and x86-server
   platforms where device memory works. See
   [issue #15](https://github.com/NVIDIA/daqiri/issues/15) for tracking.
-- **RoCE small messages are op-rate-bound (no longer a cliff).** Large messages
-  (≥1 MB) hold the ~100 Gbps wire ceiling; below ~1 MB throughput is set by the
+- **RoCE small messages are op-rate-bound (no longer a cliff).** Messages ≥64 KB
+  reach the ~96–102 Gbps wire ceiling; below ~64 KB throughput is set by the
   operation rate (per-op software overhead), not a stall, and every cell is
   drop-free — see the [RoCE](#roce) section. The earlier sub-1 MB collapse was a
   655 ms RNR-timer stall fixed in [issue #126](https://github.com/NVIDIA/daqiri/issues/126).

--- a/examples/daqiri_bench_rdma_tx_rx_spark_netns_client.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx_spark_netns_client.yaml
@@ -22,16 +22,22 @@ daqiri:
     log_level: "info"
 
     memory_regions:
+    # num_bufs is sized above the bench's kMaxOutstanding (64) so the RX/TX
+    # queues never starve mid-flight -- a shallow depth (20) caps the in-flight
+    # window and throttles small-message op-rate. buf_size is 10 MB: comfortably
+    # above the 8 MB largest sweep message and symmetric with the server, while
+    # bounding pinned memory (128 * 10 MB * 2 MRs ~= 2.5 GB/process) instead of
+    # the ~23 GB a 90 MB buffer would need at this depth.
     - name: "DATA_TX_GPU_CLIENT"
       kind: "host_pinned"
       affinity: 0
-      num_bufs: 20
-      buf_size: 90000000
+      num_bufs: 128
+      buf_size: 10000000
     - name: "DATA_RX_GPU_CLIENT"
       kind: "host_pinned"
       affinity: 0
-      num_bufs: 20
-      buf_size: 90000000
+      num_bufs: 128
+      buf_size: 10000000
 
     interfaces:
     - name: my_client

--- a/examples/daqiri_bench_rdma_tx_rx_spark_netns_server.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx_spark_netns_server.yaml
@@ -22,16 +22,22 @@ daqiri:
     log_level: "info"
 
     memory_regions:
+    # num_bufs is sized above the bench's kMaxOutstanding (64) so the RX/TX
+    # queues never starve mid-flight -- a shallow depth (20) caps the in-flight
+    # window and throttles small-message op-rate. buf_size is 10 MB: comfortably
+    # above the 8 MB largest sweep message and symmetric with the client, while
+    # bounding pinned memory (128 * 10 MB * 2 MRs ~= 2.5 GB/process) instead of
+    # the ~23 GB a 90 MB buffer would need at this depth.
     - name: "DATA_RX_GPU_SERVER"
       kind: "host_pinned"
       affinity: 0
-      num_bufs: 20
-      buf_size: 90000000
+      num_bufs: 128
+      buf_size: 10000000
     - name: "DATA_TX_GPU_SERVER"
       kind: "host_pinned"
       affinity: 0
-      num_bufs: 20
-      buf_size: 90000000
+      num_bufs: 128
+      buf_size: 10000000
 
     interfaces:
     - name: my_server


### PR DESCRIPTION
Follow-up to the #126 RNR-timer fix. With the 655 ms stall gone, the RoCE small-message op-rate was still capped by a shallow RX/TX queue: the netns bench YAMLs set num_bufs=20, well below the bench's kMaxOutstanding=64, so the in-flight window pinned at 20 and 64 KB never reached line rate.

Raise num_bufs to 128 (above the 64-deep in-flight window) on both server and client memory regions, and set buf_size to 10 MB -- still above the 8 MB largest sweep message and symmetric on both sides, while bounding pinned memory to ~2.5 GB/process (128 * 10 MB * 2 MRs) instead of ~23 GB at the prior 90 MB.

Measured on the DGX Spark netns wire loopback (Release, batch 1, 0 drops, min_rnr_timer=12 default):
  64 KB: 10.79 -> 95.7 Gb/s (20,580 -> 182,592 pps; now near line rate)
   8 KB: 0.935 -> 3.41 Gb/s (14,272 -> 51,976 pps)
   4 KB: 0.475 -> 1.29 Gb/s (14,484 -> 39,219 pps)
Large messages are unchanged (8 MB ~101.8, 1 MB ~100.9 Gb/s -- wire-bound, so queue depth doesn't affect them). Both perf docs updated to match.