### PR TITLE
#1497 - Port queue-specific DPDK RX flush

### DIFF
--- a/src/managers/dpdk/daqiri_dpdk_mgr.cpp
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.cpp
@@ -3523,16 +3523,14 @@ void DpdkMgr::run() {
 ///  \brief
 ///
 ////////////////////////////////////////////////////////////////////////////////
-void DpdkMgr::flush_packets(int port) {
-  struct rte_mbuf* rx_mbuf;
-  DAQIRI_LOG_INFO("Flushing packet on port {}", port);
-  while (rte_eth_rx_burst(port, 0, &rx_mbuf, 1) != 0) { rte_pktmbuf_free(rx_mbuf); }
-}
-
-void DpdkMgr::flush_port_queue(int port, int queue) {
+void DpdkMgr::flush_port_queue_impl(int port, int queue) {
   struct rte_mbuf* rx_mbuf;
   DAQIRI_LOG_INFO("Flushing packets on port {} queue {}", port, queue);
   while (rte_eth_rx_burst(port, queue, &rx_mbuf, 1) != 0) { rte_pktmbuf_free(rx_mbuf); }
+}
+
+void DpdkMgr::flush_port_queue(int port, int queue) {
+  flush_port_queue_impl(port, queue);
 }
 
 /*
@@ -3583,6 +3581,10 @@ int DpdkMgr::rx_core_multi_q_worker(void* arg) {
   };
 
   update_cur_idx();
+
+  for (const auto& pq : tparams->q_params) {
+    flush_port_queue_impl(pq.port, pq.queue);
+  }
 
   //
   //  run loop
@@ -3739,7 +3741,7 @@ int DpdkMgr::rx_core_worker(void* arg) {
   uint64_t last_cycles = rte_get_tsc_cycles();
   uint64_t total_pkts = 0;
 
-  flush_packets(tparams->port);
+  flush_port_queue_impl(tparams->port, tparams->queue);
   struct rte_mbuf* mbuf_arr[DEFAULT_NUM_RX_BURST];
 
   DAQIRI_LOG_INFO("Starting RX Core {}, port {}, queue {}, socket {}",

--- a/src/managers/dpdk/daqiri_dpdk_mgr.h
+++ b/src/managers/dpdk/daqiri_dpdk_mgr.h
@@ -157,7 +157,7 @@ class DpdkMgr : public Manager {
   static int tx_core_worker(void* arg);
   static int rx_lb_worker(void* arg);
   static int tx_lb_worker(void* arg);
-  static void flush_packets(int port);
+  static void flush_port_queue_impl(int port, int queue);
   bool setup_rx_timestamp_dynfield();
   bool setup_tx_timestamp_dynfield();
   bool calibrate_rx_timestamp_clock(uint16_t port_id);


### PR DESCRIPTION
Port the RX startup flush fix from nvidia-holoscan/holohub#1497 so DPDK workers drain the actual assigned queue instead of hardcoding queue 0.

May fix #141 