### PR TITLE
Pin example app threads from config

### DIFF
--- a/docs/benchmarks/raw_benchmarking.md
+++ b/docs/benchmarks/raw_benchmarking.md
@@ -55,6 +55,8 @@ docker run --rm -it --privileged \
     - [`daqiri_bench_raw_tx_rx_spark.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_raw_tx_rx_spark.yaml) for `daqiri_bench_raw_gpudirect` — still set `eth_dst_addr` to the RX MAC. The rx_port is `0002:01:00.1` (physical port p1), so read its MAC: `cat /sys/class/net/enP2p1s0f1np1/address`. This p0-to-p1 pairing is intentional for an over-the-wire single-machine loopback; using two PFs that map to the same physical port exercises the on-chip eswitch path instead.
     - [`daqiri_bench_rdma_tx_rx_spark.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_rdma_tx_rx_spark.yaml) for `daqiri_bench_rdma` — no further edits needed.
 
+    The Spark configs also pin the benchmark application's `bench_tx.cpu_core` / `bench_rx.cpu_core` fields to the high-frequency Cortex-X925 cores. Keep both the DAQIRI queue cores and the application worker cores on cores 16-19 unless you intentionally want a lower-power core in the measurement.
+
 #### Cross-host two-DGX-Spark loopback
 
 If you have two DGX Sparks cross-cabled p0↔p0 instead of a chassis QSFP loop on one machine, use the `_xhost` configs. Each host runs only its own role, so the YAML on each side configures one port instead of two. Both hosts must already be set up per the [DGX Spark profile](../tutorials/system_configuration.md#dgx-spark-profile), with one adjustment: the `daqiri-tx` (`1.1.1.1/24`) and `daqiri-rx` (`2.2.2.2/24`) nmcli profiles are *split across* the two hosts — bring up `daqiri-tx` on the TX host's p0 and `daqiri-rx` on the RX host's p0, instead of both on one box.
@@ -152,13 +154,15 @@ interfaces:
 
 ##### Configure the application
 
-To run the benchmarking application to run a loopback on your system, you'll need to modify the `bench_tx` section which configures the application itself, to create the packet headers and direct the packets to the NIC. Make sure to remove the template brackets `< >`.
+To run the benchmarking application to run a loopback on your system, you'll need to modify the `bench_tx` section which configures the application itself, to create the packet headers, pin the application TX worker, and direct the packets to the NIC. Make sure to remove the template brackets `< >`.
 
 - `eth_dst_addr` with the MAC address (and not the PCIe address) of the NIC interface you want to use for Rx. You can get the MAC address of your `if_name` interface with `#!bash cat /sys/class/net/$if_name/address`:
+- `cpu_core` with the CPU core for the benchmark application's TX thread. This is separate from the DAQIRI TX queue `cpu_core`; use a different isolated core when you have one, or deliberately share when the machine has a tight core budget.
 
-```yaml hl_lines="4"
+```yaml hl_lines="3 5"
 bench_tx:
 - interface_name: "tx_port" # Name of the TX port from the daqiri config
+  cpu_core: 11              # Benchmark application TX thread affinity
   ...
   eth_dst_addr: <00:00:00:00:00:00> # Destination MAC address - required when Rx flow_isolation=true
   ...
@@ -166,9 +170,10 @@ bench_tx:
 
 ???+ abstract "See an example yaml"
 
-    ```yaml hl_lines="4"
+    ```yaml hl_lines="3 5"
     bench_tx:
     - interface_name: "tx_port" # Name of the TX port from the daqiri config
+      cpu_core: 11              # Benchmark application TX thread affinity
       ...
       eth_dst_addr: 48:b0:2d:ee:83:ad # Destination MAC address - required when Rx flow_isolation=true
       ...
@@ -177,6 +182,7 @@ bench_tx:
 ??? info "Show explanation"
 
     - `eth_dst_addr` - the destination ethernet MAC address - will be embedded in the packet headers by the application. This is required here because the Rx interface above has `flow_isolation: true` (explained in more details below). In that configuration, only the packets listing the adequate destination MAC address will be accepted by the Rx interface.
+    - `cpu_core` - the benchmark application's own TX worker thread affinity. Set the matching `bench_rx.cpu_core` for RX workers too; these app-thread fields are distinct from the DAQIRI queue `cpu_core` values that poll the NIC.
     - We ignore the IP fields (`ip_src_addr`, `ip_dst_addr`) for now, as we are testing on a layer 2 network by just connecting a cable between the two interfaces on our system, therefore having mock values has no impact.
     - You might have noted the lack of a `eth_src_addr` field in this `bench_tx` section. This is because the source Ethernet MAC address can be inferred automatically by the DAQIRI library from the PCIe address of the Tx interface referenced above.
 

--- a/docs/benchmarks/socket_benchmarking.md
+++ b/docs/benchmarks/socket_benchmarking.md
@@ -202,6 +202,7 @@ socket_bench_server:
   server: true
   send: false
   receive: true
+  cpu_core: 8
   iterations: 1000000000
   message_size: 65507
   server_address: 10.250.0.2
@@ -257,6 +258,7 @@ socket_bench_client:
   server: false
   send: true
   receive: false
+  cpu_core: 7
   iterations: 1000000000
   message_size: 65507
   server_address: 10.250.0.2
@@ -264,7 +266,7 @@ socket_bench_client:
   server_port: 5021
 ```
 
-For TCP, change `protocol: "udp"` to `protocol: "tcp"` in both files. For UDP, keep `message_size` at or below `65507`.
+For TCP, change `protocol: "udp"` to `protocol: "tcp"` in both files. For UDP, keep `message_size` at or below `65507`. The `socket_bench_server.cpu_core` and `socket_bench_client.cpu_core` fields pin the benchmark application's server/client threads; they are separate from the DAQIRI queue `cpu_core` values above.
 
 Run the server and client in their namespaces:
 
@@ -295,8 +297,10 @@ Start from `examples/daqiri_bench_rdma_tx_rx.yaml` or `examples/daqiri_bench_rdm
   --seconds 10 --mode both
 ```
 
-`rdma_bench_server` and `rdma_bench_client` accept optional `tx_depth` and
-`rx_depth` fields. The defaults follow the `ib_send_bw` shape:
+`rdma_bench_server` and `rdma_bench_client` accept `cpu_core` plus optional
+`tx_depth` and `rx_depth` fields. `cpu_core` pins the benchmark application's
+server/client role thread, separately from the DAQIRI queue worker cores. The
+depth defaults follow the `ib_send_bw` shape:
 `tx_depth: 128`, `rx_depth: 512`. The benchmark preposts receive work before
 sending, refills receive work after completions, and keeps the transmit side
 bounded by `tx_depth`. For 4 KiB SEND-style stress tests, set the RX/TX

--- a/docs/tutorials/configuration-walkthrough.md
+++ b/docs/tutorials/configuration-walkthrough.md
@@ -97,7 +97,7 @@ For a shorter backend-selection guide, start with the [Benchmarking overview](..
     - **Closed-loop TX+RX with four queues** — [`daqiri_bench_raw_tx_rx_4q.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_raw_tx_rx_4q.yaml) (runs on `daqiri_bench_raw_gpudirect`).
     - [`daqiri_bench_raw_rx_multi_q.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_raw_rx_multi_q.yaml) (runs on `daqiri_bench_raw_gpudirect`).
 
-    The four-queue TX+RX config is self-contained and maps each `bench_tx`/`bench_rx` list entry to the matching DAQIRI queue. The RX-only config is for an external traffic source. Both demonstrate flow-rule-based routing across multiple RX queues, each pinned to its own CPU core.
+    The four-queue TX+RX config is self-contained and maps each `bench_tx`/`bench_rx` list entry to the matching DAQIRI queue. The RX-only config is for an external traffic source. Both demonstrate flow-rule-based routing across multiple RX queues, with explicit CPU cores for both DAQIRI queue workers and benchmark application workers.
 
     *Requires: Raw Ethernet build (`DAQIRI_MGR` includes `dpdk`) + NVIDIA ConnectX-class NIC. The RX-only config also requires a separate TX traffic source.*
 
@@ -133,7 +133,7 @@ In each code block, the lines you're most likely to tune are highlighted: system
 
 The annotated example below is [`daqiri_bench_raw_tx_rx.yaml`](https://github.com/nvidia/daqiri/blob/main/examples/daqiri_bench_raw_tx_rx.yaml).
 
-```yaml hl_lines="5 24 30 36 42 64 65 66"
+```yaml hl_lines="5 24 30 36 42 58 62 66 67 68"
 daqiri: # (1)!
   cfg:
     version: 1
@@ -191,9 +191,11 @@ daqiri: # (1)!
 
 bench_rx: # (24)!
 - interface_name: "rx_port"
+  cpu_core: 9
 
 bench_tx: # (25)!
 - interface_name: "tx_port"
+  cpu_core: 11
   batch_size: 10240
   payload_size: 8000
   header_size: 64
@@ -227,8 +229,8 @@ bench_tx: # (25)!
 21. **`id`** · `integer` · *required* — Tag attached to packets that match this flow. Useful when multiple flows route to a single queue and the application needs to distinguish which rule matched.
 22. What to do with packets that match this flow. The only currently supported action is `type: queue` (send the packet to the queue with the given `id`).
 23. :material-package-variant: List of rules to match packets against. **All** rules must hold for a packet to match the flow. Currently supported keys: `udp_src` / `udp_dst` (UDP source/destination port numbers, integer), `ipv4_len` (full IPv4 packet length in bytes, integer). **Adjust to match your incoming traffic.**
-24. The `bench_rx` section is specific to the benchmark application. It is a list of application worker configs; list entries map to DAQIRI RX queues on the named interface, either by explicit `queue_id` or by queue-list order when `queue_id` is omitted. In this base config there is one RX queue, so there is one entry. Other DAQIRI binaries (e.g. the reorder-quantize bench) may add fields here; see those configs for details.
-25. :material-package-variant: The `bench_tx` section configures the TX side of the benchmark: packet sizes and the Ethernet/IP/UDP header fields embedded in outgoing packets. It is a list for the same reason as `bench_rx`: each entry maps to a DAQIRI TX queue on the named interface, either by explicit `queue_id` or by queue-list order when `queue_id` is omitted. The `eth_dst_addr` is required when `flow_isolation` is enabled on the RX interface. The `ip_src_addr` / `ip_dst_addr` are only needed when traffic is routed across subnets — for a direct cable loopback, any value works. The `payload_size`, `header_size`, and UDP ports should match your application's packet format.
+24. The `bench_rx` section is specific to the benchmark application. It is a list of application worker configs; list entries map to DAQIRI RX queues on the named interface, either by explicit `queue_id` or by queue-list order when `queue_id` is omitted. `cpu_core` pins the benchmark application's RX worker thread; it is separate from the DAQIRI queue `cpu_core` above, and can use the same core only when you intentionally want to share. In this base config there is one RX queue, so there is one entry. Other DAQIRI binaries (e.g. the reorder-quantize bench) may add fields here; see those configs for details.
+25. :material-package-variant: The `bench_tx` section configures the TX side of the benchmark: the benchmark application's TX worker core, packet sizes, and the Ethernet/IP/UDP header fields embedded in outgoing packets. It is a list for the same reason as `bench_rx`: each entry maps to a DAQIRI TX queue on the named interface, either by explicit `queue_id` or by queue-list order when `queue_id` is omitted. The `cpu_core` field pins the application TX thread. The `eth_dst_addr` is required when `flow_isolation` is enabled on the RX interface. The `ip_src_addr` / `ip_dst_addr` are only needed when traffic is routed across subnets — for a direct cable loopback, any value works. The `payload_size`, `header_size`, and UDP ports should match your application's packet format.
 
 ### Header-data split (HDS)
 

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -1536,7 +1536,7 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
 
     ### Step 5: Isolate CPU cores
 
-    Spark has 20 cores arranged big.LITTLE-style: cluster 0 is 10 Cortex-A725 LITTLE cores (IDs 0-9 + part of 10-15), cluster 1 is the big Cortex-X925 cores (IDs 16-19 are the four highest-frequency big cores). Pin the daqiri TX/RX/processing threads onto **16, 17, 18, 19**; the rest of the system continues working normally on cores 0-15.
+    Spark has 20 cores arranged big.LITTLE-style: cluster 0 is 10 Cortex-A725 LITTLE cores (IDs 0-9 + part of 10-15), cluster 1 is the big Cortex-X925 cores (IDs 16-19 are the four highest-frequency big cores). Pin both the DAQIRI TX/RX/processing threads and the benchmark application's `bench_tx.cpu_core` / `bench_rx.cpu_core` worker threads onto **16, 17, 18, 19**; otherwise the application side of the benchmark can land on a lower-power core and become the measurement bottleneck. The rest of the system continues working normally on cores 0-15.
 
     The grub drop-in created in [Step 4](#step-4-enable-huge-pages-grub-drop-in-pattern) above already includes:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,6 +65,11 @@ MAC if the backend fills it. The generated Ethernet/IPv4/UDP headers include Eth
 `0x0800`, TTL `64`, correct IPv4 total length/checksum, UDP length/checksum, and the
 configured addresses and ports.
 
+The app-level `bench_tx.cpu_core`, `bench_rx.cpu_core`,
+`socket_bench_*.cpu_core`, and `rdma_bench_*.cpu_core` fields pin the benchmark
+application threads. These are separate from the DAQIRI queue `cpu_core` values that
+pin the library's worker threads.
+
 Included configs:
 
 | Config file | Benchmark |

--- a/examples/daqiri_bench_raw_rx_multi_q.yaml
+++ b/examples/daqiri_bench_raw_rx_multi_q.yaml
@@ -60,5 +60,7 @@ daqiri:
 bench_rx:
 - interface_name: "rx_port"
   queue_id: 0
+  cpu_core: 9
 - interface_name: "rx_port"
   queue_id: 1
+  cpu_core: 10

--- a/examples/daqiri_bench_raw_rx_reorder_seq_batch.yaml
+++ b/examples/daqiri_bench_raw_rx_reorder_seq_batch.yaml
@@ -61,3 +61,4 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 9

--- a/examples/daqiri_bench_raw_rx_reorder_seq_ppb.yaml
+++ b/examples/daqiri_bench_raw_rx_reorder_seq_ppb.yaml
@@ -59,3 +59,4 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 9

--- a/examples/daqiri_bench_raw_rx_spark_xhost.yaml
+++ b/examples/daqiri_bench_raw_rx_spark_xhost.yaml
@@ -7,7 +7,8 @@
 # Spark substitutions baked in here:
 #   - rx_port BDF = 0000:01:00.0 (p0); change if your p0 sits elsewhere
 #   - kind: host_pinned (GB10 dma-buf path; nvidia-peermem N/A on Spark)
-#   - master_core: 8; cpu_core: 18 (isolated big-cluster X925 16-19)
+#   - master_core: 8; cpu_core: 18 for both the DAQIRI RX queue and the app RX
+#     worker (isolated big-cluster X925 16-19)
 #   - flow match: udp_src/dst = 4096 -- same UDP tuple the TX side sends to
 #
 %YAML 1.2
@@ -52,3 +53,4 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 18

--- a/examples/daqiri_bench_raw_sw_loopback.yaml
+++ b/examples/daqiri_bench_raw_sw_loopback.yaml
@@ -47,9 +47,11 @@ daqiri:
 
 bench_rx:
   interface_name: "loopback_ports"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "loopback_ports"
+  cpu_core: 11
   batch_size: 10240
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_sw_loopback_reorder_seq_1024.yaml
+++ b/examples/daqiri_bench_raw_sw_loopback_reorder_seq_1024.yaml
@@ -77,9 +77,11 @@ daqiri:
 
 bench_rx:
   interface_name: "loopback_ports"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "loopback_ports"
+  cpu_core: 11
   batch_size: 1024
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx.py
+++ b/examples/daqiri_bench_raw_tx_rx.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import ipaddress
+import os
 import signal
 import struct
 import sys
@@ -44,6 +45,7 @@ PRINT_LOCK = threading.Lock()
 class RawTxConfig:
     interface_name: str = "tx_port"
     queue_id: int = 0
+    cpu_core: int = -1
     batch_size: int = 1024
     payload_size: int = 1000
     header_size: int = 64
@@ -58,6 +60,7 @@ class RawTxConfig:
 class RawRxConfig:
     interface_name: str = "rx_port"
     queue_id: int = -1
+    cpu_core: int = -1
 
 
 def parse_args() -> argparse.Namespace:
@@ -162,16 +165,21 @@ def assign_queue_ids(
 
 
 def parse_rx_item(data: dict) -> RawRxConfig:
-    return RawRxConfig(
+    cfg = RawRxConfig(
         interface_name=str(data.get("interface_name", "rx_port")),
         queue_id=int(data.get("queue_id", -1)),
+        cpu_core=int(data.get("cpu_core", -1)),
     )
+    if cfg.cpu_core < -1:
+        raise ValueError(f"bench_rx cpu_core is out of range for {cfg.interface_name}")
+    return cfg
 
 
 def parse_tx_item(data: dict) -> RawTxConfig:
     cfg = RawTxConfig(
         interface_name=str(data.get("interface_name", "tx_port")),
         queue_id=int(data.get("queue_id", 0)),
+        cpu_core=int(data.get("cpu_core", -1)),
         batch_size=int(data.get("batch_size", 1024)),
         payload_size=int(data.get("payload_size", 1000)),
         header_size=int(data.get("header_size", 64)),
@@ -182,6 +190,8 @@ def parse_tx_item(data: dict) -> RawTxConfig:
         eth_dst_addr=str(data.get("eth_dst_addr", "00:00:00:00:00:00")),
     )
     validate_queue_id(cfg.queue_id, [], "bench_tx", cfg.interface_name)
+    if cfg.cpu_core < -1:
+        raise ValueError(f"bench_tx cpu_core is out of range for {cfg.interface_name}")
     return cfg
 
 
@@ -267,7 +277,28 @@ def build_udp_ipv4_packet_template(cfg: RawTxConfig, src_port: int, dst_port: in
     return bytes(packet)
 
 
+def set_current_thread_affinity(cpu_core: int, thread_name: str) -> bool:
+    if cpu_core < 0:
+        return True
+    if not hasattr(os, "sched_setaffinity"):
+        print(f"{thread_name} cpu_core requires os.sched_setaffinity", file=sys.stderr)
+        return False
+    try:
+        os.sched_setaffinity(threading.get_native_id(), {cpu_core})
+    except OSError as exc:
+        print(
+            f"Failed to set {thread_name} affinity to CPU core {cpu_core}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def tx_worker(cfg: RawTxConfig, stop: threading.Event) -> None:
+    if not set_current_thread_affinity(cfg.cpu_core, "bench_tx"):
+        stop.set()
+        return
+
     port_id = daqiri.get_port_id(cfg.interface_name)
     if port_id < 0:
         print(f"Invalid TX interface_name: {cfg.interface_name}", file=sys.stderr)
@@ -354,6 +385,10 @@ def tx_worker(cfg: RawTxConfig, stop: threading.Event) -> None:
 
 
 def rx_worker(cfg: RawRxConfig, stop: threading.Event) -> None:
+    if not set_current_thread_affinity(cfg.cpu_core, "bench_rx"):
+        stop.set()
+        return
+
     port_id = daqiri.get_port_id(cfg.interface_name)
     if port_id < 0:
         print(f"Invalid RX interface_name: {cfg.interface_name}", file=sys.stderr)

--- a/examples/daqiri_bench_raw_tx_rx.yaml
+++ b/examples/daqiri_bench_raw_tx_rx.yaml
@@ -57,9 +57,11 @@ daqiri:
 
 bench_rx:
 - interface_name: "rx_port"
+  cpu_core: 9
 
 bench_tx:
 - interface_name: "tx_port"
+  cpu_core: 11
   batch_size: 10240
   payload_size: 8000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx_4q.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_4q.yaml
@@ -154,16 +154,21 @@ daqiri:
 bench_rx:
 - interface_name: "rx_port"
   queue_id: 0
+  cpu_core: 8
 - interface_name: "rx_port"
   queue_id: 1
+  cpu_core: 9
 - interface_name: "rx_port"
   queue_id: 2
+  cpu_core: 10
 - interface_name: "rx_port"
   queue_id: 3
+  cpu_core: 11
 
 bench_tx:
 - interface_name: "tx_port"
   queue_id: 0
+  cpu_core: 4
   batch_size: 10240
   payload_size: 8000
   header_size: 64
@@ -174,6 +179,7 @@ bench_tx:
   udp_dst_port: 4096
 - interface_name: "tx_port"
   queue_id: 1
+  cpu_core: 5
   batch_size: 10240
   payload_size: 8000
   header_size: 64
@@ -184,6 +190,7 @@ bench_tx:
   udp_dst_port: 4097
 - interface_name: "tx_port"
   queue_id: 2
+  cpu_core: 6
   batch_size: 10240
   payload_size: 8000
   header_size: 64
@@ -194,6 +201,7 @@ bench_tx:
   udp_dst_port: 4098
 - interface_name: "tx_port"
   queue_id: 3
+  cpu_core: 7
   batch_size: 10240
   payload_size: 8000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx_hds.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_hds.yaml
@@ -70,9 +70,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "tx_port"
+  cpu_core: 11
   batch_size: 10240
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml
@@ -84,6 +84,7 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 9
   gpu_direct: true
   split_boundary: false
   batch_size: 256
@@ -92,6 +93,7 @@ bench_rx:
 
 bench_tx:
   interface_name: "tx_port"
+  cpu_core: 11
   gpu_direct: true
   split_boundary: false
   batch_size: 256

--- a/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024.yaml
@@ -80,9 +80,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "tx_port"
+  cpu_core: 11
   batch_size: 1024
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024_cpu.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024_cpu.yaml
@@ -80,9 +80,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "tx_port"
+  cpu_core: 11
   batch_size: 1024
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx_spark.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_spark.yaml
@@ -12,8 +12,9 @@
 #   - kind: host_pinned, NOT device. GB10 has unified memory; nvidia_peermem
 #     does not load and CUDA reports DMA_BUF_SUPPORTED=0. PR #41 made
 #     host_pinned the working GPUDirect path on Spark (~94 Gbps unicast).
-#   - cpu_core: 17/18 from the four big-cluster X925 cores 16-19 isolated by the
-#     daqiri-tuning grub drop-in.
+#   - cpu_core: DAQIRI queue threads and benchmark app workers use 17/18 from
+#     the four big-cluster X925 cores 16-19 isolated by the daqiri-tuning grub
+#     drop-in.
 #   - master_core: 8 (a non-isolated big core; any 0-15 works).
 #   - bench_tx ip_src/ip_dst: match the daqiri-tx / daqiri-rx nmcli profiles
 #     (1.1.1.1/24 and 2.2.2.2/24, MTU 9000).
@@ -82,9 +83,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 18
 
 bench_tx:
   interface_name: "tx_port"
+  cpu_core: 17
   batch_size: 10240
   payload_size: 8000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_spark_xhost.yaml
+++ b/examples/daqiri_bench_raw_tx_spark_xhost.yaml
@@ -7,7 +7,8 @@
 # Spark substitutions baked in here:
 #   - tx_port BDF = 0000:01:00.0 (p0); change if your p0 sits elsewhere
 #   - kind: host_pinned (GB10 dma-buf path; nvidia-peermem N/A on Spark)
-#   - master_core: 8; cpu_core: 17 (isolated big-cluster X925 16-19)
+#   - master_core: 8; cpu_core: 17 for both the DAQIRI TX queue and the app TX
+#     worker (isolated big-cluster X925 16-19)
 #   - eth_dst_addr is the *peer* RX port's MAC -- replace with your own:
 #       cat /sys/class/net/<peer rx ifname>/address  # on the RX host
 #   - ip_src/ip_dst: arbitrary 1.1.1.1 -> 2.2.2.2 (kernel stack bypassed by
@@ -48,6 +49,7 @@ daqiri:
 
 bench_tx:
   interface_name: "tx_port"
+  cpu_core: 17
   batch_size: 10240
   payload_size: 8000
   header_size: 64

--- a/examples/daqiri_bench_rdma_tx_rx.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx.yaml
@@ -79,6 +79,7 @@ rdma_bench_server:
   message_size: 8000000
   send: true
   receive: true
+  cpu_core: 8
   server: true
 
 rdma_bench_client:
@@ -88,4 +89,5 @@ rdma_bench_client:
   server_port: 4096
   receive: true
   send: true
+  cpu_core: 7
   server: false

--- a/examples/daqiri_bench_rdma_tx_rx_spark.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx_spark.yaml
@@ -6,8 +6,9 @@
 #   - IPs: 1.1.1.1 (client/TX) and 2.2.2.2 (server/RX), matching the
 #     daqiri-tx / daqiri-rx nmcli profiles documented in the system
 #     configuration tutorial DGX Spark tab.
-#   - cpu_core values pulled from the isolated big-cluster X925 cores
-#     16-19 (see grub drop-in /etc/default/grub.d/daqiri-tuning.cfg).
+#   - cpu_core values for DAQIRI queue threads and benchmark app role threads
+#     are pulled from the isolated big-cluster X925 cores 16-19 (see grub
+#     drop-in /etc/default/grub.d/daqiri-tuning.cfg).
 #   - master_core: 8 (non-isolated big core).
 #   - kind: host_pinned (already correct upstream and required on GB10
 #     where peermem is N/A and DMA-BUF is unreachable).
@@ -93,6 +94,7 @@ rdma_bench_server:
   message_size: 8000000
   send: true
   receive: true
+  cpu_core: 19
   server: true
 
 rdma_bench_client:
@@ -102,4 +104,5 @@ rdma_bench_client:
   server_port: 4096
   receive: true
   send: true
+  cpu_core: 17
   server: false

--- a/examples/daqiri_bench_rdma_tx_rx_spark_xhost.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx_spark_xhost.yaml
@@ -16,7 +16,8 @@
 #
 # Spark substitutions baked in here:
 #   - IPs: 1.1.1.1 (client/TX p0) and 2.2.2.2 (server/RX p0)
-#   - cpu_core values from isolated big-cluster X925 16-19; master_core: 8
+#   - cpu_core values for DAQIRI queues and benchmark app role threads from
+#     isolated big-cluster X925 16-19; master_core: 8
 #   - kind: host_pinned (required upstream on GB10; peermem N/A, dma-buf used)
 #
 %YAML 1.2
@@ -100,6 +101,7 @@ rdma_bench_server:
   message_size: 8000000
   send: true
   receive: true
+  cpu_core: 19
   server: true
 
 rdma_bench_client:
@@ -109,4 +111,5 @@ rdma_bench_client:
   server_port: 4096
   receive: true
   send: true
+  cpu_core: 17
   server: false

--- a/examples/daqiri_bench_socket_tcp_tx_rx.yaml
+++ b/examples/daqiri_bench_socket_tcp_tx_rx.yaml
@@ -76,6 +76,7 @@ socket_bench_server:
   server: true
   send: true
   receive: true
+  cpu_core: 8
   iterations: 1000
   message_size: 1024
   server_address: 127.0.0.1
@@ -85,6 +86,7 @@ socket_bench_client:
   server: false
   send: true
   receive: true
+  cpu_core: 7
   iterations: 1000
   message_size: 1024
   server_address: 127.0.0.1

--- a/examples/daqiri_bench_socket_udp_tx_rx.yaml
+++ b/examples/daqiri_bench_socket_udp_tx_rx.yaml
@@ -76,6 +76,7 @@ socket_bench_server:
   server: true
   send: true
   receive: true
+  cpu_core: 8
   iterations: 1000
   message_size: 1024
   server_address: 127.0.0.1
@@ -85,6 +86,7 @@ socket_bench_client:
   server: false
   send: true
   receive: true
+  cpu_core: 7
   iterations: 1000
   message_size: 1024
   server_address: 127.0.0.1

--- a/examples/daqiri_example_gds_write_sw_loopback.yaml
+++ b/examples/daqiri_example_gds_write_sw_loopback.yaml
@@ -47,9 +47,11 @@ daqiri:
 
 bench_rx:
   interface_name: "loopback_ports"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "loopback_ports"
+  cpu_core: 11
   batch_size: 16
   payload_size: 256
   header_size: 60

--- a/examples/daqiri_example_gds_write_tx_rx.yaml
+++ b/examples/daqiri_example_gds_write_tx_rx.yaml
@@ -59,9 +59,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "tx_port"
+  cpu_core: 11
   batch_size: 16
   payload_size: 256
   header_size: 60

--- a/examples/daqiri_example_pcap_writer_sw_loopback.yaml
+++ b/examples/daqiri_example_pcap_writer_sw_loopback.yaml
@@ -47,9 +47,11 @@ daqiri:
 
 bench_rx:
   interface_name: "loopback_ports"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "loopback_ports"
+  cpu_core: 11
   batch_size: 1024
   payload_size: 256
   header_size: 42

--- a/examples/daqiri_example_pcap_writer_tx_rx.yaml
+++ b/examples/daqiri_example_pcap_writer_tx_rx.yaml
@@ -61,9 +61,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
+  cpu_core: 9
 
 bench_tx:
   interface_name: "tx_port"
+  cpu_core: 11
   batch_size: 1024
   payload_size: 256
   header_size: 42

--- a/examples/gds_write_example.cpp
+++ b/examples/gds_write_example.cpp
@@ -257,10 +257,18 @@ bool run_one_capture(const daqiri::bench::RawBenchTxConfig &tx_cfg,
                      const daqiri::bench::RawBenchRxConfig &rx_cfg,
                      const CliConfig &cli, const std::string &prefix,
                      bool async_write) {
+  if (!daqiri::bench::set_current_thread_affinity(tx_cfg.cpu_core,
+                                                  "bench_tx")) {
+    return false;
+  }
   if (!fill_and_send_one_burst(tx_cfg, cli.offset)) {
     return false;
   }
 
+  if (!daqiri::bench::set_current_thread_affinity(rx_cfg.cpu_core,
+                                                  "bench_rx")) {
+    return false;
+  }
   daqiri::BurstParams *rx_burst = wait_for_rx_burst(rx_cfg, cli.timeout_ms);
   if (rx_burst == nullptr) {
     std::cerr << "Timed out waiting for RX burst\n";

--- a/examples/pcap_writer_example.cpp
+++ b/examples/pcap_writer_example.cpp
@@ -423,6 +423,12 @@ PcapTxConfig parse_pcap_tx_config(const YAML::Node &root) {
 }
 
 void tx_worker(PcapTxConfig cfg, std::atomic<bool> *stop) {
+  if (!daqiri::bench::set_current_thread_affinity(cfg.raw.cpu_core,
+                                                  "bench_tx")) {
+    stop->store(true, std::memory_order_relaxed);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(cfg.raw.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid TX interface_name: " << cfg.raw.interface_name
@@ -501,6 +507,12 @@ void tx_worker(PcapTxConfig cfg, std::atomic<bool> *stop) {
 
 void rx_pcap_loop(const daqiri::bench::RawBenchRxConfig &rx_cfg,
                   PcapWriter *writer, std::atomic<bool> *stop) {
+  if (!daqiri::bench::set_current_thread_affinity(rx_cfg.cpu_core,
+                                                  "bench_rx")) {
+    stop->store(true, std::memory_order_relaxed);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(rx_cfg.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid RX interface_name: " << rx_cfg.interface_name << "\n";

--- a/examples/raw_bench_common.cpp
+++ b/examples/raw_bench_common.cpp
@@ -18,6 +18,8 @@
 #include "raw_bench_common.h"
 
 #include <arpa/inet.h>
+#include <pthread.h>
+#include <sched.h>
 
 #include <algorithm>
 #include <chrono>
@@ -161,6 +163,11 @@ RawBenchRxConfig parse_rx_item(const YAML::Node &rx) {
   RawBenchRxConfig cfg;
   cfg.interface_name = rx["interface_name"].as<std::string>(cfg.interface_name);
   cfg.queue_id = rx["queue_id"].as<int>(cfg.queue_id);
+  cfg.cpu_core = rx["cpu_core"].as<int>(cfg.cpu_core);
+  if (cfg.cpu_core < -1) {
+    throw std::runtime_error("bench_rx cpu_core is out of range for " +
+                             cfg.interface_name);
+  }
   return cfg;
 }
 
@@ -168,6 +175,7 @@ RawBenchTxConfig parse_tx_item(const YAML::Node &tx) {
   RawBenchTxConfig cfg;
   cfg.interface_name = tx["interface_name"].as<std::string>(cfg.interface_name);
   cfg.queue_id = tx["queue_id"].as<int>(cfg.queue_id);
+  cfg.cpu_core = tx["cpu_core"].as<int>(cfg.cpu_core);
   cfg.batch_size = tx["batch_size"].as<uint32_t>(cfg.batch_size);
   cfg.payload_size = tx["payload_size"].as<uint32_t>(cfg.payload_size);
   cfg.header_size = tx["header_size"].as<uint32_t>(cfg.header_size);
@@ -178,6 +186,10 @@ RawBenchTxConfig parse_tx_item(const YAML::Node &tx) {
   cfg.eth_src_addr = tx["eth_src_addr"].as<std::string>(cfg.eth_src_addr);
   cfg.eth_dst_addr = tx["eth_dst_addr"].as<std::string>(cfg.eth_dst_addr);
   validate_queue_id(cfg.queue_id, {}, "bench_tx", cfg.interface_name);
+  if (cfg.cpu_core < -1) {
+    throw std::runtime_error("bench_tx cpu_core is out of range for " +
+                             cfg.interface_name);
+  }
   return cfg;
 }
 
@@ -391,6 +403,31 @@ std::vector<uint16_t> parse_udp_ports(const std::string &spec) {
   return ports;
 }
 
+bool set_current_thread_affinity(int cpu_core,
+                                 const std::string &thread_name) {
+  if (cpu_core < 0) {
+    return true;
+  }
+  if (cpu_core >= CPU_SETSIZE) {
+    std::cerr << thread_name << " cpu_core " << cpu_core
+              << " exceeds CPU_SETSIZE " << CPU_SETSIZE << "\n";
+    return false;
+  }
+
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+  CPU_SET(cpu_core, &cpuset);
+  const int status =
+      pthread_setaffinity_np(pthread_self(), sizeof(cpuset), &cpuset);
+  if (status != 0) {
+    std::cerr << "Failed to set " << thread_name
+              << " affinity to CPU core " << cpu_core << ": "
+              << std::strerror(status) << "\n";
+    return false;
+  }
+  return true;
+}
+
 uint32_t add_checksum_bytes(const void *data, size_t len, uint32_t sum) {
   const auto *bytes = static_cast<const uint8_t *>(data);
   for (size_t i = 0; i + 1 < len; i += 2) {
@@ -512,6 +549,11 @@ void print_queue_stats(const char *direction, const std::string &interface_name,
 }
 
 void rx_count_worker(const RawBenchRxConfig &cfg, std::atomic<bool> &stop) {
+  if (!set_current_thread_affinity(cfg.cpu_core, "bench_rx")) {
+    stop.store(true);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(cfg.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid RX interface_name: " << cfg.interface_name << "\n";

--- a/examples/raw_bench_common.h
+++ b/examples/raw_bench_common.h
@@ -62,6 +62,7 @@ private:
 struct RawBenchTxConfig {
   std::string interface_name = "tx_port";
   int queue_id = 0;
+  int cpu_core = -1;
   uint32_t batch_size = 1024;
   uint32_t payload_size = 1000;
   uint32_t header_size = 64;
@@ -76,6 +77,7 @@ struct RawBenchTxConfig {
 struct RawBenchRxConfig {
   std::string interface_name = "rx_port";
   int queue_id = -1;
+  int cpu_core = -1;
 };
 
 struct RawBenchQueueStats {
@@ -115,6 +117,7 @@ RawBenchTxConfig parse_tx(const YAML::Node &root);
 std::vector<RawBenchRxConfig> parse_rx_configs(const YAML::Node &root);
 std::vector<RawBenchTxConfig> parse_tx_configs(const YAML::Node &root);
 std::vector<uint16_t> parse_udp_ports(const std::string &spec);
+bool set_current_thread_affinity(int cpu_core, const std::string &thread_name);
 
 void populate_udp_ipv4_headers(uint8_t *pkt_data, uint32_t header_size,
                                uint32_t payload_size, const char *eth_src,

--- a/examples/raw_gpudirect_bench.cpp
+++ b/examples/raw_gpudirect_bench.cpp
@@ -39,6 +39,11 @@ namespace {
 void tx_worker(const daqiri::bench::RawBenchTxConfig &cfg,
                daqiri::bench::TokenBucketPacer &pacer,
                std::atomic<bool> &stop) {
+  if (!daqiri::bench::set_current_thread_affinity(cfg.cpu_core, "bench_tx")) {
+    stop.store(true);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(cfg.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid TX interface_name: " << cfg.interface_name << "\n";

--- a/examples/raw_hds_bench.cpp
+++ b/examples/raw_hds_bench.cpp
@@ -36,6 +36,11 @@ namespace {
 
 void tx_worker(const daqiri::bench::RawBenchTxConfig &cfg,
                std::atomic<bool> &stop) {
+  if (!daqiri::bench::set_current_thread_affinity(cfg.cpu_core, "bench_tx")) {
+    stop.store(true);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(cfg.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid TX interface_name: " << cfg.interface_name << "\n";

--- a/examples/raw_reorder_quantize_bench.cpp
+++ b/examples/raw_reorder_quantize_bench.cpp
@@ -86,6 +86,8 @@ struct ReorderPlanConfig {
 struct BenchConfig {
   std::string interface_name = "loopback_ports";
   uint32_t queue_id = 0;
+  int tx_cpu_core = -1;
+  int rx_cpu_core = -1;
   uint32_t batch_size = 256;
   uint32_t payload_size = 256;
   uint32_t header_size = 64;
@@ -498,7 +500,11 @@ BenchConfig parse_bench_config(const YAML::Node &root,
                                const ReorderPlanConfig &plan) {
   BenchConfig cfg;
   const auto bench = root["bench_reorder_quantize"];
+  const auto bench_rx = root["bench_rx"];
   const auto bench_tx = root["bench_tx"];
+  const auto rx = bench_rx && bench_rx.IsSequence() && bench_rx.size() > 0
+                      ? bench_rx[0]
+                      : bench_rx;
   const auto tx = bench_tx && bench_tx.IsSequence() && bench_tx.size() > 0
                       ? bench_tx[0]
                       : bench_tx;
@@ -514,6 +520,7 @@ BenchConfig parse_bench_config(const YAML::Node &root,
   }
   if (tx) {
     cfg.queue_id = tx["queue_id"].as<uint32_t>(cfg.queue_id);
+    cfg.tx_cpu_core = tx["cpu_core"].as<int>(cfg.tx_cpu_core);
     cfg.batch_size = tx["batch_size"].as<uint32_t>(cfg.batch_size);
     cfg.payload_size = tx["payload_size"].as<uint32_t>(cfg.payload_size);
     cfg.header_size = tx["header_size"].as<uint32_t>(cfg.header_size);
@@ -523,6 +530,9 @@ BenchConfig parse_bench_config(const YAML::Node &root,
     cfg.ip_dst_addr = tx["ip_dst_addr"].as<std::string>(cfg.ip_dst_addr);
     cfg.udp_src_port = tx["udp_src_port"].as<uint16_t>(cfg.udp_src_port);
     cfg.udp_dst_port = tx["udp_dst_port"].as<uint16_t>(cfg.udp_dst_port);
+  }
+  if (rx) {
+    cfg.rx_cpu_core = rx["cpu_core"].as<int>(cfg.rx_cpu_core);
   }
 
   if (bench) {
@@ -557,6 +567,9 @@ BenchConfig parse_bench_config(const YAML::Node &root,
   }
   if (cfg.input_endianness == Endianness::INVALID) {
     throw std::runtime_error("Invalid bench endianness");
+  }
+  if (cfg.tx_cpu_core < -1 || cfg.rx_cpu_core < -1) {
+    throw std::runtime_error("bench_tx/bench_rx cpu_core is out of range");
   }
   if (!plan.data_types_defined) {
     throw std::runtime_error(
@@ -598,6 +611,13 @@ BenchConfig parse_bench_config(const YAML::Node &root,
 
 void tx_worker(const BenchConfig &cfg, const ReorderPlanConfig &plan,
                std::atomic<bool> &stop, SharedStats &stats) {
+  if (!daqiri::bench::set_current_thread_affinity(cfg.tx_cpu_core,
+                                                  "bench_tx")) {
+    stats.failures.fetch_add(1);
+    stop.store(true);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(cfg.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid TX interface_name: " << cfg.interface_name << "\n";
@@ -778,6 +798,13 @@ void tx_worker(const BenchConfig &cfg, const ReorderPlanConfig &plan,
 
 void rx_worker(const BenchConfig &cfg, const ReorderPlanConfig &plan,
                std::atomic<bool> &stop, SharedStats &stats) {
+  if (!daqiri::bench::set_current_thread_affinity(cfg.rx_cpu_core,
+                                                  "bench_rx")) {
+    stats.failures.fetch_add(1);
+    stop.store(true);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(plan.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid RX interface_name: " << plan.interface_name << "\n";

--- a/examples/raw_reorder_seq_bench.cpp
+++ b/examples/raw_reorder_seq_bench.cpp
@@ -99,6 +99,12 @@ parse_gpu_reorder_plans(const YAML::Node &root) {
 }
 
 void tx_worker(const SequenceTxConfig &cfg, std::atomic<bool> &stop) {
+  if (!daqiri::bench::set_current_thread_affinity(cfg.packet.cpu_core,
+                                                  "bench_tx")) {
+    stop.store(true);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(cfg.packet.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid TX interface_name: " << cfg.packet.interface_name
@@ -202,6 +208,11 @@ void tx_worker(const SequenceTxConfig &cfg, std::atomic<bool> &stop) {
 
 void rx_reorder_worker(const daqiri::bench::RawBenchRxConfig &cfg,
                        std::atomic<bool> &stop) {
+  if (!daqiri::bench::set_current_thread_affinity(cfg.cpu_core, "bench_rx")) {
+    stop.store(true);
+    return;
+  }
+
   const int port_id = daqiri::get_port_id(cfg.interface_name);
   if (port_id < 0) {
     std::cerr << "Invalid RX interface_name: " << cfg.interface_name << "\n";

--- a/examples/rdma_bench.cpp
+++ b/examples/rdma_bench.cpp
@@ -22,6 +22,7 @@
 #include <csignal>
 #include <cstdint>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -40,6 +41,7 @@ struct RdmaBenchConfig {
   bool server = false;
   bool send = false;
   bool receive = false;
+  int cpu_core = -1;
   int message_size = 1024;
   int tx_depth = 128;
   int rx_depth = 512;
@@ -60,6 +62,10 @@ RdmaBenchConfig parse_rdma_cfg(const YAML::Node& node) {
   cfg.server = node["server"].as<bool>(cfg.server);
   cfg.send = node["send"].as<bool>(cfg.send);
   cfg.receive = node["receive"].as<bool>(cfg.receive);
+  cfg.cpu_core = node["cpu_core"].as<int>(cfg.cpu_core);
+  if (cfg.cpu_core < -1) {
+    throw std::runtime_error("rdma_bench cpu_core is out of range");
+  }
   cfg.message_size = node["message_size"].as<int>(cfg.message_size);
   cfg.tx_depth = node["tx_depth"].as<int>(cfg.tx_depth);
   cfg.rx_depth = node["rx_depth"].as<int>(cfg.rx_depth);
@@ -73,6 +79,13 @@ RdmaBenchConfig parse_rdma_cfg(const YAML::Node& node) {
 
 void rdma_worker(const RdmaBenchConfig& cfg, daqiri::bench::TokenBucketPacer& pacer,
                  std::atomic<bool>& stop, RdmaWorkerStats& stats) {
+  const char *thread_name =
+      cfg.server ? "rdma_bench_server" : "rdma_bench_client";
+  if (!daqiri::bench::set_current_thread_affinity(cfg.cpu_core, thread_name)) {
+    stop.store(true);
+    return;
+  }
+
   int outstanding_send = 0;
   int outstanding_recv = 0;
   uint64_t send_wr_id = 0x1234;
@@ -217,18 +230,31 @@ int main(int argc, char** argv) {
   daqiri::bench::TokenBucketPacer client_pacer(target_gbps);
   bool run_server = false;
   bool run_client = false;
+  RdmaBenchConfig server_cfg;
+  RdmaBenchConfig client_cfg;
 
-  if ((mode == "server" || mode == "both") && root["rdma_bench_server"]) {
-    run_server = true;
-    server_thread = std::thread(
-        rdma_worker, parse_rdma_cfg(root["rdma_bench_server"]),
-        std::ref(server_pacer), std::ref(stop), std::ref(server_stats));
+  try {
+    if ((mode == "server" || mode == "both") && root["rdma_bench_server"]) {
+      run_server = true;
+      server_cfg = parse_rdma_cfg(root["rdma_bench_server"]);
+    }
+    if ((mode == "client" || mode == "both") && root["rdma_bench_client"]) {
+      run_client = true;
+      client_cfg = parse_rdma_cfg(root["rdma_bench_client"]);
+    }
+  } catch (const std::exception &e) {
+    std::cerr << "Invalid benchmark config: " << e.what() << "\n";
+    daqiri::shutdown();
+    return 1;
   }
-  if ((mode == "client" || mode == "both") && root["rdma_bench_client"]) {
-    run_client = true;
-    client_thread = std::thread(
-        rdma_worker, parse_rdma_cfg(root["rdma_bench_client"]),
-        std::ref(client_pacer), std::ref(stop), std::ref(client_stats));
+
+  if (run_server) {
+    server_thread = std::thread(rdma_worker, server_cfg, std::ref(server_pacer),
+                                std::ref(stop), std::ref(server_stats));
+  }
+  if (run_client) {
+    client_thread = std::thread(rdma_worker, client_cfg, std::ref(client_pacer),
+                                std::ref(stop), std::ref(client_stats));
   }
 
   if (!server_thread.joinable() && !client_thread.joinable()) {

--- a/examples/socket_bench.cpp
+++ b/examples/socket_bench.cpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -41,6 +42,7 @@ struct SocketBenchConfig {
   bool server = false;
   bool send = false;
   bool receive = false;
+  int cpu_core = -1;
   int message_size = 1024;
   int iterations = 1000;
   std::string server_address = "127.0.0.1";
@@ -60,6 +62,10 @@ SocketBenchConfig parse_socket_cfg(const YAML::Node& node) {
   cfg.server = node["server"].as<bool>(cfg.server);
   cfg.send = node["send"].as<bool>(cfg.send);
   cfg.receive = node["receive"].as<bool>(cfg.receive);
+  cfg.cpu_core = node["cpu_core"].as<int>(cfg.cpu_core);
+  if (cfg.cpu_core < -1) {
+    throw std::runtime_error("socket_bench cpu_core is out of range");
+  }
   cfg.message_size = node["message_size"].as<int>(cfg.message_size);
   cfg.iterations = node["iterations"].as<int>(cfg.iterations);
   cfg.server_address = node["server_address"].as<std::string>(cfg.server_address);
@@ -70,6 +76,13 @@ SocketBenchConfig parse_socket_cfg(const YAML::Node& node) {
 
 void socket_worker(const SocketBenchConfig& cfg, daqiri::bench::TokenBucketPacer& pacer,
                    std::atomic<bool>& stop, SocketWorkerStats& stats) {
+  const char *thread_name =
+      cfg.server ? "socket_bench_server" : "socket_bench_client";
+  if (!daqiri::bench::set_current_thread_affinity(cfg.cpu_core, thread_name)) {
+    stop.store(true);
+    return;
+  }
+
   uintptr_t conn_id = 0;
   uint16_t port = 0;
   uint16_t queue = 0;
@@ -179,22 +192,31 @@ int main(int argc, char** argv) {
   daqiri::bench::TokenBucketPacer client_pacer(target_gbps);
   bool run_server = false;
   bool run_client = false;
+  SocketBenchConfig server_cfg;
+  SocketBenchConfig client_cfg;
 
-  if ((mode == "server" || mode == "both") && root["socket_bench_server"]) {
-    run_server = true;
-    server_thread = std::thread(socket_worker,
-                                parse_socket_cfg(root["socket_bench_server"]),
-                                std::ref(server_pacer),
-                                std::ref(stop),
-                                std::ref(server_stats));
+  try {
+    if ((mode == "server" || mode == "both") && root["socket_bench_server"]) {
+      run_server = true;
+      server_cfg = parse_socket_cfg(root["socket_bench_server"]);
+    }
+    if ((mode == "client" || mode == "both") && root["socket_bench_client"]) {
+      run_client = true;
+      client_cfg = parse_socket_cfg(root["socket_bench_client"]);
+    }
+  } catch (const std::exception &e) {
+    std::cerr << "Invalid benchmark config: " << e.what() << "\n";
+    daqiri::shutdown();
+    return 1;
   }
-  if ((mode == "client" || mode == "both") && root["socket_bench_client"]) {
-    run_client = true;
-    client_thread = std::thread(socket_worker,
-                                parse_socket_cfg(root["socket_bench_client"]),
-                                std::ref(client_pacer),
-                                std::ref(stop),
-                                std::ref(client_stats));
+
+  if (run_server) {
+    server_thread = std::thread(socket_worker, server_cfg, std::ref(server_pacer),
+                                std::ref(stop), std::ref(server_stats));
+  }
+  if (run_client) {
+    client_thread = std::thread(socket_worker, client_cfg, std::ref(client_pacer),
+                                std::ref(stop), std::ref(client_stats));
   }
 
   if (!server_thread.joinable() && !client_thread.joinable()) {


### PR DESCRIPTION
Previously only the daqiri queue cores pinned themselves. This opens it up to the app cores as well.