### PR TITLE
Separate Spark app worker cores from DAQIRI queue cores

### DIFF
--- a/examples/daqiri_bench_raw_rx_spark_xhost.yaml
+++ b/examples/daqiri_bench_raw_rx_spark_xhost.yaml
@@ -7,8 +7,9 @@
 # Spark substitutions baked in here:
 #   - rx_port BDF = 0000:01:00.0 (p0); change if your p0 sits elsewhere
 #   - kind: host_pinned (GB10 dma-buf path; nvidia-peermem N/A on Spark)
-#   - master_core: 8; cpu_core: 18 for both the DAQIRI RX queue and the app RX
-#     worker (isolated big-cluster X925 16-19)
+#   - master_core: 8; cpu_core: 18 for the DAQIRI RX queue and 19 for the app
+#     RX worker -- separate cores so they don't contend (isolated big-cluster
+#     X925 16-19)
 #   - flow match: udp_src/dst = 4096 -- same UDP tuple the TX side sends to
 #
 %YAML 1.2
@@ -53,4 +54,4 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 18
+  cpu_core: 19

--- a/examples/daqiri_bench_raw_tx_rx_spark.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_spark.yaml
@@ -12,9 +12,10 @@
 #   - kind: host_pinned, NOT device. GB10 has unified memory; nvidia_peermem
 #     does not load and CUDA reports DMA_BUF_SUPPORTED=0. PR #41 made
 #     host_pinned the working GPUDirect path on Spark (~94 Gbps unicast).
-#   - cpu_core: DAQIRI queue threads and benchmark app workers use 17/18 from
-#     the four big-cluster X925 cores 16-19 isolated by the daqiri-tuning grub
-#     drop-in.
+#   - cpu_core: DAQIRI queue threads use 17 (TX) / 18 (RX); the benchmark app
+#     workers use the remaining big cores 16 (TX) / 19 (RX) so the app and
+#     DAQIRI poll threads never share a core. All four are big-cluster X925
+#     cores 16-19 isolated by the daqiri-tuning grub drop-in.
 #   - master_core: 8 (a non-isolated big core; any 0-15 works).
 #   - bench_tx ip_src/ip_dst: match the daqiri-tx / daqiri-rx nmcli profiles
 #     (1.1.1.1/24 and 2.2.2.2/24, MTU 9000).
@@ -83,11 +84,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 18
+  cpu_core: 19
 
 bench_tx:
   interface_name: "tx_port"
-  cpu_core: 17
+  cpu_core: 16
   batch_size: 10240
   payload_size: 8000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_spark_xhost.yaml
+++ b/examples/daqiri_bench_raw_tx_spark_xhost.yaml
@@ -7,8 +7,9 @@
 # Spark substitutions baked in here:
 #   - tx_port BDF = 0000:01:00.0 (p0); change if your p0 sits elsewhere
 #   - kind: host_pinned (GB10 dma-buf path; nvidia-peermem N/A on Spark)
-#   - master_core: 8; cpu_core: 17 for both the DAQIRI TX queue and the app TX
-#     worker (isolated big-cluster X925 16-19)
+#   - master_core: 8; cpu_core: 17 for the DAQIRI TX queue and 16 for the app
+#     TX worker -- separate cores so they don't contend (isolated big-cluster
+#     X925 16-19)
 #   - eth_dst_addr is the *peer* RX port's MAC -- replace with your own:
 #       cat /sys/class/net/<peer rx ifname>/address  # on the RX host
 #   - ip_src/ip_dst: arbitrary 1.1.1.1 -> 2.2.2.2 (kernel stack bypassed by
@@ -49,7 +50,7 @@ daqiri:
 
 bench_tx:
   interface_name: "tx_port"
-  cpu_core: 17
+  cpu_core: 16
   batch_size: 10240
   payload_size: 8000
   header_size: 64

--- a/examples/daqiri_bench_rdma_tx_rx_spark_xhost.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx_spark_xhost.yaml
@@ -17,7 +17,10 @@
 # Spark substitutions baked in here:
 #   - IPs: 1.1.1.1 (client/TX p0) and 2.2.2.2 (server/RX p0)
 #   - cpu_core values for DAQIRI queues and benchmark app role threads from
-#     isolated big-cluster X925 16-19; master_core: 8
+#     isolated big-cluster X925 16-19; master_core: 8. Each host runs only one
+#     role, so the app thread takes a big core its local queues don't use:
+#     client host queues 17/18 -> client app 16; server host queues 16/19 ->
+#     server app 18.
 #   - kind: host_pinned (required upstream on GB10; peermem N/A, dma-buf used)
 #
 %YAML 1.2
@@ -101,7 +104,7 @@ rdma_bench_server:
   message_size: 8000000
   send: true
   receive: true
-  cpu_core: 19
+  cpu_core: 18
   server: true
 
 rdma_bench_client:
@@ -111,5 +114,5 @@ rdma_bench_client:
   server_port: 4096
   receive: true
   send: true
-  cpu_core: 17
+  cpu_core: 16
   server: false


### PR DESCRIPTION
The Spark example configs pinned the benchmark app worker threads to the same cpu_core as the DAQIRI queue poll threads, so the two busy-poll threads contended for a single big core. Move the app workers to the remaining isolated big-cluster X925 cores (16-19) so they no longer share a core:

  raw_tx_rx_spark:      bench_tx 17->16, bench_rx 18->19
  raw_rx_spark_xhost:   bench_rx 18->19
  raw_tx_spark_xhost:   bench_tx 17->16
  rdma_tx_rx_spark_xhost: client 17->16, server 19->18 (per-host free core)