### PR TITLE
Separate benchmark app worker cores from DAQIRI queue cores

### DIFF
--- a/docs/benchmarks/raw_benchmarking.md
+++ b/docs/benchmarks/raw_benchmarking.md
@@ -162,7 +162,7 @@ To run the benchmarking application to run a loopback on your system, you'll nee
 ```yaml hl_lines="3 5"
 bench_tx:
 - interface_name: "tx_port" # Name of the TX port from the daqiri config
-  cpu_core: 11              # Benchmark application TX thread affinity
+  cpu_core: 10              # Benchmark application TX thread affinity
   ...
   eth_dst_addr: <00:00:00:00:00:00> # Destination MAC address - required when Rx flow_isolation=true
   ...
@@ -173,7 +173,7 @@ bench_tx:
     ```yaml hl_lines="3 5"
     bench_tx:
     - interface_name: "tx_port" # Name of the TX port from the daqiri config
-      cpu_core: 11              # Benchmark application TX thread affinity
+      cpu_core: 10              # Benchmark application TX thread affinity
       ...
       eth_dst_addr: 48:b0:2d:ee:83:ad # Destination MAC address - required when Rx flow_isolation=true
       ...

--- a/docs/benchmarks/socket_benchmarking.md
+++ b/docs/benchmarks/socket_benchmarking.md
@@ -202,7 +202,7 @@ socket_bench_server:
   server: true
   send: false
   receive: true
-  cpu_core: 8
+  cpu_core: 9
   iterations: 1000000000
   message_size: 65507
   server_address: 10.250.0.2
@@ -258,7 +258,7 @@ socket_bench_client:
   server: false
   send: true
   receive: false
-  cpu_core: 7
+  cpu_core: 9
   iterations: 1000000000
   message_size: 65507
   server_address: 10.250.0.2

--- a/docs/tutorials/configuration-walkthrough.md
+++ b/docs/tutorials/configuration-walkthrough.md
@@ -191,11 +191,11 @@ daqiri: # (1)!
 
 bench_rx: # (24)!
 - interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx: # (25)!
 - interface_name: "tx_port"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 10240
   payload_size: 8000
   header_size: 64

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -835,7 +835,7 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
         cat /proc/cmdline | grep -e isolcpus -e irqaffinity -e nohz_full -e rcu_nocbs -e rcu_nocb_poll
         ```
 
-    Decide which cores to isolate based on your configuration. We recommend one core per queue as a rule of thumb. First, identify your core IDs:
+    Decide which cores to isolate based on your configuration. We recommend one core per DAQIRI queue, plus one core per benchmark application worker thread (the `bench_tx` / `bench_rx` `cpu_core` fields), as a rule of thumb — these are separate busy-poll threads and should not share a core. First, identify your core IDs:
 
     ```bash
     cat /proc/cpuinfo | grep processor
@@ -859,10 +859,10 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
         processor       # 11
         ```
 
-    As an example, the line below will isolate cores 9, 10 and 11, leaving cores 0-8 free for other tasks and hardware interrupts:
+    As an example, the line below will isolate cores 8, 9, 10 and 11 (enough for the two DAQIRI queues and two application worker threads in the base TX+RX config), leaving cores 0-7 free for other tasks and hardware interrupts:
 
     ```bash
-    isolcpus=9-11 irqaffinity=0-8 nohz_full=9-11 rcu_nocbs=9-11 rcu_nocb_poll
+    isolcpus=8-11 irqaffinity=0-7 nohz_full=8-11 rcu_nocbs=8-11 rcu_nocb_poll
     ```
 
     ??? info "Show explanation"

--- a/examples/daqiri_bench_raw_rx_multi_q.yaml
+++ b/examples/daqiri_bench_raw_rx_multi_q.yaml
@@ -60,7 +60,7 @@ daqiri:
 bench_rx:
 - interface_name: "rx_port"
   queue_id: 0
-  cpu_core: 9
+  cpu_core: 8
 - interface_name: "rx_port"
   queue_id: 1
-  cpu_core: 10
+  cpu_core: 11

--- a/examples/daqiri_bench_raw_rx_reorder_seq_batch.yaml
+++ b/examples/daqiri_bench_raw_rx_reorder_seq_batch.yaml
@@ -61,4 +61,4 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 10

--- a/examples/daqiri_bench_raw_rx_reorder_seq_ppb.yaml
+++ b/examples/daqiri_bench_raw_rx_reorder_seq_ppb.yaml
@@ -59,4 +59,4 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 10

--- a/examples/daqiri_bench_raw_sw_loopback.yaml
+++ b/examples/daqiri_bench_raw_sw_loopback.yaml
@@ -47,11 +47,11 @@ daqiri:
 
 bench_rx:
   interface_name: "loopback_ports"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "loopback_ports"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 10240
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_sw_loopback_reorder_seq_1024.yaml
+++ b/examples/daqiri_bench_raw_sw_loopback_reorder_seq_1024.yaml
@@ -77,11 +77,11 @@ daqiri:
 
 bench_rx:
   interface_name: "loopback_ports"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "loopback_ports"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 1024
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx.yaml
+++ b/examples/daqiri_bench_raw_tx_rx.yaml
@@ -57,11 +57,11 @@ daqiri:
 
 bench_rx:
 - interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
 - interface_name: "tx_port"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 10240
   payload_size: 8000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx_4q.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_4q.yaml
@@ -1,3 +1,12 @@
+# Four-queue closed-loop TX+RX template.
+#
+# Core budget note: this config runs 8 DAQIRI queue threads (TX cores 4-7,
+# RX cores 8-11) plus 8 benchmark app worker threads, so on a 12-core host
+# each app worker intentionally shares a core with its matching queue (the
+# bench_tx/bench_rx cpu_core values mirror the queue cores). Unlike the
+# single/dual-queue configs -- where the app workers get their own isolated
+# cores -- there are not enough cores here to separate them. Give each app
+# worker its own isolated core if you have more than 12 cores available.
 %YAML 1.2
 ---
 daqiri:

--- a/examples/daqiri_bench_raw_tx_rx_hds.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_hds.yaml
@@ -70,11 +70,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "tx_port"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 10240
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_reorder_quantize_seq_batch.yaml
@@ -84,7 +84,7 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 8
   gpu_direct: true
   split_boundary: false
   batch_size: 256
@@ -93,7 +93,7 @@ bench_rx:
 
 bench_tx:
   interface_name: "tx_port"
-  cpu_core: 11
+  cpu_core: 10
   gpu_direct: true
   split_boundary: false
   batch_size: 256

--- a/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024.yaml
@@ -80,11 +80,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "tx_port"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 1024
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024_cpu.yaml
+++ b/examples/daqiri_bench_raw_tx_rx_reorder_seq_1024_cpu.yaml
@@ -80,11 +80,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "tx_port"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 1024
   payload_size: 1000
   header_size: 64

--- a/examples/daqiri_bench_rdma_tx_rx.yaml
+++ b/examples/daqiri_bench_rdma_tx_rx.yaml
@@ -79,7 +79,7 @@ rdma_bench_server:
   message_size: 8000000
   send: true
   receive: true
-  cpu_core: 8
+  cpu_core: 9
   server: true
 
 rdma_bench_client:
@@ -89,5 +89,5 @@ rdma_bench_client:
   server_port: 4096
   receive: true
   send: true
-  cpu_core: 7
+  cpu_core: 10
   server: false

--- a/examples/daqiri_bench_socket_tcp_tx_rx.yaml
+++ b/examples/daqiri_bench_socket_tcp_tx_rx.yaml
@@ -76,7 +76,7 @@ socket_bench_server:
   server: true
   send: true
   receive: true
-  cpu_core: 8
+  cpu_core: 9
   iterations: 1000
   message_size: 1024
   server_address: 127.0.0.1
@@ -86,7 +86,7 @@ socket_bench_client:
   server: false
   send: true
   receive: true
-  cpu_core: 7
+  cpu_core: 10
   iterations: 1000
   message_size: 1024
   server_address: 127.0.0.1

--- a/examples/daqiri_bench_socket_udp_tx_rx.yaml
+++ b/examples/daqiri_bench_socket_udp_tx_rx.yaml
@@ -76,7 +76,7 @@ socket_bench_server:
   server: true
   send: true
   receive: true
-  cpu_core: 8
+  cpu_core: 9
   iterations: 1000
   message_size: 1024
   server_address: 127.0.0.1
@@ -86,7 +86,7 @@ socket_bench_client:
   server: false
   send: true
   receive: true
-  cpu_core: 7
+  cpu_core: 10
   iterations: 1000
   message_size: 1024
   server_address: 127.0.0.1

--- a/examples/daqiri_example_gds_write_sw_loopback.yaml
+++ b/examples/daqiri_example_gds_write_sw_loopback.yaml
@@ -47,11 +47,11 @@ daqiri:
 
 bench_rx:
   interface_name: "loopback_ports"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "loopback_ports"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 16
   payload_size: 256
   header_size: 60

--- a/examples/daqiri_example_gds_write_tx_rx.yaml
+++ b/examples/daqiri_example_gds_write_tx_rx.yaml
@@ -59,11 +59,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "tx_port"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 16
   payload_size: 256
   header_size: 60

--- a/examples/daqiri_example_pcap_writer_sw_loopback.yaml
+++ b/examples/daqiri_example_pcap_writer_sw_loopback.yaml
@@ -47,11 +47,11 @@ daqiri:
 
 bench_rx:
   interface_name: "loopback_ports"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "loopback_ports"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 1024
   payload_size: 256
   header_size: 42

--- a/examples/daqiri_example_pcap_writer_tx_rx.yaml
+++ b/examples/daqiri_example_pcap_writer_tx_rx.yaml
@@ -61,11 +61,11 @@ daqiri:
 
 bench_rx:
   interface_name: "rx_port"
-  cpu_core: 9
+  cpu_core: 8
 
 bench_tx:
   interface_name: "tx_port"
-  cpu_core: 11
+  cpu_core: 10
   batch_size: 1024
   payload_size: 256
   header_size: 42


### PR DESCRIPTION
PR #155 fixed the app-worker/DAQIRI-queue core collisions in the Spark configs, but the same problem exists in the rest of the example configs: the benchmark app worker threads (bench_tx/bench_rx/socket_bench/rdma_bench cpu_core) were pinned to the same core as a DAQIRI queue poll thread, so the two busy-poll threads contended for one core.

Move the app workers onto distinct isolated cores wherever the core budget allows:

  raw 2-queue configs:  queues 9/11, app workers -> 8/10
  raw RX-only configs:  queue 9,    app worker  -> 10
  raw multi-queue:      queues 9/10, app workers -> 8/11
  socket + rdma:        queues 7/8,  app workers -> 9/10

daqiri_bench_raw_tx_rx_4q.yaml is left sharing cores (8 queues + 8 app workers = 16 threads on a 12-core host cannot be separated) with an added comment explaining the intentional sharing.

Docs synced: configuration-walkthrough base TX+RX block (CI structural check), raw_benchmarking bench_tx snippet, socket_benchmarking UDP templates, and the system_configuration CPU-isolation example/rule of thumb now reserves a core per app worker.