### PR TITLE
#170 - Guard socket engine RdmaEngine member behind DAQIRI_ENGINE_RDMA

### DIFF
--- a/src/engines/socket/daqiri_socket_engine.cpp
+++ b/src/engines/socket/daqiri_socket_engine.cpp
@@ -121,8 +121,10 @@ void SocketEngine::initialize() {
       initialized_ = roce_engine_->is_initialized();
       return;
     }
-#endif
     initialized_ = roce_engine_ != nullptr;
+#else
+    initialized_ = false;
+#endif
     return;
   }
 
@@ -1449,51 +1451,76 @@ Status SocketEngine::socket_get_server_conn_id(const std::string& server_addr, u
 
 Status SocketEngine::rdma_connect_to_server(const std::string& dst_addr, uint16_t dst_port,
                                          uintptr_t* conn_id) {
+#if DAQIRI_ENGINE_RDMA
   if (!is_roce_protocol() || roce_engine_ == nullptr) {
     return roce_not_initialized("rdma_connect_to_server");
   }
   return roce_engine_->rdma_connect_to_server(dst_addr, dst_port, conn_id);
+#else
+  return roce_not_initialized("rdma_connect_to_server");
+#endif
 }
 
 Status SocketEngine::rdma_connect_to_server(const std::string& dst_addr, uint16_t dst_port,
                                          const std::string& src_addr, uintptr_t* conn_id) {
+#if DAQIRI_ENGINE_RDMA
   if (!is_roce_protocol() || roce_engine_ == nullptr) {
     return roce_not_initialized("rdma_connect_to_server");
   }
   return roce_engine_->rdma_connect_to_server(dst_addr, dst_port, src_addr, conn_id);
+#else
+  return roce_not_initialized("rdma_connect_to_server");
+#endif
 }
 
 Status SocketEngine::rdma_get_port_queue(uintptr_t conn_id, uint16_t* port, uint16_t* queue) {
+#if DAQIRI_ENGINE_RDMA
   if (!is_roce_protocol() || roce_engine_ == nullptr) {
     return roce_not_initialized("rdma_get_port_queue");
   }
   return roce_engine_->rdma_get_port_queue(conn_id, port, queue);
+#else
+  return roce_not_initialized("rdma_get_port_queue");
+#endif
 }
 
 Status SocketEngine::rdma_get_server_conn_id(const std::string& server_addr, uint16_t server_port,
                                           uintptr_t* conn_id) {
+#if DAQIRI_ENGINE_RDMA
   if (!is_roce_protocol() || roce_engine_ == nullptr) {
     return roce_not_initialized("rdma_get_server_conn_id");
   }
   return roce_engine_->rdma_get_server_conn_id(server_addr, server_port, conn_id);
+#else
+  return roce_not_initialized("rdma_get_server_conn_id");
+#endif
 }
 
 Status SocketEngine::rdma_set_header(BurstParams* burst, RDMAOpCode op_code, uintptr_t conn_id,
                                   bool is_server, int num_pkts, uint64_t wr_id,
                                   const std::string& local_mr_name) {
+#if DAQIRI_ENGINE_RDMA
   if (!is_roce_protocol() || roce_engine_ == nullptr) {
     return roce_not_initialized("rdma_set_header");
   }
   return roce_engine_->rdma_set_header(
       burst, op_code, conn_id, is_server, num_pkts, wr_id, local_mr_name);
+#else
+  return roce_not_initialized("rdma_set_header");
+#endif
 }
 
 RDMAOpCode SocketEngine::rdma_get_opcode(BurstParams* burst) {
+#if DAQIRI_ENGINE_RDMA
   if (!is_roce_protocol() || roce_engine_ == nullptr) {
     DAQIRI_LOG_ERROR("rdma_get_opcode is only valid with roce:// endpoints");
     return RDMAOpCode::INVALID;
   }
   return roce_engine_->rdma_get_opcode(burst);
+#else
+  DAQIRI_LOG_ERROR("rdma_get_opcode is only valid with roce:// endpoints");
+  return RDMAOpCode::INVALID;
+#endif
 }
 
 }  // namespace daqiri

--- a/src/engines/socket/daqiri_socket_engine.h
+++ b/src/engines/socket/daqiri_socket_engine.h
@@ -209,7 +209,9 @@ class SocketEngine : public Engine {
   std::atomic<uint64_t> rx_pkts_{0};
   std::atomic<uint64_t> rx_bytes_{0};
 
+#if DAQIRI_ENGINE_RDMA
   std::unique_ptr<RdmaEngine> roce_engine_;
+#endif
 };
 
 }  // namespace daqiri


### PR DESCRIPTION
## Summary

Building with `DAQIRI_ENGINE=dpdk` (i.e. without `ibverbs`/RDMA) failed to compile the always-built `daqiri_socket` target. This PR guards the socket engine's RoCE-delegation member and methods behind `DAQIRI_ENGINE_RDMA`, matching the convention already used throughout the file.

Fixes #170.

## Root cause

The socket engine is always built (since #156) and carries a RoCE path that delegates to the rdma engine only when it is also built (`#if DAQIRI_ENGINE_RDMA`). The `#include` of the rdma header and `make_unique<RdmaEngine>()` were correctly guarded, but three things were left **unguarded**:

1. `src/engines/socket/daqiri_socket_engine.h:212` — the `std::unique_ptr<RdmaEngine> roce_engine_;` member declaration. With `ibverbs` absent, `RdmaEngine` stays incomplete, so the `unique_ptr` destructor instantiated in `SocketEngine::~SocketEngine()` fails its complete-type `static_assert`.
2. `src/engines/socket/daqiri_socket_engine.cpp` — the `rdma_connect_to_server` / `rdma_get_port_queue` / `rdma_get_server_conn_id` / `rdma_set_header` / `rdma_get_opcode` method bodies, which dereference `roce_engine_` directly (incomplete-type errors at lines 1455–1496).
3. The trailing `initialized_ = roce_engine_ != nullptr;` in `initialize()`, which sat just after the `#endif` and referenced the now-conditional member.

The default `DAQIRI_ENGINE="dpdk ibverbs"` build was unaffected (RdmaEngine is complete there). Introduced by #156.

## Fix

- Guard the `roce_engine_` member declaration behind `#if DAQIRI_ENGINE_RDMA`.
- Wrap the previously-unguarded `rdma_*` method bodies in `#if DAQIRI_ENGINE_RDMA`, with an `#else` that short-circuits to `roce_not_initialized(...)` / `RDMAOpCode::INVALID` when RDMA is not built.
- Move the trailing `initialized_` assignment in `initialize()` inside the guard, with an `#else` setting `initialized_ = false`.

## Validation

Both container builds verified green via `scripts/build-container.sh`:

- **DPDK-only** (`DAQIRI_ENGINE=dpdk`): now compiles past the socket engine — `Built daqiri:fix-dpdk-only`. (Previously failed with the `static_assert(sizeof(_Tp)>0)` incomplete-type error in `~SocketEngine()`.)
- **Default** (`DAQIRI_ENGINE="dpdk ibverbs"`): still builds — `Built daqiri:fix-default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
