### PR TITLE
#187 - Polish landing page links and footer CTA

### DIFF
--- a/docs/landing/cta.html
+++ b/docs/landing/cta.html
@@ -11,12 +11,12 @@ cmake -S daqiri -B build \
   -DDAQIRI_ENGINE=<span class="str">"dpdk ibverbs"</span>
 cmake --build build -j</pre>
       <div class="cta-actions">
-        <a href="#getting-started" class="btn btn-primary">Quick Start Guide →</a>
+        <a href="getting-started/" class="btn btn-primary">Getting Started Guide →</a>
+        <a href="api-reference/" class="btn btn-outline">API Reference →</a>
         <a href="https://github.com/NVIDIA/daqiri" class="btn btn-outline" target="_blank">
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           View on GitHub
         </a>
-        <a href="api-reference/" class="btn btn-outline">API Reference →</a>
       </div>
     </div>
   </section>

--- a/docs/landing/footer.html
+++ b/docs/landing/footer.html
@@ -41,7 +41,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <div class="footer-bottom-l">© 2025 NVIDIA Corporation. Licensed under Apache 2.0.</div>
+        <div class="footer-bottom-l">© 2026 NVIDIA Corporation. Licensed under Apache 2.0.</div>
         <div class="footer-bottom-r">
           <a href="https://github.com/NVIDIA/daqiri/blob/main/LICENSE" target="_blank">License</a>
           <a href="https://github.com/NVIDIA/daqiri/blob/main/SECURITY.md" target="_blank">Security</a>

--- a/docs/landing/hero.html
+++ b/docs/landing/hero.html
@@ -25,9 +25,8 @@
         </div>
         <div class="hero-actions">
           <a href="#getting-started" class="btn btn-primary">Quick Start →</a>
-          <a href="concepts/" class="btn btn-outline">Key Concepts</a>
-          <a href="api-reference/" class="btn btn-outline">API Reference</a>
-          <a href="benchmarks/benchmarks/" class="btn btn-outline">Benchmarking</a>
+          <a href="#examples" class="btn btn-outline">Examples</a>
+          <a href="#tutorials" class="btn btn-outline">Tutorials</a>
         </div>
         <div class="hero-stats">
           <div><div class="stat-value">PCIe + Ethernet</div><div class="stat-label">Sensor Paths</div></div>


### PR DESCRIPTION
## Summary
- Update the landing hero buttons to stay on-page for Quick Start, Examples, and Tutorials
- Reorder the bottom CTA buttons and point Getting Started Guide to the Getting Started docs page
- Update the landing footer copyright year to 2026

Closes #187

## Verification
- `git diff --check -- docs/landing/hero.html docs/landing/cta.html docs/landing/footer.html`
- `mkdocs build --strict --site-dir /tmp/daqiri-site`
- `python3 scripts/check_html_links.py /tmp/daqiri-site`