### PR TITLE
#197 - Fix DPDK MTU sizing for asymmetric RX/TX queues

### DIFF
--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -2409,6 +2409,10 @@ void DpdkEngine::initialize() {
     // For now make a single queue. Support more sophisticated TX on next release
     const auto& tx = intf.tx_;
 
+    const auto is_dummy_tx_queue = [](const CommonQueueConfig& queue) {
+      return queue.name_.find("UNUSED_TX_P") == 0;
+    };
+
     for (auto& q : tx.queues_) {
       DAQIRI_LOG_INFO("Configuring TX queue: {} ({}) on port {}",
                         q.common_.name_,
@@ -2440,7 +2444,12 @@ void DpdkEngine::initialize() {
         q_packet_size += mr.buf_size_;
       }
 
-      max_pkt_size = std::max(max_pkt_size, q_packet_size);
+      // Exclude generated dummy TX queues so RX-only ports are not inflated to the
+      // dummy jumbo frame size when MTU sizing uses the combined RX/TX maximum.
+      // Generated dummy RX queues are left unchanged to preserve TX-only behavior.
+      if (!is_dummy_tx_queue(q.common_)) {
+        max_pkt_size = std::max(max_pkt_size, q_packet_size);
+      }
       uint32_t key = generate_queue_key(intf.port_id_, q.common_.id_);
       tx_dpdk_q_map_[key] = q_backend;
     }
@@ -2457,10 +2466,12 @@ void DpdkEngine::initialize() {
 
     local_port_conf[intf.port_id_].txmode.offloads = 0;
 
-    // Compute MTU conservatively. Clamp to jumbo frame bounds and enforce a valid minimum MTU.
-    max_rx_pkt_size = std::max(max_rx_pkt_size, 64UL);
+    // Compute MTU from the largest RX/TX queue buffer frame needed on this port
+    // (max_pkt_size already folds in the existing RX tunnel decap overhead).
+    // Clamp to jumbo bounds and enforce a valid minimum MTU.
+    max_pkt_size = std::max(max_pkt_size, 64UL);
     const size_t requested_frame_size =
-        std::min(max_rx_pkt_size, static_cast<size_t>(JUMBOFRAME_SIZE));
+        std::min(max_pkt_size, static_cast<size_t>(JUMBOFRAME_SIZE));
     const size_t crc_and_hdr = RTE_ETHER_CRC_LEN + RTE_ETHER_HDR_LEN;
     const size_t requested_mtu =
         (requested_frame_size > crc_and_hdr) ? (requested_frame_size - crc_and_hdr) : 0;


### PR DESCRIPTION
### Summary

Closes #197 

This fixes DPDK MTU sizing for ports that use the same interface for both RX and TX with asymmetric packet sizes.

Before this change, DPDK collected a combined RX/TX maximum packet size in `max_pkt_size`, but configured the port MTU from the RX-only value `max_rx_pkt_size`. If TX packets were larger than RX packets on the same port, the NIC could silently drop all TX traffic even though `send_tx_burst()` reported success.

The fix configures bidirectional DPDK port MTU from the combined RX/TX queue buffer requirement while preserving the existing RX decap/pop overhead accounting.

### Scope

This PR intentionally keeps the fix narrow:

- DPDK only. The ibverbs MTU path already considers both RX and TX queue buffer
  sizes.
- Queue buffer sizing only. TX hardware encap/push overhead is not added here.
- No public API, YAML schema, or documentation contract changes.
- No dummy-queue worker-path refactor and no new queue-name validation.

Consider follow-ups below.

### Dummy queue handling

DPDK appends internal dummy queues for one-way configurations so device setup has at least one queue in each direction.

When switching MTU sizing to the combined RX/TX maximum, internal dummy TX queues must be excluded. Otherwise RX-only ports would be incorrectly inflated to the dummy 9100-byte frame size. This PR excludes generated dummy TX queues (`UNUSED_TX_P...`) from MTU accumulation.

Generated dummy RX queues are intentionally left in the calculation to preserve current TX-only behavior. This is especially important because TX hardware encap/push overhead is not yet included in MTU sizing; lowering TX-only MTUs in this PR could regress TX-only transform configurations.

### Follow-ups

Consider creating GitHub issues for these remaining issues:

- Add TX hardware encap/push overhead to MTU sizing for DPDK and ibverbs. Config validation already checks TX transform wire size against the jumbo bound, but MTU sizing does not yet include `flow_action_wire_overhead()` for TX flows. This matters for TX-only transform configs, where the egress wire frame can exceed the configured TX buffer frame.
- After TX transform MTU accounting is fixed, exclude generated dummy RX queues from DPDK MTU sizing too. This would make dummy queues consistently setup-only while avoiding a TX-only transform regression.
- Optional: Separately harden oversized TX behavior. `send_tx_burst()` can report success after enqueueing work even when the NIC later drops frames due to MTU or hardware constraints. Follow-up work should decide whether this is best handled by up-front packet length validation, clearer counters/logging, or completion/error reporting.

### Verification

- Built in the project container (`DAQIRI_ENGINE="dpdk ibverbs"`, Release): `daqiri_dpdk`, `daqiri_common`, and the DPDK benches compile clean.
- MTU-sizing check: on a single-interface config doing both RX and TX with a TX MR `buf_size` larger than the RX MR `buf_size`, the `Setting port config for port N mtu:` log now equals `max(TX_frame, RX_frame) − 18` instead of the RX-only value.
- Regression: RX-only configs are not inflated by the dummy TX queue; TX-only and standard two-interface `daqiri_bench_raw_tx_rx.yaml` MTUs are unchanged.
- HW verification pending