### PR TITLE
#207: Fix TX mempool exhaustion deadlock in tx_core_worker

### DIFF
--- a/dpdk_patches/mlx5_tx_done_cleanup.patch
+++ b/dpdk_patches/mlx5_tx_done_cleanup.patch
@@ -1,0 +1,59 @@
+diff --git a/drivers/net/mlx5/mlx5_tx.h b/drivers/net/mlx5/mlx5_tx.h
+--- a/drivers/net/mlx5/mlx5_tx.h
++++ b/drivers/net/mlx5/mlx5_tx.h
+@@ -237,6 +237,7 @@
+ void mlx5_tx_handle_completion(struct mlx5_txq_data *__rte_restrict txq,
+ 			       unsigned int olx __rte_unused);
+ int mlx5_tx_descriptor_status(void *tx_queue, uint16_t offset);
++int mlx5_tx_done_cleanup(void *tx_queue, uint32_t free_cnt);
+ void mlx5_txq_info_get(struct rte_eth_dev *dev, uint16_t queue_id,
+ 		       struct rte_eth_txq_info *qinfo);
+ int mlx5_tx_burst_mode_get(struct rte_eth_dev *dev, uint16_t tx_queue_id,
+diff --git a/drivers/net/mlx5/mlx5_tx.c b/drivers/net/mlx5/mlx5_tx.c
+--- a/drivers/net/mlx5/mlx5_tx.c
++++ b/drivers/net/mlx5/mlx5_tx.c
+@@ -288,5 +288,27 @@ mlx5_tx_descriptor_status(void *tx_queue, uint16_t offset)
+ }
+ 
++/**
++ * DPDK callback to free consumed TX mbufs.
++ *
++ * @param tx_queue
++ *   The TX queue.
++ * @param[in] free_cnt
++ *   Maximum number of packets to free. Use 0 to indicate all possible packets
++ *   should be freed. Note that a packet may be using multiple mbufs.
++ *
++ * @return
++ *   Number of packets freed, or negative errno on error.
++ */
++int
++mlx5_tx_done_cleanup(void *tx_queue, uint32_t free_cnt __rte_unused)
++{
++	struct mlx5_txq_data *__rte_restrict txq = tx_queue;
++	uint16_t tail_before = txq->elts_tail;
++
++	mlx5_tx_handle_completion(txq, 0);
++	return (uint16_t)(txq->elts_tail - tail_before);
++}
++
+ /*
+  * Array of declared and compiled Tx burst function and corresponding
+  * supported offloads set. The array is used to select the Tx burst
+diff --git a/drivers/net/mlx5/mlx5.c b/drivers/net/mlx5/mlx5.c
+--- a/drivers/net/mlx5/mlx5.c
++++ b/drivers/net/mlx5/mlx5.c
+@@ -2585,5 +2585,6 @@ const struct eth_dev_ops mlx5_dev_ops = {
+ 	.rxq_info_get = mlx5_rxq_info_get,
+ 	.txq_info_get = mlx5_txq_info_get,
++	.tx_done_cleanup = mlx5_tx_done_cleanup,
+ 	.rx_burst_mode_get = mlx5_rx_burst_mode_get,
+ 	.tx_burst_mode_get = mlx5_tx_burst_mode_get,
+ 	.rx_queue_intr_enable = mlx5_rx_intr_enable,
+@@ -2680,5 +2681,6 @@ const struct eth_dev_ops mlx5_dev_ops_isolate = {
+ 	.rxq_info_get = mlx5_rxq_info_get,
+ 	.txq_info_get = mlx5_txq_info_get,
++	.tx_done_cleanup = mlx5_tx_done_cleanup,
+ 	.rx_burst_mode_get = mlx5_rx_burst_mode_get,
+ 	.tx_burst_mode_get = mlx5_tx_burst_mode_get,
+ 	.rx_queue_intr_enable = mlx5_rx_intr_enable,

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -6110,7 +6110,16 @@ int DpdkEngine::tx_core_worker(void* arg) {
                     (void*)tparams->ring);
 
   while (!force_quit.load()) {
-    if (rte_ring_dequeue(tparams->ring, reinterpret_cast<void**>(&msg)) != 0) { continue; }
+    if (rte_ring_dequeue(tparams->ring, reinterpret_cast<void**>(&msg)) != 0) {
+      // Poll TX completions while idle so the PMD reclaims mbufs back to the
+      // mempool.  Without this, is_tx_burst_available() can permanently gate
+      // new submissions once the pool drops below the 2×batch threshold,
+      // because rte_eth_tx_burst() — the only other reclaim path — is never
+      // called when the ring is empty.  On mlx5 this dispatches to
+      // mlx5_tx_descriptor_status() → mlx5_tx_handle_completion().
+      (void)rte_eth_tx_descriptor_status(tparams->port, tparams->queue, 0);
+      continue;
+    }
 
     // Scatter mode needs to chain all the buffers
     if (msg->hdr.hdr.num_segs > 1) {

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -6115,9 +6115,8 @@ int DpdkEngine::tx_core_worker(void* arg) {
       // mempool.  Without this, is_tx_burst_available() can permanently gate
       // new submissions once the pool drops below the 2×batch threshold,
       // because rte_eth_tx_burst() — the only other reclaim path — is never
-      // called when the ring is empty.  On mlx5 this dispatches to
-      // mlx5_tx_descriptor_status() → mlx5_tx_handle_completion().
-      (void)rte_eth_tx_descriptor_status(tparams->port, tparams->queue, 0);
+      // called when the ring is empty.
+      (void)rte_eth_tx_done_cleanup(tparams->port, tparams->queue, 0);
       continue;
     }
 


### PR DESCRIPTION
Fixes #207

## Problem

`tx_core_worker` never polls NIC TX completions while idling (empty ring), so mbufs are never reclaimed and `is_tx_burst_available()` blocks the producer permanently. Throughput collapses from >10 Mpps to ~2 Kpps.

## Fix

Poll completions in the `tx_core_worker` idle path so mbufs are returned to the pool even when no new work is queued.

### Why the DPDK patch is needed

DPDK provides `rte_eth_tx_done_cleanup()` as the standard API for explicitly reclaiming completed TX mbufs without sending new packets. However, the mlx5 PMD in DPDK 25.11 does **not** implement the `tx_done_cleanup` callback — calling it returns `-ENOTSUP`.

The only ways to trigger mlx5 completion processing (`mlx5_tx_handle_completion`) are:

| Method | API | Problem |
|--------|-----|---------|
| Send packets | `rte_eth_tx_burst()` | Requires work in the ring — useless when idle |
| Check descriptor | `rte_eth_tx_descriptor_status()` | Calls `mlx5_tx_handle_completion()` as a **side effect**, but that's not the function's contract — it is meant to report descriptor state, not reclaim mbufs. Future DPDK versions could change this behavior. |
| Done cleanup | `rte_eth_tx_done_cleanup()` | Correct API, but returns `-ENOTSUP` on mlx5 |

The patch adds a trivial `mlx5_tx_done_cleanup()` (~20 lines) that wraps the **existing** `mlx5_tx_handle_completion()` — no new completion logic is introduced. It simply exposes the internal function through the official DPDK callback so `rte_eth_tx_done_cleanup()` works as intended.

Without this patch, the only alternative is the `rte_eth_tx_descriptor_status` side-effect workaround (commit 1), which is fragile and semantically incorrect.

## Commits

| Commit | Description |
|--------|-------------|
| `9f62fe2` | **Workaround** — call `rte_eth_tx_descriptor_status(port, queue, 0)` in idle path. On mlx5 this triggers `mlx5_tx_handle_completion()` as a side effect. |
| `19f5329` | **DPDK patch** — add `mlx5_tx_done_cleanup()` to mlx5 PMD as a wrapper around `mlx5_tx_handle_completion`. Registered in `mlx5_dev_ops` and `mlx5_dev_ops_isolate`. |
| `a7354dc` | **Use proper API** — replace descriptor_status workaround with `rte_eth_tx_done_cleanup(port, queue, 0)`. |

## Reproduction

See the self-contained test script in issue #207.

```bash
# Without fix (demonstrates the bug):
# → ~20K packets in 10s → FAIL

# With fix:
# → >10M packets in 10s → PASS
```

## Testing

- Container build: clean, no warnings
- Throughput test PASS after commit 1 (workaround) and after commit 3 (final fix)
