### PR TITLE
Use DPDK bulk free for RX bursts

### DIFF
--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -6729,9 +6729,10 @@ void DpdkEngine::free_all_packets(BurstParams* burst) {
     }
     return;
   }
-  for (int p = 0; p < burst->hdr.hdr.num_pkts; p++) {
-    rte_pktmbuf_free(reinterpret_cast<rte_mbuf**>(burst->pkts[0])[p]);
+  if (burst->hdr.hdr.num_pkts == 0 || burst->pkts[0] == nullptr) {
+    return;
   }
+  rte_pktmbuf_free_bulk(reinterpret_cast<rte_mbuf**>(burst->pkts[0]), burst->hdr.hdr.num_pkts);
 }
 
 void DpdkEngine::free_rx_burst(BurstParams* burst) {


### PR DESCRIPTION
## Summary
- Fixes #228.
- Changes only the non-reordered DPDK `DpdkEngine::free_all_packets` whole-burst path to call `rte_pktmbuf_free_bulk` instead of freeing each mbuf individually.
- Enables a single RX queue HDS GPUDirect path to sustain 100 GbE line rate without RX missed/out-of-buffer drops.
- Leaves reordered burst release unchanged.
- Leaves `free_packet`, `free_packet_segment`, and `free_all_segment_packets` unchanged, so partial packet/segment-free semantics are intentionally unchanged.

## Testing
- `git diff --check`
- `git clang-format --style file --diff HEAD -- src/engines/dpdk/daqiri_dpdk_engine.cpp`
- `cmake --build build --target daqiri_dpdk -j8`
- `cmake --build build --target daqiri_bench_raw_gpudirect -j8`
- `cmake --build build --target daqiri_bench_raw_hds -j8`

HDS hardware-loopback A/B, 1 RX queue, GPUDirect HDS, 30 seconds:

- Baseline parent, per-packet `rte_pktmbuf_free` loop:
  - App RX: 50,145,280 packets, about 96.8 Gbps
  - `mlnx_perf` RX physical samples: line rate
  - RX missed/out-of-buffer errors: 391,156

- This PR, `rte_pktmbuf_free_bulk`:
  - App RX: 50,544,640 packets, about 97.5 Gbps
  - `mlnx_perf` RX physical samples: line rate
  - RX missed/out-of-buffer errors: 0

Single-segment device-memory GPUDirect hardware-loopback, 1 RX queue, 30 seconds:
- App RX: about 96.5 Gbps
- DPDK `rx_phy`: about 96.6 Gbps
- `mlnx_perf` steady RX physical samples: about 100 Gbps

## Notes
- This PR is not an API expansion.
- The change applies only when DAQIRI is releasing an entire non-reordered DPDK RX burst.
- The measured effect is that the existing whole-burst free API no longer prevents single-queue HDS GPUDirect RX from sustaining line rate.
