### PR TITLE
#230 - Fix raw bench TX fill into CPU packet buffers (cudaMemcpyDefault)

### DIFF
--- a/examples/raw_gpudirect_bench.cpp
+++ b/examples/raw_gpudirect_bench.cpp
@@ -122,8 +122,9 @@ void tx_worker(const daqiri::bench::RawBenchTxConfig &cfg,
           std::memcpy(packet_template.data() + cfg.header_size, &seq, sizeof(seq));
         }
         daqiri::bench::finalize_udp_ipv4_checksums(packet_template.data());
+        // cudaMemcpyDefault works whether the packet buffer is GPU or CPU memory.
         if (cudaMemcpy(gpu_pkt, packet_template.data(), packet_template.size(),
-                       cudaMemcpyHostToDevice) != cudaSuccess) {
+                       cudaMemcpyDefault) != cudaSuccess) {
           failed = true;
           break;
         }


### PR DESCRIPTION
The raw GPUDirect bench fills each TX packet buffer from a host-side template with cudaMemcpy(..., cudaMemcpyHostToDevice). That direction is only valid when the destination is device memory. With memory kind: huge (or host), the packet buffers live in CPU hugepages, so the copy fails, tx_worker aborts the fill, and the sweep reports zero TX bursts.

Use cudaMemcpyDefault, which infers the copy direction from the pointers under UVA. It behaves identically for the existing kind: device / host_pinned cases (destination is device memory) and additionally works when the destination is CPU memory, enabling host-DMA TX benchmarks.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>