### PR TITLE
#237 - Add direct/indirect polling

### DIFF
--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -164,11 +164,19 @@ engine.
   - type: `string`
 - **`id`**: Integer ID used for flow steering and burst retrieval.
   - type: `integer`
-- **`cpu_core`**: CPU core ID for the RX worker thread. Should be an isolated core for best
-  performance.
+- **`poll_mode`**: `indirect` uses the current DAQIRI RX worker and application handoff ring.
+  `direct` makes the thread calling `get_rx_burst()` poll the NIC synchronously and is supported
+  only by the raw ibverbs engine.
+  - type: `string`
+  - values: `indirect`, `direct`
+  - default: `indirect`
+- **`cpu_core`**: CPU core ID for the RX worker thread. Required in indirect mode and forbidden
+  in direct mode. Should be an isolated core for best performance.
   - type: `string`
 - **`batch_size`**: Number of packets per batch passed from the NIC to the application. Larger
-  values increase throughput, and smaller values reduce latency.
+  values increase throughput, and smaller values reduce latency. Required in indirect mode and
+  forbidden in direct mode. A direct poll returns the packets currently ready, up to 256,
+  without waiting.
   - type: `integer`
 - **`memory_regions`**: List of memory region names (defined in [Memory Regions](#memory-regions)).
   The order determines segment mapping: first region = segment 0, second = segment 1, etc.
@@ -177,8 +185,14 @@ engine.
   - type: `list`
 - **`timeout_us`**: Timeout in microseconds. A partial batch is delivered if this time elapses
   before `batch_size` packets are collected. Set to `0` to disable (wait for full batch only).
+  Forbidden in direct mode.
   - type: `integer`
   - default: `0`
+
+Direct queues must be polled by exactly one user thread per queue. They do not create an RX
+worker or handoff ring, so an application stall also stops CQ draining and WQE reposting. A
+direct queue cannot be targeted by an RX reorder configuration. Unsupported engines, reorder,
+or forbidden worker fields produce a warning followed by configuration failure.
 
 ### Flex Items
 
@@ -409,11 +423,18 @@ daqiri::set_reorder_cuda_stream("rx_port", "rx_reorder_0", stream);
   - type: `string`
 - **`id`**: Integer ID used for burst submission.
   - type: `integer`
-- **`cpu_core`**: CPU core ID for the TX worker thread. Should be an isolated core for best
-  performance.
+- **`poll_mode`**: `indirect` hands bursts to a DAQIRI TX worker. `direct` makes the calling
+  thread synchronously poll completions, build one packet's WQE, and ring the NIC doorbell;
+  it is supported only by the raw ibverbs engine.
+  - type: `string`
+  - values: `indirect`, `direct`
+  - default: `indirect`
+- **`cpu_core`**: CPU core ID for the TX worker thread. Required in indirect mode and forbidden
+  in direct mode. Should be an isolated core for best performance.
   - type: `string`
 - **`batch_size`**: Number of packets per batch sent to the NIC. Larger values increase
-  throughput, and smaller values reduce latency.
+  throughput, and smaller values reduce latency. Required in indirect mode and forbidden in
+  direct mode; direct TX requires exactly one packet per API submission.
   - type: `integer`
 - **`memory_regions`**: List of memory region names. Same segment mapping rules as RX.
   - type: `list`
@@ -433,6 +454,13 @@ daqiri::set_reorder_cuda_stream("rx_port", "rx_reorder_0", stream);
   bound and typical-packet-size fields at their device defaults.
   - type: `integer`
   - default: `0`
+
+A direct TX queue creates no handoff ring or worker. One application thread owns the queue and
+may have only one acquired-but-unsubmitted packet at a time. `BurstParams` remains the ownership
+handle, but neither it nor the packet data crosses another CPU core: the caller writes directly
+to registered memory and `send_tx_burst()` posts directly to the mlx5 SQ. Completion reclamation
+occurs on later availability, allocation, or send calls. Unsupported engines and forbidden
+worker fields produce a warning followed by configuration failure.
 
 ### Transmit Flows
 

--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -190,8 +190,8 @@ engine.
   - default: `0`
 
 Direct queues must be polled by exactly one user thread per queue. They do not create an RX
-worker or handoff ring, so an application stall also stops CQ draining and WQE reposting. A
-direct queue cannot be targeted by an RX reorder configuration. Unsupported engines, reorder,
+worker or handoff ring, so an application stall also stops packet reception and buffer recycling.
+A direct queue cannot be targeted by an RX reorder configuration. Unsupported engines, reorder,
 or forbidden worker fields produce a warning followed by configuration failure.
 
 ### Flex Items
@@ -424,8 +424,8 @@ daqiri::set_reorder_cuda_stream("rx_port", "rx_reorder_0", stream);
 - **`id`**: Integer ID used for burst submission.
   - type: `integer`
 - **`poll_mode`**: `indirect` hands bursts to a DAQIRI TX worker. `direct` makes the calling
-  thread synchronously poll completions, build one packet's WQE, and ring the NIC doorbell;
-  it is supported only by the raw ibverbs engine.
+  thread submit one packet immediately and manage transmit progress; it is supported only by
+  the raw ibverbs engine.
   - type: `string`
   - values: `indirect`, `direct`
   - default: `indirect`
@@ -458,8 +458,8 @@ daqiri::set_reorder_cuda_stream("rx_port", "rx_reorder_0", stream);
 A direct TX queue creates no handoff ring or worker. One application thread owns the queue and
 may have only one acquired-but-unsubmitted packet at a time. `BurstParams` remains the ownership
 handle, but neither it nor the packet data crosses another CPU core: the caller writes directly
-to registered memory and `send_tx_burst()` posts directly to the mlx5 SQ. Completion reclamation
-occurs on later availability, allocation, or send calls. Unsupported engines and forbidden
+to the packet buffer and `send_tx_burst()` submits it directly. Completed packet buffers are
+reclaimed on later availability, allocation, or send calls. Unsupported engines and forbidden
 worker fields produce a warning followed by configuration failure.
 
 ### Transmit Flows

--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -81,8 +81,9 @@ auto status = daqiri::get_rx_burst(&burst, port_id, queue_id);
 ```
 
 `get_rx_burst()` is non-blocking. It returns `Status::SUCCESS` when a complete batch is
-available, or `Status::NULL_PTR` when no indirect burst is ready yet. There are also overloads
-that dequeue from any queue on a port, or from any queue on any port:
+available. When no burst is ready, engines return `Status::NULL_PTR` or `Status::NOT_READY`;
+applications should handle both as an empty poll. There are also overloads that dequeue from
+any queue on a port, or from any queue on any port:
 
 ```cpp
 // From any queue on port 0
@@ -778,7 +779,7 @@ All functions that can fail return `daqiri::Status`:
 | `NULL_PTR` | Burst or internal pointer not initialized / no data ready |
 | `NO_FREE_BURST_BUFFERS` | Metadata buffer pool exhausted (increase `tx/rx_meta_buffers`) |
 | `NO_FREE_PACKET_BUFFERS` | Packet buffer pool exhausted (free buffers faster or increase `num_bufs`) |
-| `NOT_READY` | System not yet initialized |
+| `NOT_READY` | Operation cannot proceed yet / no data ready |
 | `INVALID_PARAMETER` | Invalid argument passed |
 | `NO_SPACE_AVAILABLE` | Ring or queue is full |
 | `NOT_SUPPORTED` | Operation not supported by the current engine or build options |

--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -93,11 +93,11 @@ daqiri::get_rx_burst(&burst);
 ```
 
 For an ibverbs RX queue configured with `poll_mode: direct`, the calling thread performs one
-bounded NIC CQ poll inside `get_rx_burst()`. A successful call returns the packets currently
-ready, up to 256, without a DAQIRI RX worker or handoff ring. Exactly one thread may poll each
-direct queue. Continue using the normal burst-free APIs; released receive WQEs are reposted by
-a subsequent direct poll. An empty direct poll returns `Status::NOT_READY`. Indirect mode remains
-the default.
+bounded check for ready packets inside `get_rx_burst()`. A successful call returns the packets
+currently ready, up to 256, without a DAQIRI RX worker or handoff ring. Exactly one thread may
+poll each direct queue. Continue using the normal burst-free APIs; released packet buffers are
+recycled by a subsequent direct poll. An empty direct poll returns `Status::NOT_READY`. Indirect
+mode remains the default.
 
 ### RX Step 2: Access packet data
 
@@ -413,13 +413,13 @@ daqiri::send_tx_burst(burst);
 
 In the default indirect mode, the burst is enqueued to the TX worker thread, which sends it to
 the NIC via DMA. A raw ibverbs queue configured with `poll_mode: direct` requires `batch_size`
-to be omitted and `num_pkts == 1`. The calling thread polls completions, builds the WQE, and
-rings the NIC doorbell synchronously. `BurstParams` is only an ownership handle; neither the
-metadata nor packet data is handed to another core.
+to be omitted and `num_pkts == 1`. The calling thread submits the packet synchronously and
+manages transmit progress. `BurstParams` is only an ownership handle; neither the metadata nor
+packet data is handed to another core.
 
-`send_tx_burst()` takes ownership of the burst on success and on a full-ring
-or full-SQ failure. In direct mode, `SUCCESS` means the WQE has been posted and the doorbell
-rung, while completion is reclaimed by a later caller-driven operation. On
+`send_tx_burst()` takes ownership of the burst on success and when transmit capacity is
+temporarily exhausted. In direct mode, `SUCCESS` means the packet has been submitted to the NIC;
+the packet buffer is reclaimed by a later caller-driven operation. On
 `NO_SPACE_AVAILABLE` it has already freed the packet reservation and metadata. In both
 cases the application must **not** free or otherwise access the burst afterwards.
 `NO_SPACE_AVAILABLE` is the only failure a correctly-configured sender encounters

--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -81,7 +81,7 @@ auto status = daqiri::get_rx_burst(&burst, port_id, queue_id);
 ```
 
 `get_rx_burst()` is non-blocking. It returns `Status::SUCCESS` when a complete batch is
-available, or `Status::NULL_PTR` when no burst is ready yet. There are also overloads
+available, or `Status::NULL_PTR` when no indirect burst is ready yet. There are also overloads
 that dequeue from any queue on a port, or from any queue on any port:
 
 ```cpp
@@ -91,6 +91,13 @@ daqiri::get_rx_burst(&burst, 0);
 // From any queue on any port (round-robin)
 daqiri::get_rx_burst(&burst);
 ```
+
+For an ibverbs RX queue configured with `poll_mode: direct`, the calling thread performs one
+bounded NIC CQ poll inside `get_rx_burst()`. A successful call returns the packets currently
+ready, up to 256, without a DAQIRI RX worker or handoff ring. Exactly one thread may poll each
+direct queue. Continue using the normal burst-free APIs; released receive WQEs are reposted by
+a subsequent direct poll. An empty direct poll returns `Status::NOT_READY`. Indirect mode remains
+the default.
 
 ### RX Step 2: Access packet data
 
@@ -404,14 +411,20 @@ Or construct raw packets by writing directly into the packet buffer returned by
 daqiri::send_tx_burst(burst);
 ```
 
-The burst is enqueued to the TX worker thread, which sends it to the NIC via DMA.
+In the default indirect mode, the burst is enqueued to the TX worker thread, which sends it to
+the NIC via DMA. A raw ibverbs queue configured with `poll_mode: direct` requires `batch_size`
+to be omitted and `num_pkts == 1`. The calling thread polls completions, builds the WQE, and
+rings the NIC doorbell synchronously. `BurstParams` is only an ownership handle; neither the
+metadata nor packet data is handed to another core.
 
 `send_tx_burst()` takes ownership of the burst on success and on a full-ring
-failure: on `SUCCESS` the TX worker owns it, and on `NO_SPACE_AVAILABLE` (the TX
-ring is full) it has already freed the packets and the burst internally. In both
+or full-SQ failure. In direct mode, `SUCCESS` means the WQE has been posted and the doorbell
+rung, while completion is reclaimed by a later caller-driven operation. On
+`NO_SPACE_AVAILABLE` it has already freed the packet reservation and metadata. In both
 cases the application must **not** free or otherwise access the burst afterwards.
 `NO_SPACE_AVAILABLE` is the only failure a correctly-configured sender encounters
-at runtime.
+at submission time. A second direct acquisition before the pending packet is sent or freed
+returns `NOT_READY`; zero- or multi-packet direct requests return `INVALID_PARAMETER`.
 
 ### Timed Transmission
 

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -221,6 +221,10 @@ with `rx.hardware_timestamps: true` and the NIC supports
 [C++ API Usage → Receiving Packets](cpp.md#receiving-packets) for the clock
 semantics. The Python wrapper exposes the same timestamps in nanoseconds.
 
+`RxQueueConfig.poll_mode` accepts `QueuePollMode.INDIRECT` (the default) or
+`QueuePollMode.DIRECT`. Direct mode is available only on raw ibverbs RX queues and makes the
+Python thread calling `get_rx_burst()` perform the bounded CQ poll while the GIL is released.
+
 ### RX Step 3: Free buffers
 
 When you are done with a burst, free it:
@@ -357,8 +361,11 @@ status = daqiri.send_tx_burst(burst)
 ```
 
 `send_tx_burst()` takes ownership of the burst on success and on a full-ring
-failure: on `SUCCESS` the worker thread owns it, and on `NO_SPACE_AVAILABLE` (the
-TX ring is full) it has already freed the packets and the burst internally. In
+or full-SQ failure. `TxQueueConfig.poll_mode = QueuePollMode.DIRECT` selects single-packet raw
+ibverbs direct TX. The Python thread polls completions, builds the WQE, and rings the NIC
+doorbell; no worker or handoff ring touches the packet. Direct TX requires exactly one packet,
+one pending handle, and one thread per queue. On `NO_SPACE_AVAILABLE` DAQIRI has already freed
+the packet reservation and burst internally. In
 both cases the application must **not** free or otherwise access the burst
 afterwards. `NO_SPACE_AVAILABLE` is the only failure a correctly-configured
 sender encounters at runtime.
@@ -664,6 +671,7 @@ encapsulation/push rules are configured in YAML under `tx.flows`.
 | `BufferLocation` | `CPU`, `GPU`, `CPU_GPU_SPLIT` |
 | `MemoryKind` | `HOST`, `HOST_PINNED`, `HUGE`, `DEVICE`, `INVALID` |
 | `StreamType` | `RAW`, `SOCKET`, `INVALID` |
+| `QueuePollMode` | `INDIRECT`, `DIRECT`, `INVALID` |
 | `LoopbackType` | `DISABLED`, `LOOPBACK_TYPE_SW` |
 | `RDMAMode` | `CLIENT`, `SERVER`, `INVALID` |
 | `RDMATransportMode` | `RC`, `UC`, `UD`, `INVALID` |
@@ -698,8 +706,8 @@ names that mostly omit the trailing underscore from the C++ member name (e.g.
 | `RxConfig` | RX flow isolation, timestamps, queues, flows, flex items, and reorder configs. |
 | `TxConfig` | TX accurate-send flag, queues, and flows. |
 | `CommonQueueConfig` | Shared queue fields: name, ID, batch size, split boundary, CPU core, memory regions, and offloads. |
-| `RxQueueConfig` | RX queue wrapper with common queue fields and timeout. |
-| `TxQueueConfig` | TX queue wrapper with common queue fields. |
+| `RxQueueConfig` | RX queue wrapper with common queue fields, timeout, and `QueuePollMode`. |
+| `TxQueueConfig` | TX queue wrapper with common queue fields and `QueuePollMode`. |
 | `MemoryRegionConfig` | Memory region kind, affinity, access flags, sizes, counts, and ownership. |
 | `VlanActionConfig` | VLAN push parameters: VLAN ID, priority, DEI, and ethertype. |
 | `TunnelConfig` | VXLAN, GRE, or NVGRE tunnel template fields for hardware encap/decap actions. |

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -223,7 +223,7 @@ semantics. The Python wrapper exposes the same timestamps in nanoseconds.
 
 `RxQueueConfig.poll_mode` accepts `QueuePollMode.INDIRECT` (the default) or
 `QueuePollMode.DIRECT`. Direct mode is available only on raw ibverbs RX queues and makes the
-Python thread calling `get_rx_burst()` perform the bounded CQ poll while the GIL is released.
+Python thread calling `get_rx_burst()` check for ready packets while the GIL is released.
 
 ### RX Step 3: Free buffers
 
@@ -360,12 +360,12 @@ status = daqiri.send_tx_burst(burst)
 # Do not free `burst` after a SUCCESS or NO_SPACE_AVAILABLE return. See the ownership note below.
 ```
 
-`send_tx_burst()` takes ownership of the burst on success and on a full-ring
-or full-SQ failure. `TxQueueConfig.poll_mode = QueuePollMode.DIRECT` selects single-packet raw
-ibverbs direct TX. The Python thread polls completions, builds the WQE, and rings the NIC
-doorbell; no worker or handoff ring touches the packet. Direct TX requires exactly one packet,
-one pending handle, and one thread per queue. On `NO_SPACE_AVAILABLE` DAQIRI has already freed
-the packet reservation and burst internally. In
+`send_tx_burst()` takes ownership of the burst on success and when transmit capacity is
+temporarily exhausted. `TxQueueConfig.poll_mode = QueuePollMode.DIRECT` selects single-packet raw
+ibverbs direct TX. The Python thread submits the packet and manages transmit progress; no worker
+or handoff ring touches the packet. Direct TX requires exactly one packet, one pending handle,
+and one thread per queue. On `NO_SPACE_AVAILABLE` DAQIRI has already freed the packet reservation
+and burst internally. In
 both cases the application must **not** free or otherwise access the burst
 afterwards. `NO_SPACE_AVAILABLE` is the only failure a correctly-configured
 sender encounters at runtime.

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -169,8 +169,8 @@ if status != daqiri.Status.SUCCESS:
 ### RX Step 1: Get a burst
 
 `get_rx_burst()` is non-blocking. It returns `(Status, BurstParams | None)`.
-`Status.SUCCESS` means a burst is ready. Other statuses (including `NULL_PTR`)
-mean no burst is ready yet or an error occurred.
+`Status.SUCCESS` means a burst is ready. `Status.NULL_PTR` and
+`Status.NOT_READY` both mean no burst is ready; other statuses report errors.
 
 ```python
 port_id = daqiri.get_port_id("rx_port")

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -246,18 +246,24 @@ buffers (CPU hugepages, GPU device memory, or pinned host memory).
 
 ### Queue Polling Modes (`poll_mode`)
 
-The per-queue `poll_mode` setting controls which thread moves packets between
-the application and the network. It applies independently to RX and TX queues
-and defaults to `indirect` when omitted.
+With packet processing there is an inverse relationship with bandwidth and latency. This is mainly for two reasons:
+
+1) Batching packets allows more optimizations, but takes longer to wait
+2) Larger packet sizes are more efficient for higher bandwidth, but take longer to transmit and receive
+
+DAQIRI allows users to select whether to prefer higher bandwidth or lower latency on a per-queue basis. A typical 
+use case for this would be high bandwidth for data plane, and low latency for control plane. Note that these are extreme definitions of high bandwidth and low latency. DAQIRI already provides extremely low latency and high bandwidth by bypassing the Linux kernel, regardless of the setting. Choosing low latency may save low single digit microseconds per packet.
+
+The `poll_mode` setting is used by choosing either indirect for high bandwidth, or direct for low latency by choosing which thread polls the NIC. `indirect` mode is chosen by default to favor high bandwidth and batching.
 
 | Mode | Who services the queue? | Best suited for |
 |---|---|---|
-| `indirect` | A DAQIRI worker running on the queue's configured `cpu_core` | General use, batching, and applications that should not have to poll continuously |
+| `indirect` | A DAQIRI worker running on the queue's configured `cpu_core` | General use, batching, highest bandwidth |
 | `direct` | The application thread calling the RX or TX API | The lowest single-packet latency when the application can dedicate one thread to each queue |
 
 In **indirect mode**, the application and DAQIRI worker exchange bursts. The
 queue requires `cpu_core` and `batch_size`; RX queues may also use `timeout_us`
-to return a partial batch. This is the existing behavior and is supported by
+to return a partial batch. `indirect` mode also allows more processing jitter in the application threads by using a zero-copy ring in between DAQIRI and the user. This is the existing behavior and is supported by
 all applicable engines.
 
 In **direct mode**, there is no worker between the application and the queue.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,8 +10,8 @@ This page is the DAQIRI glossary. It defines the terms used across the
 [Configuration Reference](api-reference/configuration.md), and
 [tutorials](tutorials/system_configuration.md): **stream types and
 endpoint URI schemes**, **GPUDirect**, **packet / burst / segment**,
-**flow / queue**, **memory region**, **zero-copy ownership**, and
-**RX reorder**.
+**flow / queue**, **memory region**, **zero-copy ownership**,
+**queue polling modes**, and **RX reorder**.
 
 ## Stream Types
 
@@ -237,12 +237,54 @@ right application buffer.
 ### Queue
 
 A **queue** is a NIC-side buffer that an application reads from (RX) or
-writes to (TX). Each queue is assigned a CPU core in the YAML to poll
-it, but queues and cores are not strictly one-to-one: one core can poll
-multiple queues, and a TX queue can be fed from multiple cores.
+writes to (TX). By default, each queue is assigned a CPU core in the YAML
+for DAQIRI to service. Queues and cores are not strictly one-to-one: one
+core can service multiple queues.
 
 A queue points at one or more *memory regions*, which hold its packet
 buffers (CPU hugepages, GPU device memory, or pinned host memory).
+
+### Queue Polling Modes (`poll_mode`)
+
+The per-queue `poll_mode` setting controls which thread moves packets between
+the application and the network. It applies independently to RX and TX queues
+and defaults to `indirect` when omitted.
+
+| Mode | Who services the queue? | Best suited for |
+|---|---|---|
+| `indirect` | A DAQIRI worker running on the queue's configured `cpu_core` | General use, batching, and applications that should not have to poll continuously |
+| `direct` | The application thread calling the RX or TX API | The lowest single-packet latency when the application can dedicate one thread to each queue |
+
+In **indirect mode**, the application and DAQIRI worker exchange bursts. The
+queue requires `cpu_core` and `batch_size`; RX queues may also use `timeout_us`
+to return a partial batch. This is the existing behavior and is supported by
+all applicable engines.
+
+In **direct mode**, there is no worker between the application and the queue.
+The application thread performs the queue work as part of its normal API calls:
+
+- Direct RX returns all packets currently ready, up to 256, without waiting.
+  An empty poll returns `Status::NOT_READY`.
+- Direct TX accepts exactly one packet per `BurstParams`. A successful
+  `send_tx_burst()` means the packet was submitted; the application must not
+  access that burst afterward.
+- Exactly one application thread must own each direct queue. A direct TX queue
+  may have only one acquired-but-unsubmitted packet at a time.
+
+Direct mode is available only for the raw `ibverbs` engine. A direct queue must
+omit `cpu_core`, `batch_size`, and, for RX, `timeout_us`. Direct RX does not
+support reorder configurations. Direct and indirect queues may be mixed on the
+same interface.
+
+Direct mode removes the cross-thread handoff that can add latency, but it also
+makes application scheduling part of packet I/O. If the application thread is
+descheduled, blocked, or busy doing other work, packet processing for that queue
+stops until it calls DAQIRI again. Use indirect mode when steady progress or
+batch throughput matters more than minimum latency.
+
+See the [RX queue](api-reference/configuration.md#queues) and
+[TX queue](api-reference/configuration.md#queues_1) configuration references
+for the complete field rules.
 
 ### Flow
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -246,7 +246,7 @@ buffers (CPU hugepages, GPU device memory, or pinned host memory).
 
 ### Queue Polling Modes (`poll_mode`)
 
-With packet processing there is an inverse relationship with bandwidth and latency. This is mainly for two reasons:
+With packet processing there is an inverse relationship between bandwidth and latency. This is mainly for two reasons:
 
 1) Batching packets allows more optimizations, but takes longer to wait
 2) Larger packet sizes are more efficient for higher bandwidth, but take longer to transmit and receive

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -271,7 +271,9 @@ Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_
  *    SUCCESS: Packets allocated
  *    NULL_PTR: Burst or packet pools uninitialized
  *    NO_FREE_BURST_BUFFERS: No burst buffers to allocate
- *    NO_FREE_CPU_PACKET_BUFFERS: Not enough CPU packet buffers available
+ *    NO_FREE_PACKET_BUFFERS: Not enough packet buffers or SQ credits available
+ *    NOT_READY: A direct queue already has a pending packet or rejected the caller
+ *    INVALID_PARAMETER: Invalid queue or non-single-packet direct request
  */
 Status get_tx_packet_burst(BurstParams *burst);
 
@@ -754,17 +756,20 @@ void set_num_packets(BurstParams *burst, int64_t num);
 /**
  * @brief Send a TX burst.
  *
- * Takes ownership of @p burst on SUCCESS and on NO_SPACE_AVAILABLE: on SUCCESS
- * the TX worker owns it; on NO_SPACE_AVAILABLE (TX ring full) it has already
- * freed the packets and the burst internally. In both cases the caller must
+ * Takes ownership of @p burst on SUCCESS and on NO_SPACE_AVAILABLE. Indirect
+ * mode hands a successful burst to the TX worker; raw ibverbs direct mode has
+ * already posted its single-packet WQE before returning SUCCESS. On
+ * NO_SPACE_AVAILABLE it has already freed the packets and burst internally.
+ * In all ownership-consuming cases the caller must
  * NOT free or otherwise access @p burst afterwards. NO_SPACE_AVAILABLE is the
  * only failure a correctly-configured sender hits at runtime.
  *
  * @param burst Burst structure
  * @return Status indicating result. Valid values are:
- *    SUCCESS: burst enqueued to the TX worker (ownership transferred)
- *    NO_SPACE_AVAILABLE: TX ring full; burst already freed (ownership consumed)
+ *    SUCCESS: burst enqueued or directly posted (ownership transferred)
+ *    NO_SPACE_AVAILABLE: TX ring/SQ full; burst already freed (ownership consumed)
  *    INVALID_PARAMETER: bad port/queue; burst NOT consumed (see issue #164)
+ *    NOT_READY: direct queue called concurrently or from a non-owner thread; burst not consumed
  */
 Status send_tx_burst(BurstParams *burst);
 
@@ -1053,10 +1058,10 @@ template <> struct YAML::convert<daqiri::NetworkConfig> {
    * otherwise.
    * @return true if parsing was successful, false otherwise.
    */
-  static bool
-  parse_tx_queue_common_config(const YAML::Node &q_item,
-                               daqiri::TxQueueConfig &tx_queue_config,
-                               bool parse_memory_regions);
+  static bool parse_tx_queue_common_config(const YAML::Node& q_item,
+                                           daqiri::TxQueueConfig& tx_queue_config,
+                                           bool parse_memory_regions,
+                                           bool require_worker_fields = true);
 
   /**
    * @brief Decode the YAML node into an NetworkConfig object.

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -781,7 +781,7 @@ Status send_tx_burst(BurstParams *burst);
  * @param q Queue ID of interface
  * @return Status indicating status. Valid values are:
  *    SUCCESS: Burst received successfully
- *    NULL_PTR: No bursts ready to receive
+ *    NULL_PTR or NOT_READY: No bursts ready to receive
  */
 Status get_rx_burst(BurstParams **burst, int port, int q);
 
@@ -792,7 +792,7 @@ Status get_rx_burst(BurstParams **burst, int port, int q);
  * @param port Port ID of interface
  * @return Status indicating status. Valid values are:
  *    SUCCESS: Burst received successfully
- *    NULL_PTR: No bursts ready to receive on any queue for this port
+ *    NULL_PTR or NOT_READY: No bursts ready to receive on any queue for this port
  */
 Status get_rx_burst(BurstParams **burst, int port);
 
@@ -802,7 +802,7 @@ Status get_rx_burst(BurstParams **burst, int port);
  * @param burst Burst structure
  * @return Status indicating status. Valid values are:
  *    SUCCESS: Burst received successfully
- *    NULL_PTR: No bursts ready to receive on any queue on any port
+ *    NULL_PTR or NOT_READY: No bursts ready to receive on any queue on any port
  */
 Status get_rx_burst(BurstParams **burst);
 

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -271,7 +271,7 @@ Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_
  *    SUCCESS: Packets allocated
  *    NULL_PTR: Burst or packet pools uninitialized
  *    NO_FREE_BURST_BUFFERS: No burst buffers to allocate
- *    NO_FREE_PACKET_BUFFERS: Not enough packet buffers or SQ credits available
+ *    NO_FREE_PACKET_BUFFERS: Not enough packet buffers or transmit capacity available
  *    NOT_READY: A direct queue already has a pending packet or rejected the caller
  *    INVALID_PARAMETER: Invalid queue or non-single-packet direct request
  */
@@ -758,7 +758,7 @@ void set_num_packets(BurstParams *burst, int64_t num);
  *
  * Takes ownership of @p burst on SUCCESS and on NO_SPACE_AVAILABLE. Indirect
  * mode hands a successful burst to the TX worker; raw ibverbs direct mode has
- * already posted its single-packet WQE before returning SUCCESS. On
+ * already submitted its single packet before returning SUCCESS. On
  * NO_SPACE_AVAILABLE it has already freed the packets and burst internally.
  * In all ownership-consuming cases the caller must
  * NOT free or otherwise access @p burst afterwards. NO_SPACE_AVAILABLE is the
@@ -767,7 +767,7 @@ void set_num_packets(BurstParams *burst, int64_t num);
  * @param burst Burst structure
  * @return Status indicating result. Valid values are:
  *    SUCCESS: burst enqueued or directly posted (ownership transferred)
- *    NO_SPACE_AVAILABLE: TX ring/SQ full; burst already freed (ownership consumed)
+ *    NO_SPACE_AVAILABLE: No transmit capacity; burst already freed (ownership consumed)
  *    INVALID_PARAMETER: bad port/queue; burst NOT consumed (see issue #164)
  *    NOT_READY: direct queue called concurrently or from a non-owner thread; burst not consumed
  */

--- a/include/daqiri/types.h
+++ b/include/daqiri/types.h
@@ -602,13 +602,13 @@ class EngineExtraQueueConfig {
 
 struct CommonQueueConfig {
   std::string name_;
-  int id_;
-  int batch_size_;
-  int split_boundary_;
+  int id_ = 0;
+  int batch_size_ = 0;
+  int split_boundary_ = 0;
   std::string cpu_core_;
   std::vector<std::string> mrs_;
   std::vector<std::string> offloads_;
-  EngineExtraQueueConfig* extra_queue_config_;
+  EngineExtraQueueConfig* extra_queue_config_ = nullptr;
 };
 
 struct MemoryRegionConfig {
@@ -623,13 +623,38 @@ struct MemoryRegionConfig {
   bool owned_;
 };
 
+enum class QueuePollMode { INDIRECT, DIRECT, INVALID };
+
+inline QueuePollMode queue_poll_mode_from_string(const std::string& str) {
+  if (str == "indirect") {
+    return QueuePollMode::INDIRECT;
+  }
+  if (str == "direct") {
+    return QueuePollMode::DIRECT;
+  }
+  return QueuePollMode::INVALID;
+}
+
+inline std::string queue_poll_mode_to_string(QueuePollMode mode) {
+  switch (mode) {
+    case QueuePollMode::INDIRECT:
+      return "indirect";
+    case QueuePollMode::DIRECT:
+      return "direct";
+    default:
+      return "invalid";
+  }
+}
+
 struct RxQueueConfig {
   CommonQueueConfig common_;
-  uint64_t timeout_us_;
+  uint64_t timeout_us_ = 0;
+  QueuePollMode poll_mode_ = QueuePollMode::INDIRECT;
 };
 
 struct TxQueueConfig {
   CommonQueueConfig common_;
+  QueuePollMode poll_mode_ = QueuePollMode::INDIRECT;
   // Packet pacing: average TX rate cap in megabits/sec (L2 frame bytes). 0
   // disables pacing (line-rate). Honored only by engines/devices with hardware
   // packet-pacing support.

--- a/python/daqiri_common_pybind.cpp
+++ b/python/daqiri_common_pybind.cpp
@@ -541,6 +541,11 @@ void bind_enums(py::module_ &m) {
       .value("SOCKET", StreamType::SOCKET)
       .value("INVALID", StreamType::INVALID);
 
+  py::enum_<QueuePollMode>(m, "QueuePollMode")
+      .value("INDIRECT", QueuePollMode::INDIRECT)
+      .value("DIRECT", QueuePollMode::DIRECT)
+      .value("INVALID", QueuePollMode::INVALID);
+
   py::enum_<SocketProtocol>(m, "SocketProtocol")
       .value("TCP", SocketProtocol::TCP)
       .value("UDP", SocketProtocol::UDP)
@@ -738,11 +743,13 @@ void bind_config_types(py::module_ &m) {
   py::class_<RxQueueConfig>(m, "RxQueueConfig")
       .def(py::init<>())
       .def_readwrite("common", &RxQueueConfig::common_)
-      .def_readwrite("timeout_us", &RxQueueConfig::timeout_us_);
+      .def_readwrite("timeout_us", &RxQueueConfig::timeout_us_)
+      .def_readwrite("poll_mode", &RxQueueConfig::poll_mode_);
 
   py::class_<TxQueueConfig>(m, "TxQueueConfig")
       .def(py::init<>())
-      .def_readwrite("common", &TxQueueConfig::common_);
+      .def_readwrite("common", &TxQueueConfig::common_)
+      .def_readwrite("poll_mode", &TxQueueConfig::poll_mode_);
 
   py::class_<VlanActionConfig>(m, "VlanActionConfig")
       .def(py::init<>())

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -444,8 +444,7 @@ int get_port_id(const std::string& key) {
 
 Status get_tx_packet_burst(BurstParams* burst) {
   ASSERT_DAQIRI_ENGINE_INITIALIZED();
-  if (!g_daqiri_engine->is_tx_burst_available(burst)) return Status::NO_FREE_BURST_BUFFERS;
-  return g_daqiri_engine->get_tx_packet_burst(burst);
+  return g_daqiri_engine->get_tx_packet_burst_checked(burst);
 }
 
 Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) {
@@ -1639,14 +1638,23 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_roce_config(
  * @param parse_memory_regions True if memory regions should be parsed, false otherwise.
  * @return true if parsing was successful, false otherwise.
  */
-bool parse_common_queue_config(const YAML::Node& q_item,
-                               daqiri::CommonQueueConfig& common,
-                               bool parse_memory_regions) {
+bool parse_common_queue_config(const YAML::Node& q_item, daqiri::CommonQueueConfig& common,
+                               bool parse_memory_regions, bool require_worker_fields = true) {
   try {
     common.name_ = q_item["name"].as<std::string>();
     common.id_ = q_item["id"].as<int>();
-    common.cpu_core_ = q_item["cpu_core"].as<std::string>();
-    common.batch_size_ = q_item["batch_size"].as<int>();
+    if (require_worker_fields) {
+      if (!q_item["cpu_core"].IsDefined() || !q_item["batch_size"].IsDefined()) {
+        DAQIRI_LOG_ERROR("Queue '{}' requires cpu_core and batch_size in indirect mode",
+                         common.name_);
+        return false;
+      }
+      common.cpu_core_ = q_item["cpu_core"].as<std::string>();
+      common.batch_size_ = q_item["batch_size"].as<int>();
+    } else {
+      common.cpu_core_.clear();
+      common.batch_size_ = 0;
+    }
     common.extra_queue_config_ = nullptr;
     if (q_item["memory_regions"].IsDefined()) {
       if (!parse_memory_regions) {
@@ -1698,11 +1706,43 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_rx_queue_config(
     daqiri::RxQueueConfig& q, bool parse_memory_regions) {
   try {
     daqiri::EngineType _engine_type = engine_type;
-
-    if (!parse_rx_queue_common_config(q_item, q, parse_memory_regions)) { return false; }
-
     if (engine_type == daqiri::EngineType::DEFAULT) {
       _engine_type = daqiri::EngineFactory::get_default_engine_type();
+    }
+
+    if (q_item["poll_mode"].IsDefined()) {
+      q.poll_mode_ = daqiri::queue_poll_mode_from_string(q_item["poll_mode"].as<std::string>());
+      if (q.poll_mode_ == daqiri::QueuePollMode::INVALID) {
+        DAQIRI_LOG_ERROR("Invalid RX poll_mode '{}'; valid values are indirect and direct",
+                         q_item["poll_mode"].as<std::string>());
+        return false;
+      }
+    }
+
+    if (q.poll_mode_ == daqiri::QueuePollMode::DIRECT) {
+      if (_engine_type != daqiri::EngineType::IBVERBS) {
+        DAQIRI_LOG_WARN(
+            "RX poll_mode direct is supported only by the raw ibverbs engine; "
+            "configured engine is {}",
+            daqiri::engine_type_to_string(_engine_type));
+        return false;
+      }
+      bool forbidden_field = false;
+      for (const char* field : {"cpu_core", "batch_size", "timeout_us"}) {
+        if (q_item[field].IsDefined()) {
+          DAQIRI_LOG_WARN("RX queue '{}' must omit {} when poll_mode is direct",
+                          q_item["name"].as<std::string>(), field);
+          forbidden_field = true;
+        }
+      }
+      if (forbidden_field) {
+        return false;
+      }
+    }
+
+    if (!parse_common_queue_config(q_item, q.common_, parse_memory_regions,
+                                   q.poll_mode_ == daqiri::QueuePollMode::INDIRECT)) {
+      return false;
     }
   } catch (const std::exception& e) {
     DAQIRI_LOG_ERROR("Error parsing RxQueueConfig: {}", e.what());
@@ -1719,9 +1759,11 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_rx_queue_config(
  * @return true if parsing was successful, false otherwise.
  */
 bool YAML::convert<daqiri::NetworkConfig>::parse_tx_queue_common_config(
-    const YAML::Node& q_item, daqiri::TxQueueConfig& q,
-    bool parse_memory_regions) {
-  if (!parse_common_queue_config(q_item, q.common_, parse_memory_regions)) { return false; }
+    const YAML::Node& q_item, daqiri::TxQueueConfig& q, bool parse_memory_regions,
+    bool require_worker_fields) {
+  if (!parse_common_queue_config(q_item, q.common_, parse_memory_regions, require_worker_fields)) {
+    return false;
+  }
   try {
     if (q_item["offloads"].IsDefined()) {
       const auto& offload = q_item["offloads"];
@@ -1759,7 +1801,40 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_tx_queue_config(
       _engine_type = daqiri::EngineFactory::get_default_engine_type();
     }
 
-    if (!parse_tx_queue_common_config(q_item, q, parse_memory_regions)) { return false; }
+    if (q_item["poll_mode"].IsDefined()) {
+      q.poll_mode_ = daqiri::queue_poll_mode_from_string(q_item["poll_mode"].as<std::string>());
+      if (q.poll_mode_ == daqiri::QueuePollMode::INVALID) {
+        DAQIRI_LOG_ERROR("Invalid TX poll_mode '{}'; valid values are indirect and direct",
+                         q_item["poll_mode"].as<std::string>());
+        return false;
+      }
+    }
+
+    if (q.poll_mode_ == daqiri::QueuePollMode::DIRECT) {
+      if (_engine_type != daqiri::EngineType::IBVERBS) {
+        DAQIRI_LOG_WARN(
+            "TX poll_mode direct is supported only by the raw ibverbs engine; "
+            "configured engine is {}",
+            daqiri::engine_type_to_string(_engine_type));
+        return false;
+      }
+      bool forbidden_field = false;
+      for (const char* field : {"cpu_core", "batch_size"}) {
+        if (q_item[field].IsDefined()) {
+          DAQIRI_LOG_WARN("TX queue '{}' must omit {} when poll_mode is direct",
+                          q_item["name"].as<std::string>(), field);
+          forbidden_field = true;
+        }
+      }
+      if (forbidden_field) {
+        return false;
+      }
+    }
+
+    if (!parse_tx_queue_common_config(q_item, q, parse_memory_regions,
+                                      q.poll_mode_ == daqiri::QueuePollMode::INDIRECT)) {
+      return false;
+    }
 
   } catch (const std::exception& e) {
     DAQIRI_LOG_ERROR("Error parsing TxQueueConfig: {}", e.what());

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -542,10 +542,67 @@ bool Engine::validate_config() const {
 
   for (const auto& intf : cfg_.ifs_) {
     std::set<uint16_t> rx_queue_ids;
+    std::set<uint16_t> direct_rx_queue_ids;
     for (const auto& rxq : intf.rx_.queues_) {
       rx_queue_ids.insert(rxq.common_.id_);
+      if (rxq.poll_mode_ == QueuePollMode::DIRECT) {
+        direct_rx_queue_ids.insert(rxq.common_.id_);
+        if (cfg_.common_.stream_type != StreamType::RAW ||
+            cfg_.common_.engine_type != EngineType::IBVERBS) {
+          DAQIRI_LOG_WARN(
+              "RX queue '{}' requests direct polling, which is supported only by the raw "
+              "ibverbs engine",
+              rxq.common_.name_);
+          pass = false;
+        }
+        if (!rxq.common_.cpu_core_.empty() || rxq.common_.batch_size_ != 0 ||
+            rxq.timeout_us_ != 0) {
+          DAQIRI_LOG_WARN(
+              "RX queue '{}' must omit cpu_core, batch_size, and timeout_us in direct mode",
+              rxq.common_.name_);
+          pass = false;
+        }
+      } else if (rxq.poll_mode_ == QueuePollMode::INDIRECT) {
+        if (rxq.common_.cpu_core_.empty() || rxq.common_.batch_size_ <= 0) {
+          DAQIRI_LOG_ERROR(
+              "RX queue '{}' requires cpu_core and a positive batch_size in indirect mode",
+              rxq.common_.name_);
+          pass = false;
+        }
+      } else {
+        DAQIRI_LOG_ERROR("RX queue '{}' has an invalid poll mode", rxq.common_.name_);
+        pass = false;
+      }
+    }
+    for (const auto& txq : intf.tx_.queues_) {
+      if (txq.poll_mode_ == QueuePollMode::DIRECT) {
+        if (cfg_.common_.stream_type != StreamType::RAW ||
+            cfg_.common_.engine_type != EngineType::IBVERBS) {
+          DAQIRI_LOG_WARN(
+              "TX queue '{}' requests direct polling, which is supported only by the raw "
+              "ibverbs engine",
+              txq.common_.name_);
+          pass = false;
+        }
+        if (!txq.common_.cpu_core_.empty() || txq.common_.batch_size_ != 0) {
+          DAQIRI_LOG_WARN("TX queue '{}' must omit cpu_core and batch_size in direct mode",
+                          txq.common_.name_);
+          pass = false;
+        }
+      } else if (txq.poll_mode_ == QueuePollMode::INDIRECT) {
+        if (txq.common_.cpu_core_.empty() || txq.common_.batch_size_ <= 0) {
+          DAQIRI_LOG_ERROR(
+              "TX queue '{}' requires cpu_core and a positive batch_size in indirect mode",
+              txq.common_.name_);
+          pass = false;
+        }
+      } else {
+        DAQIRI_LOG_ERROR("TX queue '{}' has an invalid poll mode", txq.common_.name_);
+        pass = false;
+      }
     }
     std::set<FlowId> rss_flow_ids;
+    std::unordered_map<FlowId, std::vector<uint16_t>> flow_rx_queue_ids;
     size_t max_rx_payload_frame = 0;
     size_t max_tx_payload_frame = 0;
     auto queue_frame_size = [&](const CommonQueueConfig& queue) {
@@ -581,6 +638,7 @@ bool Engine::validate_config() const {
       } else {
         const FlowAction& queue_action = actions.back();
         const auto queue_ids = flow_queue_ids(queue_action);
+        flow_rx_queue_ids[flow.id_] = queue_ids;
         std::set<uint16_t> unique_ids;
         for (const uint16_t queue_id : queue_ids) {
           if (!unique_ids.insert(queue_id).second) {
@@ -642,6 +700,18 @@ bool Engine::validate_config() const {
               "must target exactly one RX queue",
               reorder.name_, intf.name_, flow_id);
           pass = false;
+        }
+        const auto queues_it = flow_rx_queue_ids.find(flow_id);
+        if (queues_it != flow_rx_queue_ids.end()) {
+          for (const uint16_t queue_id : queues_it->second) {
+            if (direct_rx_queue_ids.find(queue_id) != direct_rx_queue_ids.end()) {
+              DAQIRI_LOG_WARN(
+                  "Reorder config '{}' targets direct RX queue {} on interface '{}'; direct "
+                  "polling does not support reorder",
+                  reorder.name_, queue_id, intf.name_);
+              pass = false;
+            }
+          }
         }
       }
     }
@@ -780,6 +850,13 @@ Status Engine::poll_flow_op(FlowOpResult* result) {
   return Status::NOT_SUPPORTED;
 }
 
+Status Engine::get_tx_packet_burst_checked(BurstParams* burst) {
+  if (!is_tx_burst_available(burst)) {
+    return Status::NO_FREE_BURST_BUFFERS;
+  }
+  return get_tx_packet_burst(burst);
+}
+
 Status Engine::get_rx_burst(BurstParams** burst, int port_id) {
   // Check if the port_id is valid
   if (port_id < 0 || port_id >= static_cast<int>(cfg_.ifs_.size())) {
@@ -792,20 +869,22 @@ Status Engine::get_rx_burst(BurstParams** burst, int port_id) {
   size_t& next_queue_index = next_queue_index_map_[port_id];
 
   // Check all queues once, starting from the next index
+  bool saw_not_ready = false;
   for (size_t i = 0; i < num_queues; ++i) {
     size_t check_index = (next_queue_index + i) % num_queues;
     int queue_id = queues[check_index].common_.id_;
 
     Status ret = get_rx_burst(burst, port_id, queue_id);
-    if (ret != Status::NULL_PTR) {
+    if (ret != Status::NULL_PTR && ret != Status::NOT_READY) {
       // Got something, update index for next time and return status
       next_queue_index = (check_index + 1) % num_queues;
       return ret;
     }
+    saw_not_ready = saw_not_ready || ret == Status::NOT_READY;
   }
 
   // If we checked all queues and none had data
-  return Status::NULL_PTR;
+  return saw_not_ready ? Status::NOT_READY : Status::NULL_PTR;
 }
 
 Status Engine::get_rx_burst(BurstParams** burst) {
@@ -817,20 +896,22 @@ Status Engine::get_rx_burst(BurstParams** burst) {
   size_t num_interfaces = cfg_.ifs_.size();
 
   // Check all queues once, starting from the next index
+  bool saw_not_ready = false;
   for (size_t i = 0; i < num_interfaces; ++i) {
     size_t check_index = (next_port_index_ + i) % num_interfaces;
     int port_id = cfg_.ifs_[check_index].port_id_;
 
     Status ret = get_rx_burst(burst, port_id);
-    if (ret != Status::NULL_PTR) {
+    if (ret != Status::NULL_PTR && ret != Status::NOT_READY) {
       // Got something, update index for next time and return status
       next_port_index_ = (check_index + 1) % num_interfaces;
       return ret;
     }
+    saw_not_ready = saw_not_ready || ret == Status::NOT_READY;
   }
 
   // If we checked all interfaces and none yielded a burst
-  return Status::NULL_PTR;
+  return saw_not_ready ? Status::NOT_READY : Status::NULL_PTR;
 }
 
 Status Engine::socket_connect_to_server(const std::string& dst_addr, uint16_t dst_port,

--- a/src/engine.h
+++ b/src/engine.h
@@ -71,6 +71,8 @@ class Engine {
   virtual Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) = 0;
   virtual void* get_packet_extra_info(BurstParams* burst, int idx) = 0;
   virtual Status get_tx_packet_burst(BurstParams* burst) = 0;
+  // Engines with richer availability states can override this checked entrypoint.
+  virtual Status get_tx_packet_burst_checked(BurstParams* burst);
   virtual Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) = 0;
   virtual Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
                                  unsigned int src_host, unsigned int dst_host) = 0;

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -178,11 +178,13 @@ static bool fill_tunnel_l2_l3(std::vector<uint8_t>& data, const TunnelConfig& tu
 static bool build_reformat_buffer(const FlowAction& action, std::vector<uint8_t>& data,
                                   enum mlx5dv_flow_action_packet_reformat_type* type) {
   data.clear();
-  if (type == nullptr) { return false; }
+  if (type == nullptr) {
+    return false;
+  }
   if (action.type_ == FlowType::VLAN_PUSH || action.type_ == FlowType::VLAN_POP) {
-    const uint16_t tci = static_cast<uint16_t>(((action.vlan_.pcp_ & 0x7) << 13) |
-                                              ((action.vlan_.dei_ & 0x1) << 12) |
-                                              (action.vlan_.vlan_id_ & 0x0fff));
+    const uint16_t tci =
+        static_cast<uint16_t>(((action.vlan_.pcp_ & 0x7) << 13) |
+                              ((action.vlan_.dei_ & 0x1) << 12) | (action.vlan_.vlan_id_ & 0x0fff));
     const uint16_t tpid = htobe16(action.vlan_.ethertype_);
     const uint16_t be_tci = htobe16(tci);
     append_bytes(data, &tpid, sizeof(tpid));
@@ -200,35 +202,41 @@ static bool build_reformat_buffer(const FlowAction& action, std::vector<uint8_t>
   const TunnelConfig& tunnel = action.tunnel_;
   switch (tunnel.type_) {
     case TunnelType::VXLAN: {
-      if (!fill_tunnel_l2_l3(data, tunnel, IPPROTO_UDP)) { return false; }
+      if (!fill_tunnel_l2_l3(data, tunnel, IPPROTO_UDP)) {
+        return false;
+      }
       struct udphdr udp {};
       udp.source = htobe16(tunnel.outer_udp_src_);
       udp.dest = htobe16(tunnel.outer_udp_dst_);
       struct {
         uint32_t flags;
         uint32_t vni;
-      } __attribute__((packed)) vxlan {htobe32(0x08000000u), htobe32(tunnel.vni_ << 8)};
+      } __attribute__((packed)) vxlan{htobe32(0x08000000u), htobe32(tunnel.vni_ << 8)};
       append_bytes(data, &udp, sizeof(udp));
       append_bytes(data, &vxlan, sizeof(vxlan));
       break;
     }
     case TunnelType::GRE: {
-      if (!fill_tunnel_l2_l3(data, tunnel, IPPROTO_GRE)) { return false; }
+      if (!fill_tunnel_l2_l3(data, tunnel, IPPROTO_GRE)) {
+        return false;
+      }
       struct {
         uint16_t flags;
         uint16_t proto;
-      } __attribute__((packed)) gre {0, htobe16(tunnel.gre_protocol_)};
+      } __attribute__((packed)) gre{0, htobe16(tunnel.gre_protocol_)};
       append_bytes(data, &gre, sizeof(gre));
       break;
     }
     case TunnelType::NVGRE: {
-      if (!fill_tunnel_l2_l3(data, tunnel, IPPROTO_GRE)) { return false; }
+      if (!fill_tunnel_l2_l3(data, tunnel, IPPROTO_GRE)) {
+        return false;
+      }
       struct {
         uint16_t flags;
         uint16_t proto;
         uint8_t tni[3];
         uint8_t flow_id;
-      } __attribute__((packed)) nvgre {};
+      } __attribute__((packed)) nvgre{};
       nvgre.flags = htobe16(0x2000);
       nvgre.proto = htobe16(ETH_P_TEB);
       set_u24_be(nvgre.tni, tunnel.tni_);
@@ -381,7 +389,12 @@ bool IbverbsEngine::set_config_and_initialize(const NetworkConfig& cfg) {
   force_quit_.store(false, std::memory_order_relaxed);
   max_batch_ = 0;
   cfg_ = cfg;
-  if (!reserve_static_flow_ids()) { return false; }
+  if (!validate_config()) {
+    return false;
+  }
+  if (!reserve_static_flow_ids()) {
+    return false;
+  }
   initialize();
   return initialized_;
 }
@@ -970,17 +983,23 @@ struct DrMatchParam {
 
 const InterfaceConfig* IbverbsEngine::find_interface_config(int port) const {
   for (const auto& intf : cfg_.ifs_) {
-    if (intf.port_id_ == port) { return &intf; }
+    if (intf.port_id_ == port) {
+      return &intf;
+    }
   }
   return nullptr;
 }
 
 bool IbverbsEngine::reserve_static_flow_ids() {
   static_flow_ids_.clear();
-  while (!free_dynamic_flow_ids_.empty()) { free_dynamic_flow_ids_.pop(); }
+  while (!free_dynamic_flow_ids_.empty()) {
+    free_dynamic_flow_ids_.pop();
+  }
   for (const auto& intf : cfg_.ifs_) {
     for (const auto& flow : intf.rx_.flows_) {
-      if (flow.id_ == 0) { continue; }
+      if (flow.id_ == 0) {
+        continue;
+      }
       if (!static_flow_ids_.insert(flow.id_).second) {
         DAQIRI_LOG_ERROR("Duplicate static flow ID {}", flow.id_);
         return false;
@@ -992,20 +1011,30 @@ bool IbverbsEngine::reserve_static_flow_ids() {
 }
 
 FlowOpId IbverbsEngine::allocate_flow_op_id_locked() {
-  if (next_flow_op_id_ == 0) { next_flow_op_id_ = 1; }
+  if (next_flow_op_id_ == 0) {
+    next_flow_op_id_ = 1;
+  }
   return next_flow_op_id_++;
 }
 
 bool IbverbsEngine::has_dynamic_flow_id_capacity_locked(size_t count) const {
-  if (free_dynamic_flow_ids_.size() >= count) { return true; }
+  if (free_dynamic_flow_ids_.size() >= count) {
+    return true;
+  }
   count -= free_dynamic_flow_ids_.size();
 
   FlowId candidate = next_dynamic_flow_id_;
   while (count > 0 && candidate != 0 && candidate <= kMaxIbverbsFlowTag) {
     const FlowId flow_id = candidate++;
-    if (flow_id == 0) { continue; }
-    if (static_flow_ids_.find(flow_id) != static_flow_ids_.end()) { continue; }
-    if (dynamic_flows_.find(flow_id) != dynamic_flows_.end()) { continue; }
+    if (flow_id == 0) {
+      continue;
+    }
+    if (static_flow_ids_.find(flow_id) != static_flow_ids_.end()) {
+      continue;
+    }
+    if (dynamic_flows_.find(flow_id) != dynamic_flows_.end()) {
+      continue;
+    }
     --count;
   }
   return count == 0;
@@ -1015,26 +1044,44 @@ FlowId IbverbsEngine::allocate_dynamic_flow_id_locked() {
   while (!free_dynamic_flow_ids_.empty()) {
     const FlowId candidate = free_dynamic_flow_ids_.front();
     free_dynamic_flow_ids_.pop();
-    if (candidate == 0 || candidate > kMaxIbverbsFlowTag) { continue; }
-    if (static_flow_ids_.find(candidate) != static_flow_ids_.end()) { continue; }
-    if (dynamic_flows_.find(candidate) != dynamic_flows_.end()) { continue; }
+    if (candidate == 0 || candidate > kMaxIbverbsFlowTag) {
+      continue;
+    }
+    if (static_flow_ids_.find(candidate) != static_flow_ids_.end()) {
+      continue;
+    }
+    if (dynamic_flows_.find(candidate) != dynamic_flows_.end()) {
+      continue;
+    }
     return candidate;
   }
 
   while (next_dynamic_flow_id_ != 0 && next_dynamic_flow_id_ <= kMaxIbverbsFlowTag) {
     const FlowId candidate = next_dynamic_flow_id_++;
-    if (candidate == 0) { continue; }
-    if (static_flow_ids_.find(candidate) != static_flow_ids_.end()) { continue; }
-    if (dynamic_flows_.find(candidate) != dynamic_flows_.end()) { continue; }
+    if (candidate == 0) {
+      continue;
+    }
+    if (static_flow_ids_.find(candidate) != static_flow_ids_.end()) {
+      continue;
+    }
+    if (dynamic_flows_.find(candidate) != dynamic_flows_.end()) {
+      continue;
+    }
     return candidate;
   }
   return 0;
 }
 
 void IbverbsEngine::release_dynamic_flow_id_locked(FlowId flow_id) {
-  if (flow_id == 0 || flow_id > kMaxIbverbsFlowTag) { return; }
-  if (static_flow_ids_.find(flow_id) != static_flow_ids_.end()) { return; }
-  if (dynamic_flows_.find(flow_id) != dynamic_flows_.end()) { return; }
+  if (flow_id == 0 || flow_id > kMaxIbverbsFlowTag) {
+    return;
+  }
+  if (static_flow_ids_.find(flow_id) != static_flow_ids_.end()) {
+    return;
+  }
+  if (dynamic_flows_.find(flow_id) != dynamic_flows_.end()) {
+    return;
+  }
   free_dynamic_flow_ids_.push(flow_id);
 }
 
@@ -1082,8 +1129,7 @@ bool IbverbsEngine::validate_dynamic_rx_flow_locked(int port, const FlowRuleConf
   const bool has_transform = flow_actions_have_transform(actions);
   for (const auto& action : actions) {
     if (action.type_ == FlowType::VLAN_PUSH || action.type_ == FlowType::TUNNEL_ENCAP) {
-      DAQIRI_LOG_ERROR("Dynamic RX flow '{}' can only use decap/pop transform actions",
-                       flow.name_);
+      DAQIRI_LOG_ERROR("Dynamic RX flow '{}' can only use decap/pop transform actions", flow.name_);
       return false;
     }
   }
@@ -1091,16 +1137,16 @@ bool IbverbsEngine::validate_dynamic_rx_flow_locked(int port, const FlowRuleConf
   const FlowMatch& match = flow.match_;
   if (match.type_ == FlowMatchType::FLEX_ITEM) {
     if (has_transform) {
-      DAQIRI_LOG_ERROR("Dynamic RX flow '{}' cannot combine flex-item matching with tunnel/VLAN "
-                       "actions",
-                       flow.name_);
+      DAQIRI_LOG_ERROR(
+          "Dynamic RX flow '{}' cannot combine flex-item matching with tunnel/VLAN "
+          "actions",
+          flow.name_);
       return false;
     }
     const uint16_t flex_item_id = match.flex_item_match_.flex_item_id_;
-    const auto flex_it = std::find_if(intf->rx_.flex_items_.begin(), intf->rx_.flex_items_.end(),
-                                      [&](const FlexItemConfig& c) {
-                                        return c.id_ == flex_item_id;
-                                      });
+    const auto flex_it =
+        std::find_if(intf->rx_.flex_items_.begin(), intf->rx_.flex_items_.end(),
+                     [&](const FlexItemConfig& c) { return c.id_ == flex_item_id; });
     if (flex_it == intf->rx_.flex_items_.end()) {
       DAQIRI_LOG_ERROR("Dynamic RX flow references invalid flex item ID {}", flex_item_id);
       return false;
@@ -1273,7 +1319,9 @@ bool IbverbsEngine::create_dr_rule_locked(
   for (auto* reformat : reformats) {
     if (num_actions >= static_cast<int>(sizeof(actions) / sizeof(actions[0])) - 1) {
       DAQIRI_LOG_CRITICAL("Too many reformat actions for flow '{}' on port {}", desc, port);
-      if (tag_action != nullptr) { mlx5dv_dr_action_destroy(tag_action); }
+      if (tag_action != nullptr) {
+        mlx5dv_dr_action_destroy(tag_action);
+      }
       mlx5dv_dr_matcher_destroy(matcher);
       return false;
     }
@@ -1284,7 +1332,9 @@ bool IbverbsEngine::create_dr_rule_locked(
   struct mlx5dv_dr_rule* rule = mlx5dv_dr_rule_create(matcher, value, num_actions, actions);
   if (rule == nullptr) {
     DAQIRI_LOG_CRITICAL("dr_rule_create failed (port {} {}): {}", port, desc, strerror(errno));
-    if (tag_action != nullptr) { mlx5dv_dr_action_destroy(tag_action); }
+    if (tag_action != nullptr) {
+      mlx5dv_dr_action_destroy(tag_action);
+    }
     mlx5dv_dr_matcher_destroy(matcher);
     return false;
   }
@@ -1302,7 +1352,9 @@ bool IbverbsEngine::create_dr_rule_locked(
 
   st.matchers.push_back(matcher);
   st.rules.push_back(rule);
-  if (tag_action != nullptr) { st.tag_actions.push_back(tag_action); }
+  if (tag_action != nullptr) {
+    st.tag_actions.push_back(tag_action);
+  }
 
   PortSteering::RuleSpec spec{
       matcher, destination_action, tag_action, reformats, rss_destination, 0, {}};
@@ -1312,18 +1364,17 @@ bool IbverbsEngine::create_dr_rule_locked(
   return true;
 }
 
-Status IbverbsEngine::install_flow_rule_locked(int port,
-                                               PortSteering& st,
+Status IbverbsEngine::install_flow_rule_locked(int port, PortSteering& st,
                                                const InterfaceConfig& intf,
-                                               const FlowRuleConfig& flow,
-                                               FlowId flow_id,
-                                               int priority,
-                                               DynamicFlowEntry* dynamic_entry) {
+                                               const FlowRuleConfig& flow, FlowId flow_id,
+                                               int priority, DynamicFlowEntry* dynamic_entry) {
   if (st.dropped) {
     DAQIRI_LOG_ERROR("Cannot modify dynamic RX flows while port {} is dropped", port);
     return Status::INVALID_PARAMETER;
   }
-  if (st.table == nullptr) { return Status::NOT_READY; }
+  if (st.table == nullptr) {
+    return Status::NOT_READY;
+  }
 
   const auto actions = flow_rule_actions(flow);
   const FlowAction queue_action = flow_queue_action(actions);
@@ -1345,15 +1396,21 @@ Status IbverbsEngine::install_flow_rule_locked(int port,
 
   std::vector<struct mlx5dv_dr_action*> flow_reformats;
   auto cleanup_dynamic_reformats = [&]() {
-    if (dynamic_entry == nullptr) { return; }
+    if (dynamic_entry == nullptr) {
+      return;
+    }
     for (auto* reformat : dynamic_entry->reformat_actions) {
-      if (reformat != nullptr) { mlx5dv_dr_action_destroy(reformat); }
+      if (reformat != nullptr) {
+        mlx5dv_dr_action_destroy(reformat);
+      }
     }
     dynamic_entry->reformat_actions.clear();
     dynamic_entry->reformat_buffers.clear();
   };
   for (const auto& action : actions) {
-    if (!flow_action_is_transform(action)) { continue; }
+    if (!flow_action_is_transform(action)) {
+      continue;
+    }
     std::vector<uint8_t>* buffer = nullptr;
     if (dynamic_entry != nullptr) {
       dynamic_entry->reformat_buffers.emplace_back();
@@ -1410,12 +1467,10 @@ Status IbverbsEngine::install_flow_rule_locked(int port,
 
     void* m4_mask = DEVX_ADDR_OF(fte_match_param, mask_buf, misc_parameters_4);
     void* m4_value = DEVX_ADDR_OF(fte_match_param, value_buf, misc_parameters_4);
-    DEVX_SET(fte_match_set_misc4, m4_mask, prog_sample_field_id_0,
-             node_it->second.sample_field_id);
+    DEVX_SET(fte_match_set_misc4, m4_mask, prog_sample_field_id_0, node_it->second.sample_field_id);
     DEVX_SET(fte_match_set_misc4, m4_value, prog_sample_field_id_0,
              node_it->second.sample_field_id);
-    DEVX_SET(fte_match_set_misc4, m4_mask, prog_sample_field_value_0,
-             mt.flex_item_match_.mask_);
+    DEVX_SET(fte_match_set_misc4, m4_mask, prog_sample_field_value_0, mt.flex_item_match_.mask_);
     DEVX_SET(fte_match_set_misc4, m4_value, prog_sample_field_value_0,
              mt.flex_item_match_.val_ & mt.flex_item_match_.mask_);
 
@@ -2068,9 +2123,10 @@ Status IbverbsEngine::install_port_flows() {
     }
 
     if (installed == 0 && intf.rx_.flow_isolation_) {
-      DAQIRI_LOG_INFO("No static RX flows on isolated ibverbs port {}; dynamic flows may be added "
-                      "after initialization",
-                      port);
+      DAQIRI_LOG_INFO(
+          "No static RX flows on isolated ibverbs port {}; dynamic flows may be added "
+          "after initialization",
+          port);
     } else if (installed == 0) {
       // No per-flow rules: catch-all (criteria_enable = 0) -> first queue.
       DrMatchBuf mask{}, val{};
@@ -2110,14 +2166,12 @@ Status IbverbsEngine::install_tx_flows() {
     TxPortSteering& st = tx_port_steering_[port];
     st.domain = mlx5dv_dr_domain_create(ctx, MLX5DV_DR_DOMAIN_TYPE_NIC_TX);
     if (st.domain == nullptr) {
-      DAQIRI_LOG_CRITICAL("TX mlx5dv_dr_domain_create failed (port {}): {}", port,
-                          strerror(errno));
+      DAQIRI_LOG_CRITICAL("TX mlx5dv_dr_domain_create failed (port {}): {}", port, strerror(errno));
       return Status::GENERIC_FAILURE;
     }
     st.table = mlx5dv_dr_table_create(st.domain, 0);
     if (st.table == nullptr) {
-      DAQIRI_LOG_CRITICAL("TX mlx5dv_dr_table_create failed (port {}): {}", port,
-                          strerror(errno));
+      DAQIRI_LOG_CRITICAL("TX mlx5dv_dr_table_create failed (port {}): {}", port, strerror(errno));
       return Status::GENERIC_FAILURE;
     }
 
@@ -2167,18 +2221,19 @@ Status IbverbsEngine::install_tx_flows() {
         any = true;
       }
       if (fl.match_.ipv4_len_ > 0) {
-        DAQIRI_LOG_ERROR("TX flow '{}' uses ipv4_len, which is not supported by ibverbs TX "
-                         "steering",
-                         fl.name_);
+        DAQIRI_LOG_ERROR(
+            "TX flow '{}' uses ipv4_len, which is not supported by ibverbs TX "
+            "steering",
+            fl.name_);
         return Status::GENERIC_FAILURE;
       }
 
-      struct mlx5dv_dr_matcher* matcher = mlx5dv_dr_matcher_create(
-          st.table, prio++, any ? crit : 0,
-          reinterpret_cast<struct mlx5dv_flow_match_parameters*>(&mask));
+      struct mlx5dv_dr_matcher* matcher =
+          mlx5dv_dr_matcher_create(st.table, prio++, any ? crit : 0,
+                                   reinterpret_cast<struct mlx5dv_flow_match_parameters*>(&mask));
       if (matcher == nullptr) {
-        DAQIRI_LOG_CRITICAL("TX dr_matcher_create failed (port {} flow '{}'): {}", port,
-                            fl.name_, strerror(errno));
+        DAQIRI_LOG_CRITICAL("TX dr_matcher_create failed (port {} flow '{}'): {}", port, fl.name_,
+                            strerror(errno));
         return Status::GENERIC_FAILURE;
       }
       st.matchers.push_back(matcher);
@@ -2379,7 +2434,9 @@ Status IbverbsEngine::setup_rx_queue(IbvRxQueue& q, const InterfaceConfig& intf,
                                      const RxQueueConfig& qcfg) {
   q.port_id = intf.port_id_;
   q.queue_id = qcfg.common_.id_;
-  q.batch_size = std::max(1, qcfg.common_.batch_size_);
+  q.poll_mode = qcfg.poll_mode_;
+  q.batch_size = q.poll_mode == QueuePollMode::DIRECT ? static_cast<int>(kDirectPollMaxBatch)
+                                                      : std::max(1, qcfg.common_.batch_size_);
   q.timeout_us = qcfg.timeout_us_;
   if (!qcfg.common_.cpu_core_.empty()) {
     q.cpu_core = std::stoi(qcfg.common_.cpu_core_);
@@ -2431,14 +2488,17 @@ Status IbverbsEngine::setup_rx_queue(IbvRxQueue& q, const InterfaceConfig& intf,
     return s;
   }
 
-  // App-facing burst ring.
-  const std::string ring_name =
-      "ibv_rx_" + std::to_string(q.port_id) + "_" + std::to_string(q.queue_id);
-  q.ring = daqiri::Ring::create(ring_name.c_str(), 2048, daqiri::RingMode::MPMC,
-                                daqiri::detail::numa_node_for_cpu(cfg_.common_.master_core_));
-  if (q.ring == nullptr) {
-    DAQIRI_LOG_CRITICAL("Failed to create RX ring {}", ring_name);
-    return Status::GENERIC_FAILURE;
+  if (q.poll_mode == QueuePollMode::INDIRECT) {
+    // App-facing burst ring for the background worker handoff. Direct queues
+    // return the completed metadata block from get_rx_burst without a ring.
+    const std::string ring_name =
+        "ibv_rx_" + std::to_string(q.port_id) + "_" + std::to_string(q.queue_id);
+    q.ring = daqiri::Ring::create(ring_name.c_str(), 2048, daqiri::RingMode::MPMC,
+                                  daqiri::detail::numa_node_for_cpu(cfg_.common_.master_core_));
+    if (q.ring == nullptr) {
+      DAQIRI_LOG_CRITICAL("Failed to create RX ring {}", ring_name);
+      return Status::GENERIC_FAILURE;
+    }
   }
 
   if (Status s = init_reorder(q, intf, qcfg); s != Status::SUCCESS) {
@@ -2470,7 +2530,10 @@ void IbverbsEngine::initialize() {
   // Determine the largest batch (RX + TX) and build the burst metadata pools.
   for (const auto& intf : cfg_.ifs_) {
     for (const auto& q : intf.rx_.queues_) {
-      max_batch_ = std::max<uint32_t>(max_batch_, std::max(1, q.common_.batch_size_));
+      const uint32_t batch = q.poll_mode_ == QueuePollMode::DIRECT
+                                 ? kDirectPollMaxBatch
+                                 : static_cast<uint32_t>(std::max(1, q.common_.batch_size_));
+      max_batch_ = std::max(max_batch_, batch);
     }
     for (const auto& q : intf.tx_.queues_) {
       max_batch_ = std::max<uint32_t>(max_batch_, std::max(1, q.common_.batch_size_));
@@ -2589,6 +2652,11 @@ void IbverbsEngine::run() {
   std::map<int, std::vector<IbvRxQueue*>> rx_groups;
   std::vector<std::vector<IbvRxQueue*>> rx_threads;
   for (auto& q : rx_queues_) {
+    if (q->poll_mode == QueuePollMode::DIRECT) {
+      DAQIRI_LOG_INFO("RX queue port {} q{} uses caller-driven direct polling", q->port_id,
+                      q->queue_id);
+      continue;
+    }
     q->running = true;
     if (q->cpu_core >= 0) {
       rx_groups[q->cpu_core].push_back(q.get());
@@ -2607,6 +2675,11 @@ void IbverbsEngine::run() {
   std::map<int, std::vector<IbvTxQueue*>> tx_groups;
   std::vector<std::vector<IbvTxQueue*>> tx_threads;
   for (auto& q : tx_queues_) {
+    if (q->poll_mode == QueuePollMode::DIRECT) {
+      DAQIRI_LOG_INFO("TX queue port {} q{} uses caller-driven direct posting", q->port_id,
+                      q->queue_id);
+      continue;
+    }
     q->running = true;
     if (q->cpu_core >= 0) {
       tx_groups[q->cpu_core].push_back(q.get());
@@ -2636,6 +2709,7 @@ bool IbverbsEngine::rx_alloc_burst(IbvRxQueue* q) {
   b->hdr.hdr.q_id = q->queue_id;
   b->hdr.hdr.num_pkts = 0;
   b->hdr.hdr.num_segs = q->num_segs;
+  b->hdr.hdr.burst_flags = 0;
   b->pkts[0] = reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(b) + g_layout.off_pkts0);
   b->pkt_lens[0] = reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(b) + g_layout.off_lens0);
   b->pkts[1] = reinterpret_cast<void**>(reinterpret_cast<uint8_t*>(b) + g_layout.off_pkts1);
@@ -2668,7 +2742,14 @@ void IbverbsEngine::rx_flush_burst(IbvRxQueue* q) {
 // the queue's in-progress burst, then yields so a shared poller can round-robin
 // the next queue. All cursors/accumulators live in the queue, so the partial
 // burst persists across passes.
-void IbverbsEngine::rx_poll_queue(IbvRxQueue* q) {
+Status IbverbsEngine::rx_poll_queue(IbvRxQueue* q, BurstParams** direct_burst) {
+  const bool direct = direct_burst != nullptr;
+  if (direct) {
+    *direct_burst = nullptr;
+    // Application frees only record released strides. With no background
+    // worker, the next caller-driven poll is responsible for reposting them.
+    devx_advance_producer(*q);
+  }
   const uint32_t cqe_cnt = q->dv_cq.cqe_cnt;
   const uint32_t cqe_size = q->dv_cq.cqe_size;
   uint8_t* cq_buf = static_cast<uint8_t*>(q->dv_cq.buf);
@@ -2676,17 +2757,29 @@ void IbverbsEngine::rx_poll_queue(IbvRxQueue* q) {
   const uint64_t timeout_cycles = q->timeout_us ? (ibv_timer_hz * q->timeout_us) / 1'000'000ULL : 0;
 
   if (q->cur_burst == nullptr && !rx_alloc_burst(q)) {
-    DAQIRI_LOG_ERROR("RX worker q{}: metadata pool exhausted (increase rx_meta_buffers)",
+    DAQIRI_LOG_ERROR("RX poller q{}: metadata pool exhausted (increase rx_meta_buffers)",
                      q->queue_id);
-    return;
+    return Status::NO_FREE_BURST_BUFFERS;
   }
+  auto finish_direct_burst = [&]() {
+    if (!direct || q->cur_burst == nullptr || q->cur_n == 0) {
+      return;
+    }
+    q->cur_burst->hdr.hdr.num_pkts = q->cur_n;
+    *direct_burst = q->cur_burst;
+    q->cur_burst = nullptr;
+    q->cur_n = 0;
+  };
   uint16_t* wqe_arr = burst_wqe_arr(q->cur_burst);
   uint16_t* strd_arr = burst_strd_arr(q->cur_burst);
 
-  const int budget = q->batch_size > 0 ? q->batch_size : 256;
+  const int packet_budget = q->batch_size > 0 ? q->batch_size : 256;
+  // Direct mode promises a packet limit, so filler and error CQEs must not
+  // consume that limit. Still bound one call to at most one complete CQ scan.
+  const uint32_t cqe_budget = direct ? cqe_cnt : static_cast<uint32_t>(packet_budget);
   const uint32_t start_ci = q->cq_ci;
-  int processed = 0;
-  while (processed < budget) {
+  uint32_t processed = 0;
+  while (processed < cqe_budget && (!direct || q->cur_n < packet_budget)) {
     uint8_t* cqe = cq_buf + (q->cq_ci & (cqe_cnt - 1)) * cqe_size;
     // For 128B CQEs the 64B CQE is in the second half.
     struct mlx5_cqe64* cqe64 =
@@ -2702,10 +2795,11 @@ void IbverbsEngine::rx_poll_queue(IbvRxQueue* q) {
       // CQ drained. Reclaim freed regions and maybe flush a partial burst on
       // timeout, then yield to the next queue.
       devx_advance_producer(*q);
-      if (timeout_cycles && q->cur_n > 0 && (ibv_now_ns() - q->last_flush_tsc) > timeout_cycles) {
+      if (!direct && timeout_cycles && q->cur_n > 0 &&
+          (ibv_now_ns() - q->last_flush_tsc) > timeout_cycles) {
         rx_flush_burst(q);
         if (!rx_alloc_burst(q)) {
-          return;
+          return Status::NO_FREE_BURST_BUFFERS;
         }
         wqe_arr = burst_wqe_arr(q->cur_burst);
         strd_arr = burst_strd_arr(q->cur_burst);
@@ -2806,19 +2900,24 @@ void IbverbsEngine::rx_poll_queue(IbvRxQueue* q) {
     // delivers it in sop_drop_qpn (24-bit). 0 = untagged.
     burst_flowtag_arr(q->cur_burst)[n] = be32toh(cqe64->sop_drop_qpn) & 0x00ffffffu;
     q->cur_n++;
-    if (q->cur_n == 1) {
+    if (!direct && q->cur_n == 1) {
       q->last_flush_tsc = ibv_now_ns();
     }
 
     if (q->cur_n >= q->batch_size) {
-      rx_flush_burst(q);
-      if (!rx_alloc_burst(q)) {
-        DAQIRI_LOG_ERROR("RX worker q{}: metadata pool exhausted (increase rx_meta_buffers)",
-                         q->queue_id);
-        return;
+      if (direct) {
+        finish_direct_burst();
+        break;
+      } else {
+        rx_flush_burst(q);
+        if (!rx_alloc_burst(q)) {
+          DAQIRI_LOG_ERROR("RX poller q{}: metadata pool exhausted (increase rx_meta_buffers)",
+                           q->queue_id);
+          return Status::NO_FREE_BURST_BUFFERS;
+        }
+        wqe_arr = burst_wqe_arr(q->cur_burst);
+        strd_arr = burst_strd_arr(q->cur_burst);
       }
-      wqe_arr = burst_wqe_arr(q->cur_burst);
-      strd_arr = burst_strd_arr(q->cur_burst);
     }
 
     // Periodically advance the CQ doorbell so the HW can recycle CQEs, and
@@ -2833,6 +2932,11 @@ void IbverbsEngine::rx_poll_queue(IbvRxQueue* q) {
   if (q->cq_ci != start_ci) {
     *q->dv_cq.dbrec = htobe32(q->cq_ci & 0xffffff);
   }
+  if (direct && *direct_burst == nullptr) {
+    finish_direct_burst();
+  }
+  return direct ? (*direct_burst != nullptr ? Status::SUCCESS : Status::NOT_READY)
+                : Status::SUCCESS;
 }
 
 void IbverbsEngine::rx_worker(std::vector<IbvRxQueue*> group) {
@@ -2854,7 +2958,7 @@ void IbverbsEngine::rx_worker(std::vector<IbvRxQueue*> group) {
   while (leader->running.load(std::memory_order_relaxed) &&
          !force_quit_.load(std::memory_order_relaxed)) {
     for (auto* q : group) {
-      rx_poll_queue(q);
+      (void)rx_poll_queue(q);
     }
   }
 
@@ -2874,8 +2978,8 @@ void IbverbsEngine::rx_worker(std::vector<IbvRxQueue*> group) {
 
 void IbverbsEngine::release_strides(IbvRxQueue& q, uint32_t wqe_idx, uint32_t strd) {
   // Both the striding and the regular RQ are DevX: record the freed strides
-  // (regular RQ = 1 per packet); the worker thread drains and reposts WQEs in
-  // cyclic order (devx_advance_producer). Safe from the app and worker threads.
+  // (regular RQ = 1 per packet); the queue's poller drains and reposts WQEs in
+  // cyclic order (devx_advance_producer). Safe from the app and poller threads.
   q.freed_strides[wqe_idx].fetch_add(strd, std::memory_order_release);
 }
 
@@ -3258,16 +3362,34 @@ Status IbverbsEngine::get_reorder_burst_info(BurstParams* burst, ReorderBurstInf
 }
 
 Status IbverbsEngine::get_rx_burst(BurstParams** burst, int port, int q) {
+  if (burst == nullptr) {
+    return Status::NULL_PTR;
+  }
+  *burst = nullptr;
   IbvRxQueue* rq = find_rx_queue(port, q);
   if (rq == nullptr) {
     return Status::INVALID_PARAMETER;
+  }
+  if (rq->poll_mode == QueuePollMode::DIRECT) {
+    std::unique_lock<std::mutex> guard(rq->direct_poll_mutex, std::try_to_lock);
+    if (!guard.owns_lock()) {
+      const uint64_t conflicts = rq->direct_poll_conflicts.fetch_add(1) + 1;
+      if ((conflicts & (conflicts - 1)) == 0) {
+        DAQIRI_LOG_WARN(
+            "Concurrent direct RX poll on port {} queue {} rejected ({} conflict(s)); use one "
+            "polling thread per direct queue",
+            port, q, conflicts);
+      }
+      return Status::NOT_READY;
+    }
+    return rx_poll_queue(rq, burst);
   }
   if (rq->reorder && rq->reorder->enabled) {
     return reorder_get_rx(*rq, burst);
   }
   void* b = nullptr;
   if (!rq->ring->dequeue(&b)) {
-    return Status::NOT_READY;
+    return Status::NULL_PTR;
   }
   *burst = static_cast<BurstParams*>(b);
   return Status::SUCCESS;
@@ -3305,6 +3427,18 @@ void IbverbsEngine::free_all_packets(BurstParams* burst) {
     // burst, so these are the most-recent (unposted) cyclic slots.
     IbvTxQueue* tq = find_tx_queue(burst->hdr.hdr.port_id, burst->hdr.hdr.q_id);
     if (tq == nullptr) {
+      return;
+    }
+    if (tq->poll_mode == QueuePollMode::DIRECT) {
+      std::lock_guard<std::mutex> guard(tq->direct_mutex);
+      if (tq->direct_pending == burst) {
+        tq->alloc_head--;
+        tq->direct_pending = nullptr;
+      } else {
+        DAQIRI_LOG_WARN(
+            "Ignoring cancellation of a non-pending direct TX burst on port {} queue {}",
+            tq->port_id, tq->queue_id);
+      }
       return;
     }
     tq->alloc_head -= static_cast<uint64_t>(burst->hdr.hdr.num_pkts);
@@ -3596,14 +3730,17 @@ Status IbverbsEngine::get_mac_addr(int port, char* mac) {
   return Status::SUCCESS;
 }
 
-Status IbverbsEngine::create_dynamic_flow_locked(int port,
-                                                 const FlowRuleConfig& flow,
+Status IbverbsEngine::create_dynamic_flow_locked(int port, const FlowRuleConfig& flow,
                                                  FlowId flow_id) {
   const InterfaceConfig* intf = find_interface_config(port);
-  if (intf == nullptr) { return Status::INVALID_PARAMETER; }
+  if (intf == nullptr) {
+    return Status::INVALID_PARAMETER;
+  }
 
   auto steering_it = port_steering_.find(port);
-  if (steering_it == port_steering_.end()) { return Status::NOT_READY; }
+  if (steering_it == port_steering_.end()) {
+    return Status::NOT_READY;
+  }
 
   PortSteering& steering = steering_it->second;
   DynamicFlowEntry entry;
@@ -3611,7 +3748,9 @@ Status IbverbsEngine::create_dynamic_flow_locked(int port,
   const int priority = steering.next_dynamic_priority++;
   const Status status =
       install_flow_rule_locked(port, steering, *intf, flow, flow_id, priority, &entry);
-  if (status != Status::SUCCESS) { return status; }
+  if (status != Status::SUCCESS) {
+    return status;
+  }
 
   dynamic_flows_[flow_id] = entry;
   return Status::SUCCESS;
@@ -3627,7 +3766,9 @@ void IbverbsEngine::destroy_dynamic_flow_entry_locked(DynamicFlowEntry& entry) {
     entry.tag_action = nullptr;
   }
   for (auto* reformat : entry.reformat_actions) {
-    if (reformat != nullptr) { mlx5dv_dr_action_destroy(reformat); }
+    if (reformat != nullptr) {
+      mlx5dv_dr_action_destroy(reformat);
+    }
   }
   entry.reformat_actions.clear();
   entry.reformat_buffers.clear();
@@ -3638,9 +3779,13 @@ void IbverbsEngine::destroy_dynamic_flow_entry_locked(DynamicFlowEntry& entry) {
 }
 
 void IbverbsEngine::cleanup_dynamic_flows_locked() {
-  for (auto& [flow_id, entry] : dynamic_flows_) { destroy_dynamic_flow_entry_locked(entry); }
+  for (auto& [flow_id, entry] : dynamic_flows_) {
+    destroy_dynamic_flow_entry_locked(entry);
+  }
   dynamic_flows_.clear();
-  while (!ready_flow_ops_.empty()) { ready_flow_ops_.pop(); }
+  while (!ready_flow_ops_.empty()) {
+    ready_flow_ops_.pop();
+  }
 }
 
 void IbverbsEngine::enqueue_flow_completion_locked(const FlowOpResult& result) {
@@ -3648,14 +3793,20 @@ void IbverbsEngine::enqueue_flow_completion_locked(const FlowOpResult& result) {
 }
 
 Status IbverbsEngine::add_rx_flow_async(int port, const FlowRuleConfig& flow, FlowOpId* op_id) {
-  if (op_id == nullptr) { return Status::NULL_PTR; }
+  if (op_id == nullptr) {
+    return Status::NULL_PTR;
+  }
   *op_id = 0;
 
   std::lock_guard<std::mutex> guard(flow_lock_);
-  if (!validate_dynamic_rx_flow_locked(port, flow)) { return Status::INVALID_PARAMETER; }
+  if (!validate_dynamic_rx_flow_locked(port, flow)) {
+    return Status::INVALID_PARAMETER;
+  }
 
   const FlowId flow_id = allocate_dynamic_flow_id_locked();
-  if (flow_id == 0) { return Status::NO_SPACE_AVAILABLE; }
+  if (flow_id == 0) {
+    return Status::NO_SPACE_AVAILABLE;
+  }
 
   const FlowOpId new_op_id = allocate_flow_op_id_locked();
   *op_id = new_op_id;
@@ -3675,18 +3826,25 @@ Status IbverbsEngine::add_rx_flow_async(int port, const FlowRuleConfig& flow, Fl
   return Status::SUCCESS;
 }
 
-Status IbverbsEngine::add_rx_flows_async(int port,
-                                         const std::vector<FlowRuleConfig>& flows,
+Status IbverbsEngine::add_rx_flows_async(int port, const std::vector<FlowRuleConfig>& flows,
                                          FlowOpId* op_id) {
-  if (op_id == nullptr) { return Status::NULL_PTR; }
+  if (op_id == nullptr) {
+    return Status::NULL_PTR;
+  }
   *op_id = 0;
-  if (flows.empty()) { return Status::INVALID_PARAMETER; }
+  if (flows.empty()) {
+    return Status::INVALID_PARAMETER;
+  }
 
   std::lock_guard<std::mutex> guard(flow_lock_);
   for (const auto& flow : flows) {
-    if (!validate_dynamic_rx_flow_locked(port, flow)) { return Status::INVALID_PARAMETER; }
+    if (!validate_dynamic_rx_flow_locked(port, flow)) {
+      return Status::INVALID_PARAMETER;
+    }
   }
-  if (!has_dynamic_flow_id_capacity_locked(flows.size())) { return Status::NO_SPACE_AVAILABLE; }
+  if (!has_dynamic_flow_id_capacity_locked(flows.size())) {
+    return Status::NO_SPACE_AVAILABLE;
+  }
 
   std::vector<FlowId> flow_ids;
   flow_ids.reserve(flows.size());
@@ -3724,11 +3882,15 @@ Status IbverbsEngine::add_rx_flows_async(int port,
 }
 
 Status IbverbsEngine::delete_flow_async(FlowId flow_id, FlowOpId* op_id) {
-  if (op_id == nullptr) { return Status::NULL_PTR; }
+  if (op_id == nullptr) {
+    return Status::NULL_PTR;
+  }
   *op_id = 0;
 
   std::lock_guard<std::mutex> guard(flow_lock_);
-  if (!initialized_) { return Status::NOT_READY; }
+  if (!initialized_) {
+    return Status::NOT_READY;
+  }
   if (flow_id == 0 || static_flow_ids_.find(flow_id) != static_flow_ids_.end()) {
     return Status::INVALID_PARAMETER;
   }
@@ -3756,10 +3918,14 @@ Status IbverbsEngine::delete_flow_async(FlowId flow_id, FlowOpId* op_id) {
 }
 
 Status IbverbsEngine::poll_flow_op(FlowOpResult* result) {
-  if (result == nullptr) { return Status::NULL_PTR; }
+  if (result == nullptr) {
+    return Status::NULL_PTR;
+  }
 
   std::lock_guard<std::mutex> guard(flow_lock_);
-  if (ready_flow_ops_.empty()) { return Status::NOT_READY; }
+  if (ready_flow_ops_.empty()) {
+    return Status::NOT_READY;
+  }
   *result = ready_flow_ops_.front();
   ready_flow_ops_.pop();
   return Status::SUCCESS;
@@ -3772,17 +3938,21 @@ bool IbverbsEngine::validate_config() const {
 void IbverbsEngine::print_stats() {
   for (auto& q : rx_queues_) {
     DAQIRI_LOG_INFO(
-        "ibverbs RX port {} q{}: packets={} fillers={} cqe_errors={} reposts={} "
-        "app_ring_full_drops={} bursts ({} pkts)",
-        q->port_id, q->queue_id, q->dbg_data, q->dbg_filler, q->dbg_err, q->reposts.load(),
-        q->ring_full_bursts, q->ring_full_pkts);
+        "ibverbs RX port {} q{} ({}): packets={} fillers={} cqe_errors={} reposts={} "
+        "app_ring_full_drops={} bursts ({} pkts) direct_poll_conflicts={}",
+        q->port_id, q->queue_id, queue_poll_mode_to_string(q->poll_mode), q->dbg_data,
+        q->dbg_filler, q->dbg_err, q->reposts.load(), q->ring_full_bursts, q->ring_full_pkts,
+        q->direct_poll_conflicts.load());
   }
   for (auto& q : tx_queues_) {
     const uint64_t completed = q->completed_tail.load(std::memory_order_relaxed);
     const uint64_t inflight = q->slots_posted - completed;
     DAQIRI_LOG_INFO(
-        "ibverbs TX port {} q{}: transmitted={} inflight={} handoff_full_drops={} bursts ({} pkts)",
-        q->port_id, q->queue_id, completed, inflight, q->handoff_drop_bursts, q->handoff_drop_pkts);
+        "ibverbs TX port {} q{} ({}): posted={} completed={} inflight={} "
+        "handoff_full_drops={} bursts ({} pkts) direct_no_space={} direct_conflicts={}",
+        q->port_id, q->queue_id, queue_poll_mode_to_string(q->poll_mode), q->slots_posted,
+        completed, inflight, q->handoff_drop_bursts, q->handoff_drop_pkts, q->direct_no_space,
+        q->direct_conflicts.load());
   }
 }
 
@@ -3879,6 +4049,16 @@ void IbverbsEngine::shutdown() {
   tx_port_steering_.clear();
 
   for (auto& q : rx_queues_) {
+    if (q->poll_mode == QueuePollMode::DIRECT && q->cur_burst != nullptr) {
+      uint16_t* wqe_arr = burst_wqe_arr(q->cur_burst);
+      uint16_t* strd_arr = burst_strd_arr(q->cur_burst);
+      for (int i = 0; i < q->cur_n; ++i) {
+        release_strides(*q, wqe_arr[i], strd_arr[i]);
+      }
+      rx_meta_pool_->put(q->cur_burst);
+      q->cur_burst = nullptr;
+      q->cur_n = 0;
+    }
     reorder_cleanup(*q);
     devx_destroy(*q);
     if (q->qp) {
@@ -3899,6 +4079,14 @@ void IbverbsEngine::shutdown() {
   }
   rx_queues_.clear();
   for (auto& q : tx_queues_) {
+    if (q->poll_mode == QueuePollMode::DIRECT && q->direct_pending != nullptr) {
+      DAQIRI_LOG_WARN(
+          "Direct TX port {} queue {} shut down with one unsubmitted packet; reclaiming it",
+          q->port_id, q->queue_id);
+      q->alloc_head--;
+      tx_meta_pool_->put(q->direct_pending);
+      q->direct_pending = nullptr;
+    }
     if (q->qp) {
       ibv_destroy_qp(q->qp);
     }
@@ -4129,7 +4317,8 @@ Status IbverbsEngine::setup_tx_queue(IbvTxQueue& q, const InterfaceConfig& intf,
                                      const TxQueueConfig& qcfg) {
   q.port_id = intf.port_id_;
   q.queue_id = qcfg.common_.id_;
-  q.batch_size = std::max(1, qcfg.common_.batch_size_);
+  q.poll_mode = qcfg.poll_mode_;
+  q.batch_size = q.poll_mode == QueuePollMode::DIRECT ? 1 : std::max(1, qcfg.common_.batch_size_);
   if (!qcfg.common_.cpu_core_.empty()) {
     q.cpu_core = std::stoi(qcfg.common_.cpu_core_);
   }
@@ -4161,8 +4350,9 @@ Status IbverbsEngine::setup_tx_queue(IbvTxQueue& q, const InterfaceConfig& intf,
 
   struct mlx5dv_context dv_ctx {};
   const uint64_t empw_flags = MLX5DV_CONTEXT_FLAGS_MPW_ALLOWED | MLX5DV_CONTEXT_FLAGS_ENHANCED_MPW;
-  q.empw_enabled =
-      mlx5dv_query_device(q.ctx, &dv_ctx) == 0 && (dv_ctx.flags & empw_flags) == empw_flags;
+  q.empw_enabled = q.poll_mode == QueuePollMode::INDIRECT &&
+                   mlx5dv_query_device(q.ctx, &dv_ctx) == 0 &&
+                   (dv_ctx.flags & empw_flags) == empw_flags;
 
   // Register every MR as a TX scatter region; num_slots is the smallest region's
   // buffer count (a packet consumes slot i from every region).
@@ -4194,18 +4384,22 @@ Status IbverbsEngine::setup_tx_queue(IbvTxQueue& q, const InterfaceConfig& intf,
     return s;
   }
 
-  // Hand-off ring: the app fill thread enqueues filled bursts; the pinned TX
-  // worker dequeues and does the WQE build + doorbell + completion reclaim.
-  const std::string send_name =
-      "ibv_txsend_" + std::to_string(q.port_id) + "_" + std::to_string(q.queue_id);
-  q.send_ring = daqiri::Ring::create(send_name.c_str(), 4096, daqiri::RingMode::SPSC,
-                                     daqiri::detail::numa_node_for_cpu(cfg_.common_.master_core_));
-  if (q.send_ring == nullptr) {
-    DAQIRI_LOG_CRITICAL("Failed to create TX send ring {}", send_name);
-    return Status::GENERIC_FAILURE;
+  if (q.poll_mode == QueuePollMode::INDIRECT) {
+    // Hand-off ring: the app fill thread enqueues filled bursts; the pinned TX
+    // worker dequeues and does the WQE build + doorbell + completion reclaim.
+    const std::string send_name =
+        "ibv_txsend_" + std::to_string(q.port_id) + "_" + std::to_string(q.queue_id);
+    q.send_ring =
+        daqiri::Ring::create(send_name.c_str(), 4096, daqiri::RingMode::SPSC,
+                             daqiri::detail::numa_node_for_cpu(cfg_.common_.master_core_));
+    if (q.send_ring == nullptr) {
+      DAQIRI_LOG_CRITICAL("Failed to create TX send ring {}", send_name);
+      return Status::GENERIC_FAILURE;
+    }
   }
-  DAQIRI_LOG_INFO("TX queue {} ready: {} slots of {}B, qp {} (mr {})", q.queue_id, q.num_slots,
-                  q.slot_size, (void*)q.qp, q.mr_name);
+  DAQIRI_LOG_INFO("TX queue {} ready in {} mode: {} slots of {}B, qp {} (mr {})", q.queue_id,
+                  queue_poll_mode_to_string(q.poll_mode), q.num_slots, q.slot_size, (void*)q.qp,
+                  q.mr_name);
   return Status::SUCCESS;
 }
 
@@ -4247,6 +4441,37 @@ void IbverbsEngine::poll_tx_completions(IbvTxQueue& q) {
     doorbell_store_barrier();
     *q.dv_txcq.dbrec = htobe32(q.tx_cq_ci & 0xffffff);
   }
+}
+
+bool IbverbsEngine::lock_direct_tx_queue(IbvTxQueue& q, std::unique_lock<std::mutex>& guard) {
+  if (!guard.try_lock()) {
+    const uint64_t conflicts = q.direct_conflicts.fetch_add(1) + 1;
+    if ((conflicts & (conflicts - 1)) == 0) {
+      DAQIRI_LOG_WARN(
+          "Concurrent direct TX access on port {} queue {} rejected ({} conflict(s)); use one "
+          "thread per direct queue",
+          q.port_id, q.queue_id, conflicts);
+    }
+    return false;
+  }
+
+  const std::thread::id caller = std::this_thread::get_id();
+  if (!q.direct_owner_set) {
+    q.direct_owner = caller;
+    q.direct_owner_set = true;
+    return true;
+  }
+  if (q.direct_owner != caller) {
+    const uint64_t conflicts = q.direct_conflicts.fetch_add(1) + 1;
+    if ((conflicts & (conflicts - 1)) == 0) {
+      DAQIRI_LOG_WARN(
+          "Direct TX port {} queue {} called from a non-owner thread ({} conflict(s)); the first "
+          "caller owns this queue",
+          q.port_id, q.queue_id, conflicts);
+    }
+    return false;
+  }
+  return true;
 }
 
 uint64_t IbverbsEngine::tx_burst_wqebbs(const IbvTxQueue& q, const BurstParams* burst) const {
@@ -4359,24 +4584,63 @@ Status IbverbsEngine::get_tx_metadata_buffer(BurstParams** burst) {
 }
 
 bool IbverbsEngine::is_tx_burst_available(BurstParams* burst) {
+  if (burst == nullptr) {
+    return false;
+  }
   IbvTxQueue* q = find_tx_queue(burst->hdr.hdr.port_id, burst->hdr.hdr.q_id);
   if (q == nullptr) {
     return false;
+  }
+  if (q->poll_mode == QueuePollMode::DIRECT) {
+    if (burst->hdr.hdr.num_pkts != 1) {
+      return false;
+    }
+    std::unique_lock<std::mutex> guard(q->direct_mutex, std::defer_lock);
+    if (!lock_direct_tx_queue(*q, guard) || q->direct_pending != nullptr) {
+      return false;
+    }
+    poll_tx_completions(*q);
+    const uint64_t in_flight = q->alloc_head - q->completed_tail.load(std::memory_order_acquire);
+    return in_flight < q->num_slots && tx_sq_has_space(*q, 2);
   }
   const uint64_t in_flight = q->alloc_head - q->completed_tail.load(std::memory_order_acquire);
   return (q->num_slots - in_flight) >= static_cast<uint64_t>(burst->hdr.hdr.num_pkts);
 }
 
 Status IbverbsEngine::get_tx_packet_burst(BurstParams* burst) {
+  if (burst == nullptr) {
+    return Status::NULL_PTR;
+  }
   IbvTxQueue* q = find_tx_queue(burst->hdr.hdr.port_id, burst->hdr.hdr.q_id);
   if (q == nullptr) {
     return Status::INVALID_PARAMETER;
   }
   const unsigned n = static_cast<unsigned>(burst->hdr.hdr.num_pkts);
+  std::unique_lock<std::mutex> direct_guard;
+  if (q->poll_mode == QueuePollMode::DIRECT) {
+    if (n != 1) {
+      DAQIRI_LOG_WARN("Direct TX port {} queue {} requires exactly one packet; requested {}",
+                      q->port_id, q->queue_id, n);
+      return Status::INVALID_PARAMETER;
+    }
+    direct_guard = std::unique_lock<std::mutex>(q->direct_mutex, std::defer_lock);
+    if (!lock_direct_tx_queue(*q, direct_guard)) {
+      return Status::NOT_READY;
+    }
+    if (q->direct_pending != nullptr) {
+      return Status::NOT_READY;
+    }
+    poll_tx_completions(*q);
+    const uint64_t in_flight = q->alloc_head - q->completed_tail.load(std::memory_order_acquire);
+    if (in_flight >= q->num_slots || !tx_sq_has_space(*q, 2)) {
+      return Status::NO_FREE_PACKET_BUFFERS;
+    }
+  }
   burst->hdr.hdr.num_segs = q->num_segs;
   // Hand out the next n cyclic slots if they fit under num_slots in flight. No
   // ring ops: each slot pointer is computed from the monotonic alloc_head, and
-  // the TX worker frees them by advancing completed_tail as completions arrive.
+  // the TX worker or direct caller frees it by advancing completed_tail as
+  // completions arrive.
   const uint64_t in_flight = q->alloc_head - q->completed_tail.load(std::memory_order_acquire);
   if (q->num_slots - in_flight < n) {
     return Status::NO_FREE_PACKET_BUFFERS;
@@ -4391,7 +4655,20 @@ Status IbverbsEngine::get_tx_packet_burst(BurstParams* burst) {
     }
   }
   q->alloc_head += n;
+  if (q->poll_mode == QueuePollMode::DIRECT) {
+    q->direct_pending = burst;
+  }
   return Status::SUCCESS;
+}
+
+Status IbverbsEngine::get_tx_packet_burst_checked(BurstParams* burst) {
+  if (burst != nullptr) {
+    IbvTxQueue* q = find_tx_queue(burst->hdr.hdr.port_id, burst->hdr.hdr.q_id);
+    if (q != nullptr && q->poll_mode == QueuePollMode::DIRECT) {
+      return get_tx_packet_burst(burst);
+    }
+  }
+  return Engine::get_tx_packet_burst_checked(burst);
 }
 
 Status IbverbsEngine::set_packet_lengths(BurstParams* burst, int idx,
@@ -4572,13 +4849,15 @@ void IbverbsEngine::post_tx_burst_empw(IbvTxQueue& q, BurstParams* burst) {
   q.bf_offset ^= q.dv_qp.bf.size;
 }
 
-// Runs on the pinned TX worker thread: builds the burst's send WQEs directly
-// into the SQ ring and rings the BlueFlame doorbell once for the whole burst,
+// Builds the burst's send WQEs directly into the SQ ring and rings the BlueFlame
+// doorbell once for the whole burst. This runs on the pinned worker for indirect
+// queues and synchronously on the application thread for direct queues,
 // bypassing ibv_post_send. Each WQE is ctrl(16) + minimal eth(16) + data
 // segs(16 each); with <=2 segments it is exactly one 64B WQEBB, so the SQ
 // producer (and the CQE wqe_counter) advances by one per packet. Signals every
 // SIGNAL_EVERY-th WQE (and the last) for completion-driven slot reclaim.
-// Does NOT free the metadata block (the caller in tx_worker does).
+// Does NOT free the metadata block; the worker or direct caller does that after
+// this function returns.
 void IbverbsEngine::post_tx_burst(IbvTxQueue& q, BurstParams* burst) {
   const int n = static_cast<int>(burst->hdr.hdr.num_pkts);
   const int segs = burst->hdr.hdr.num_segs;
@@ -4648,14 +4927,40 @@ void IbverbsEngine::post_tx_burst(IbvTxQueue& q, BurstParams* burst) {
   q.bf_offset ^= q.dv_qp.bf.size;
 }
 
-// App fill thread: hand the filled burst to the pinned TX worker, which does
-// the DevX WQE build + doorbell + completion reclaim on its own core. This
-// overlaps the next fill batch with the post of the previous one and beat the
-// single-thread inline model in measurement.
+// Submit a filled TX burst. Indirect queues hand it to the pinned worker so WQE
+// posting overlaps application fill; direct queues post one packet inline on
+// the owner thread and return only after ringing the doorbell.
 Status IbverbsEngine::send_tx_burst(BurstParams* burst) {
+  if (burst == nullptr) {
+    return Status::NULL_PTR;
+  }
   IbvTxQueue* q = find_tx_queue(burst->hdr.hdr.port_id, burst->hdr.hdr.q_id);
   if (q == nullptr) {
     return Status::INVALID_PARAMETER;
+  }
+  if (q->poll_mode == QueuePollMode::DIRECT) {
+    std::unique_lock<std::mutex> guard(q->direct_mutex, std::defer_lock);
+    if (!lock_direct_tx_queue(*q, guard)) {
+      return Status::NOT_READY;
+    }
+    if (burst->hdr.hdr.num_pkts != 1 || q->direct_pending != burst) {
+      DAQIRI_LOG_WARN("Direct TX port {} queue {} requires its one pending single-packet burst",
+                      q->port_id, q->queue_id);
+      return Status::INVALID_PARAMETER;
+    }
+    poll_tx_completions(*q);
+    const uint64_t needed_wqebbs = tx_burst_wqebbs(*q, burst);
+    if (!tx_sq_has_space(*q, needed_wqebbs)) {
+      q->alloc_head--;
+      q->direct_pending = nullptr;
+      q->direct_no_space++;
+      tx_meta_pool_->put(burst);
+      return Status::NO_SPACE_AVAILABLE;
+    }
+    post_tx_burst(*q, burst);
+    q->direct_pending = nullptr;
+    tx_meta_pool_->put(burst);
+    return Status::SUCCESS;
   }
   if (!q->send_ring->enqueue(burst)) {
     // Worker is behind: roll back this (most-recent, unposted) allocation and
@@ -4692,12 +4997,13 @@ Status IbverbsEngine::drop_all_traffic(int port) {
   // The matchers/specs persist so allow_all_traffic can recreate the rules.
   {
     std::lock_guard<std::mutex> guard(flow_lock_);
-    const auto has_dynamic_flow_on_port = std::any_of(
-        dynamic_flows_.begin(), dynamic_flows_.end(), [&](const auto& item) {
+    const auto has_dynamic_flow_on_port =
+        std::any_of(dynamic_flows_.begin(), dynamic_flows_.end(), [&](const auto& item) {
           return item.second.port == port && item.second.state == DynamicFlowState::ACTIVE;
         });
     if (has_dynamic_flow_on_port) {
-      DAQIRI_LOG_ERROR("drop_all_traffic is not supported while port {} has dynamic RX flows", port);
+      DAQIRI_LOG_ERROR("drop_all_traffic is not supported while port {} has dynamic RX flows",
+                       port);
       return Status::NOT_SUPPORTED;
     }
   }

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -3389,7 +3389,7 @@ Status IbverbsEngine::get_rx_burst(BurstParams** burst, int port, int q) {
   }
   void* b = nullptr;
   if (!rq->ring->dequeue(&b)) {
-    return Status::NULL_PTR;
+    return Status::NOT_READY;
   }
   *burst = static_cast<BurstParams*>(b);
   return Status::SUCCESS;

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.h
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.h
@@ -123,6 +123,7 @@ struct IbvRxQueue {
   int cpu_core = -1;
   int batch_size = 1;
   uint64_t timeout_us = 0;
+  QueuePollMode poll_mode = QueuePollMode::INDIRECT;
   int num_segs = 1;
   int split_boundary = 0;
   // Flow id reported for packets on this queue. When a single configured flow
@@ -202,14 +203,20 @@ struct IbvRxQueue {
   std::vector<uint32_t> consumed_strides;  // strides handed to the app (verbs path)
   std::vector<uint32_t> released_strides;  // strides freed by the app (verbs path)
   // DevX path: strides freed per region, fetch_add'd by both the app (data
-  // frees) and the worker (filler frees); drained only by the worker thread.
+  // frees) and the poller (filler frees); drained by the queue's active poller.
   std::unique_ptr<std::atomic<uint32_t>[]> freed_strides;
   uint32_t cur_wqe = 0;              // region currently being filled
   uint32_t cur_consumed = 0;         // strides consumed in cur_wqe
   std::atomic<uint64_t> reposts{0};  // diagnostic: WQE reposts
 
-  // App-facing burst ring (worker enqueues, get_rx_burst dequeues).
+  // Indirect-mode app-facing burst ring (worker enqueues, get_rx_burst dequeues).
   daqiri::Ring* ring = nullptr;
+
+  // Direct polling transfers CQ ownership to the get_rx_burst caller. Only one
+  // caller may poll a queue at a time; frees remain safe from other threads via
+  // freed_strides' atomic counters.
+  std::mutex direct_poll_mutex;
+  std::atomic<uint64_t> direct_poll_conflicts{0};
 
   // Optional GPU reordering state for this queue.
   std::unique_ptr<IbvReorderState> reorder;
@@ -236,14 +243,15 @@ struct IbvRxQueue {
 /**
  * @brief Per-queue raw-packet TX context.
  *
- * The TX memory region is carved into fixed-size slots held in a free ring; a
- * burst pulls slots, the app fills them, and send_tx_burst posts one WR per
- * packet (wr_id = slot pointer). A completion worker returns slots to the ring.
- * No per-packet allocation.
+ * The TX memory region is carved into fixed-size cyclic slots. The application
+ * fills allocated slots and send_tx_burst posts their WQEs. Indirect queues use
+ * a completion worker; single-packet direct queues do posting and completion
+ * reclaim on their owner thread. No per-packet memory allocation.
  */
 struct IbvTxQueue {
   int port_id = 0;
   int queue_id = 0;
+  QueuePollMode poll_mode = QueuePollMode::INDIRECT;
   int cpu_core = -1;
   int batch_size = 1;
   int num_segs = 1;
@@ -280,7 +288,7 @@ struct IbvTxQueue {
   // Slots are handed out cyclically and posted/completed in order, so the whole
   // free/in-flight lifecycle is two counters instead of rings (slot k lives at
   // mr_base + (k % num_slots) * slot_size). alloc_head is owned by the app fill
-  // thread; completed_tail is advanced by the TX worker. In flight =
+  // thread; completed_tail is advanced by the TX worker or direct caller. In flight =
   // alloc_head - completed_tail, which must stay <= num_slots.
   uint64_t alloc_head = 0;
   std::atomic<uint64_t> completed_tail{0};
@@ -298,6 +306,14 @@ struct IbvTxQueue {
   // so the burst was dropped and its slots rolled back. App-thread-written.
   uint64_t handoff_drop_bursts = 0;
   uint64_t handoff_drop_pkts = 0;
+  // Direct mode has no handoff worker. One caller thread owns the queue and may
+  // have exactly one allocated-but-unposted packet at a time.
+  std::mutex direct_mutex;
+  std::thread::id direct_owner;
+  bool direct_owner_set = false;
+  BurstParams* direct_pending = nullptr;
+  std::atomic<uint64_t> direct_conflicts{0};
+  uint64_t direct_no_space = 0;
   // tx_eth_src offload: when set, set_eth_header stamps the port's MAC as the
   // Ethernet source so the application doesn't have to supply it.
   bool insert_eth_src = false;
@@ -340,6 +356,7 @@ class IbverbsEngine : public Engine {
 
   // TX construction / header fill (implemented in the TX milestone)
   Status get_tx_packet_burst(BurstParams* burst) override;
+  Status get_tx_packet_burst_checked(BurstParams* burst) override;
   Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) override;
   Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
                          unsigned int src_host, unsigned int dst_host) override;
@@ -373,7 +390,8 @@ class IbverbsEngine : public Engine {
   Status drop_all_traffic(int port) override;
   Status allow_all_traffic(int port) override;
   Status add_rx_flow_async(int port, const FlowRuleConfig& flow, FlowOpId* op_id) override;
-  Status add_rx_flows_async(int port, const std::vector<FlowRuleConfig>& flows, FlowOpId* op_id) override;
+  Status add_rx_flows_async(int port, const std::vector<FlowRuleConfig>& flows,
+                            FlowOpId* op_id) override;
   Status delete_flow_async(FlowId flow_id, FlowOpId* op_id) override;
   Status poll_flow_op(FlowOpResult* result) override;
   uint16_t get_num_rx_queues(int port_id) const override;
@@ -429,7 +447,7 @@ class IbverbsEngine : public Engine {
                                                    uint32_t* out_id_sample_id);
   void devx_build_wqe(IbvRxQueue& q, uint32_t wqe_idx);  // write one RQ WQE
   void devx_ring_rq_doorbell(IbvRxQueue& q);
-  void devx_advance_producer(IbvRxQueue& q);  // worker-only: refill freed regions
+  void devx_advance_producer(IbvRxQueue& q);  // poller-owned: refill freed regions
   void devx_destroy(IbvRxQueue& q);
 
   // ---- GPU reorder ----
@@ -446,7 +464,7 @@ class IbverbsEngine : public Engine {
   // One poller thread services a group of RX queues that share a cpu_core,
   // round-robin. rx_poll_queue does one bounded pass over a single queue's CQ.
   void rx_worker(std::vector<IbvRxQueue*> group);
-  void rx_poll_queue(IbvRxQueue* q);
+  Status rx_poll_queue(IbvRxQueue* q, BurstParams** direct_burst = nullptr);
   bool rx_alloc_burst(IbvRxQueue* q);  // grab a metadata burst into q->cur_burst
   void rx_flush_burst(IbvRxQueue* q);  // enqueue q->cur_burst to the app ring
   // Release `strd` strides belonging to `wqe_idx`; repost the region if fully
@@ -455,7 +473,7 @@ class IbverbsEngine : public Engine {
 
   // ---- TX path ----
   Status setup_tx_queue(IbvTxQueue& q, const InterfaceConfig& intf, const TxQueueConfig& qcfg);
-  Status create_tx_raw_qp(IbvTxQueue& q);                 // IBV_QPT_RAW_PACKET, RESET->RTS
+  Status create_tx_raw_qp(IbvTxQueue& q);  // IBV_QPT_RAW_PACKET, RESET->RTS
   Status configure_tx_pacing(IbvTxQueue& q, uint64_t pacing_mbps);
   void post_tx_burst(IbvTxQueue& q, BurstParams* burst);  // build send WQEs + ring doorbell
   void post_tx_burst_empw(IbvTxQueue& q, BurstParams* burst);
@@ -466,6 +484,7 @@ class IbverbsEngine : public Engine {
   uint64_t tx_burst_wqebbs(const IbvTxQueue& q, const BurstParams* burst) const;
   bool tx_sq_has_space(IbvTxQueue& q, uint64_t needed_wqebbs);
   void poll_tx_completions(IbvTxQueue& q);  // drain TX CQ, reclaim slot-runs
+  bool lock_direct_tx_queue(IbvTxQueue& q, std::unique_lock<std::mutex>& guard);
   // One worker services a group of TX queues sharing a cpu_core, round-robin:
   // drains each send_ring (post) + reclaims completions.
   void tx_worker(std::vector<IbvTxQueue*> group);
@@ -650,6 +669,7 @@ class IbverbsEngine : public Engine {
   daqiri::ObjectPool* tx_meta_pool_ = nullptr;
   size_t rx_meta_pool_size_ = 0;
   uint32_t max_batch_ = 0;  // largest batch_size across RX+TX queues
+  static constexpr uint32_t kDirectPollMaxBatch = 256;
 
   // Tag every burst metadata block so free paths can find the owning queue.
   // Stored in the burst's BurstHeader.


### PR DESCRIPTION
Adds per-queue poll_mode support for the raw ibverbs engine, with existing queues remaining indirect by default. In direct mode, the application thread services RX or submits single-packet TX directly, removing the worker-thread handoff to reduce latency. Direct queues require one application thread per queue, omit worker-specific configuration fields, and can coexist with indirect queues on the same interface. The change preserves zero-copy buffer ownership, hardware timestamps, flow steering, HDS, packet pacing, scheduled transmission, and existing APIs, while adding C++ and Python configuration support plus documentation of the behavior, restrictions, and latency-versus-progress tradeoffs.

Closes #237 