### PR TITLE
#241 - Document IGX Thor hybrid-GPU and ibdev2netdev gaps

### DIFF
--- a/docs/benchmarks/raw_benchmarking.md
+++ b/docs/benchmarks/raw_benchmarking.md
@@ -46,6 +46,24 @@ docker run --rm -it --privileged \
     | `--network=host` | Shares the host network namespace so DPDK can discover the physical NIC interfaces and their PCIe topology |
     | `-v /dev/hugepages:/dev/hugepages` | Mounts the hugepage filesystem for DPDK memory allocation (`--privileged` alone does not cover mounted filesystems) |
 
+!!! warning "Hybrid iGPU + dGPU hosts (IGX Thor)"
+
+    On Tegra/IGX systems that pair an integrated GPU with a discrete card, `--privileged` populates `/dev` with all Tegra iGPU nodes and the container runtime's device selection is ignored — `--gpus '"device=N"'` and `NVIDIA_VISIBLE_DEVICES` both leave CUDA seeing only the **iGPU**. Select the target GPU inside the container instead, by UUID:
+
+    ```bash
+    nvidia-smi --query-gpu=index,name,uuid --format=csv   # on the host
+
+    docker run --rm -it --privileged \
+      --runtime=nvidia \
+      --network=host \
+      --gpus all \
+      -e CUDA_VISIBLE_DEVICES=GPU-<uuid> \
+      -v /dev/hugepages:/dev/hugepages \
+      daqiri:local bash
+    ```
+
+    Use the UUID, not a numeric index: CUDA enumerates Tegra GPUs in the opposite order from `nvidia-smi`. The selected GPU becomes CUDA ordinal **0**, so `memory_regions[*].affinity` must be `0` regardless of what `nvidia-smi` reports. Selecting both GPUs at once fails — the Tegra CUDA driver initializes only one GPU class per process.
+
 ## Update the loopback configuration
 
 !!! tip "DGX Spark"

--- a/docs/javascripts/platform-tab-toc.js
+++ b/docs/javascripts/platform-tab-toc.js
@@ -12,7 +12,7 @@
     );
     if (blocks.length < 2) return;
 
-    var tabKeys = ["igx-orin", "dgx-spark"];
+    var tabKeys = ["igx-series", "dgx-spark"];
 
     var anchorTab = {};
     blocks.forEach(function (block, i) {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -658,7 +658,7 @@
   border-radius: 12px;
 }
 
-/* ── Platform tabs (IGX Orin / DGX Spark) — enlarged labels ─────────── */
+/* ── Platform tabs (IGX Series / DGX Spark) — enlarged labels ─────────── */
 /* Scoped to the .platform-tabs wrapper in system_configuration.md and  */
 /* limited to the wrapper's direct tabbed-set so nested sub-tabs        */
 /* (tune_system.py / manual, One-time / Persistent, …) are unaffected.  */
@@ -672,8 +672,8 @@
 /* JS (platform-tab-toc.js) tags each [data-tab] link and mirrors the active */
 /* tab onto <body data-active-tab="...">. We hide the link's containing <li> */
 /* (via :has()) so the surrounding indentation collapses too.                */
-body[data-active-tab="igx-orin"] .md-nav--secondary li:has(> a[data-tab="dgx-spark"]),
-body[data-active-tab="dgx-spark"] .md-nav--secondary li:has(> a[data-tab="igx-orin"]) {
+body[data-active-tab="igx-series"] .md-nav--secondary li:has(> a[data-tab="dgx-spark"]),
+body[data-active-tab="dgx-spark"] .md-nav--secondary li:has(> a[data-tab="igx-series"]) {
   display: none;
 }
 

--- a/docs/tutorials/bare-metal-cmake-build.md
+++ b/docs/tutorials/bare-metal-cmake-build.md
@@ -424,7 +424,7 @@ The build recipe above is the same on every supported host. The notes below cove
         ```
 
         Use a different value (or extra entries) if you have a different dGPU installed.
-    - On IGX Orin, several system settings (BAR1 size, MRRS, NIC link layer) need to be applied **before** DAQIRI will run end-to-end. Follow the [IGX Orin tab in System Configuration](system_configuration.md) for the full sequence. The build itself does not require those changes.
+    - On IGX Orin, several system settings (BAR1 size, MRRS, NIC link layer) need to be applied **before** DAQIRI will run end-to-end. Follow the [IGX Series tab in System Configuration](system_configuration.md) for the full sequence. The build itself does not require those changes.
     - GPUDirect can use either the patched DPDK's dma-buf path (recommended) or the legacy `nvidia-peermem` module. The patched DPDK built in [Step 3](#step-3-build-dpdk-with-daqiri-patches) removes the peermem dependency.
     - For ARM64 (`aarch64`) hosts, set `PKG_CONFIG_PATH` to the aarch64 directory:
 

--- a/docs/tutorials/system_configuration.md
+++ b/docs/tutorials/system_configuration.md
@@ -7,20 +7,41 @@ hide:
 
 DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking/ethernet-adapters/) (ConnectX-6 Dx or later) and a CUDA-capable GPU. Two reference platforms are documented in this tutorial. Pick the one closest to yours below:
 
-- **IGX Orin** with a discrete GPU (e.g. [RTX 6000 Ada](https://www.nvidia.com/en-us/design-visualization/rtx-6000/)): peermem-based GPUDirect, a separate GPU BAR1, and a discrete-PCIe path between GPU and NIC. The originally-supported reference platform.
+- **IGX series** (Orin and Thor developer kits) with a discrete GPU: peermem-based GPUDirect, a separate GPU BAR1, and a discrete-PCIe path between GPU and NIC. The originally-supported reference platform.
 - **DGX Spark** (Grace Blackwell **GB10** superchip): unified CPU/GPU memory via NVLink-C2C, integrated **ConnectX-7**, no peermem, and GPUDirect via `kind: host_pinned` data buffers.
 
 <div class="platform-tabs" markdown="1">
 
-=== "IGX Orin"
+=== "IGX Series"
 
-    This tab covers both the **required system setup** to get DAQIRI running on IGX Orin and **optional performance tuning** to maximize throughput and minimize latency. Complete the [System Setup for DAQIRI](#system-setup-for-daqiri) section first, then move on to [System Optimization](#system-optimization) as needed.
+    This tab covers both the **required system setup** to get DAQIRI running on the IGX series and **optional performance tuning** to maximize throughput and minimize latency. Complete the [System Setup for DAQIRI](#system-setup-for-daqiri) section first, then move on to [System Optimization](#system-optimization) as needed.
 
     ## System Setup for DAQIRI
 
     This section covers the essential system setup steps needed before using DAQIRI. Complete this setup before moving on to [System Optimization](#system-optimization) or [running benchmarks](../benchmarks/index.md).
 
-    In this tutorial, we will be developing on an **NVIDIA IGX Orin platform** with [IGX SW 1.1](https://docs.nvidia.com/igx-orin/user-guide/latest/base-os.html) and an [NVIDIA RTX 6000 ADA GPU](https://www.nvidia.com/en-us/design-visualization/rtx-6000/), which is the configuration that is currently actively tested. The concepts should be applicable to other systems based on Ubuntu 22.04 as well. It should also work on other Linux distributions with a glibc version of 2.35 or higher by containerizing the dependencies and applications on top of an Ubuntu 22.04 image, but this is not actively tested at this time.
+    Two IGX configurations are actively tested:
+
+    - **IGX Orin** with [IGX SW 1.1](https://docs.nvidia.com/igx-orin/user-guide/latest/base-os.html) (Ubuntu 22.04) and an [NVIDIA RTX 6000 Ada GPU](https://www.nvidia.com/en-us/design-visualization/rtx-6000/). The steps below are written against this platform.
+    - **IGX Thor developer kit** (Ubuntu 24.04, driver 580 / CUDA 13) with a discrete RTX PRO 6000 Blackwell **alongside the Thor iGPU**. Everything below applies unchanged except for GPU selection — see the admonition immediately after.
+
+    The concepts should be applicable to other systems based on Ubuntu 22.04 as well. It should also work on other Linux distributions with a glibc version of 2.35 or higher by containerizing the dependencies and applications on top of an Ubuntu 22.04 image, but this is not actively tested at this time.
+
+    !!! Warning "IGX Thor: select the discrete GPU explicitly"
+
+        Thor developer kits expose **two** GPUs: the integrated Thor iGPU and the discrete card. CUDA enumerates them in the **opposite order** from `nvidia-smi`/NVML, and the Tegra CUDA driver initializes only **one GPU class at a time** — requesting both (`CUDA_VISIBLE_DEVICES=0,1`) makes `cuInit` fail outright. Always select by **UUID**, never by index:
+
+        ```bash
+        nvidia-smi --query-gpu=index,name,uuid --format=csv
+        ```
+
+        Without an explicit selection, CUDA resolves to the **iGPU**. `tune_system.py` gates four checks on `is_any_integrated_gpu()`, so on Thor they silently skip or report an iGPU-flavored INFO instead of evaluating the discrete card: `--check peermem`, `--check gpudirect`, `--check topo`, and `--check bar1-size`. Prefix the run with the discrete GPU's UUID to get real results:
+
+        ```bash
+        sudo CUDA_VISIBLE_DEVICES=GPU-<uuid> ./python/tune_system.py --check all
+        ```
+
+        The same applies to containers — see [Running the DAQIRI container](../benchmarks/raw_benchmarking.md#running-the-daqiri-container).
 
     !!! Warning "Secure boot conflict"
 
@@ -57,8 +78,10 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
 
         ```bash
         sudo apt update
-        sudo apt install infiniband-diags ibverbs-utils mlnx-ofed-kernel-utils mft
+        sudo apt install infiniband-diags ibverbs-utils mlnx-tools mlnx-ofed-kernel-utils mft
         ```
+
+        `mlnx-tools` (which provides `ibdev2netdev`) comes from the NVIDIA DOCA-Host APT repository. Without that repository configured it is unavailable, so every step below that uses `ibdev2netdev` offers a `lspci` or sysfs alternative.
 
         Also upgrade the user space libraries to make sure your tools have all the symbols they need:
 
@@ -220,6 +243,23 @@ DAQIRI requires an [**NVIDIA SmartNIC**](https://www.nvidia.com/en-us/networking
         mlx5_0 port 1 ==> eth0 (Down)
         mlx5_1 port 1 ==> eth1 (Up)
         ```
+
+    ??? failure "ibdev2netdev: command not found"
+
+        `ibdev2netdev` ships in `mlnx-tools` (DOCA-Host). If it is unavailable, read the same IB-device → netdev → PCIe mapping straight out of sysfs:
+
+        ```bash
+        for dev in /sys/class/infiniband/*; do
+          echo "$(basename "$dev") ==> $(ls "$dev"/device/net) [$(basename "$(readlink -f "$dev"/device)")]"
+        done
+        ```
+
+        ```sh
+        roceP4p3s0f0 ==> enP4p3s0f0np0 [0004:03:00.0]
+        roceP4p3s0f1 ==> enP4p3s0f1np1 [0004:03:00.1]
+        ```
+
+        Link state comes from `cat /sys/class/net/<netdev>/operstate`.
 
     ??? failure "ibdev2netdev does not show the NIC"
 

--- a/python/tune_system.py
+++ b/python/tune_system.py
@@ -317,8 +317,8 @@ def get_nic_info():
 
     except FileNotFoundError:
         logging.warning(
-            "The ibdev2netdev command is not found (try: apt install infiniband-diags). "
-            "Skipping NIC-dependent checks (mrrs, mps, mtu)."
+            "The ibdev2netdev command is not found (ships in mlnx-tools, from the NVIDIA "
+            "DOCA-Host APT repository). Skipping NIC-dependent checks (mrrs, mps, mtu)."
         )
         return []
     except subprocess.CalledProcessError as e:
@@ -2119,7 +2119,8 @@ def check_mtu_size():
 
     except FileNotFoundError:
         logging.error(
-            "The ibdev2netdev command is not found. Ensure that it is installed and available in your PATH."
+            "The ibdev2netdev command is not found. Install mlnx-tools from the NVIDIA "
+            "DOCA-Host APT repository."
         )
     except subprocess.CalledProcessError as e:
         logging.error(f"Error while executing a command: {e}")
@@ -2182,7 +2183,8 @@ def update_mrrs_for_nvidia_devices():
 
     except FileNotFoundError:
         logging.error(
-            "The ibdev2netdev or setpci command is not found. Ensure that they are installed and available in your PATH."
+            "The ibdev2netdev or setpci command is not found. ibdev2netdev ships in mlnx-tools "
+            "from the NVIDIA DOCA-Host APT repository; setpci ships in pciutils."
         )
     except subprocess.CalledProcessError as e:
         logging.error(f"Error while executing a command: {e}")


### PR DESCRIPTION
Closes Issue #241 

Running the raw GPUDirect sweep on an IGX Thor devkit surfaced three places where the system tuning tutorial is wrong or silently unhelpful on a host that pairs the Thor iGPU with a discrete card.

Generalize the "IGX Orin" tab to "IGX Series" and name both tested configurations: Orin with an RTX 6000 Ada on IGX SW 1.1, and the Thor devkit with an RTX PRO 6000 on Ubuntu 24.04 / driver 580. Everything in the tab applies to both; the only divergence is GPU selection, so it is stated once rather than repeated per step.

That divergence, verified on the Thor rig:

  - CUDA enumerates the two GPUs in the opposite order from nvidia-smi/NVML. CUDA_VISIBLE_DEVICES=0 resolves to the discrete RTX PRO 6000 while nvidia-smi calls it index 1, so numeric selection silently targets the wrong device in either direction. UUID is the only reliable form.
  - The Tegra CUDA driver initializes one GPU class per process. CUDA_VISIBLE_DEVICES=0,1 fails in cuInit rather than returning two devices.
  - With no explicit selection CUDA resolves to the iGPU, so is_any_integrated_gpu() returns true and tune_system.py skips or downgrades four checks -- peermem, gpudirect, topo, bar1-size -- none of which ever look at the discrete card. Prefixing the run with the discrete GPU's UUID restores them.

For containers, --privileged populates /dev with the Tegra iGPU nodes and the runtime's device selection stops working: --gpus '"device=N"' and NVIDIA_VISIBLE_DEVICES=GPU-<uuid> both leave CUDA seeing only the iGPU. -e CUDA_VISIBLE_DEVICES=GPU-<uuid> does work, and the selected GPU becomes CUDA ordinal 0, so memory_regions[*].affinity must be 0 regardless of what nvidia-smi reports. Documented against the raw benchmarking container recipe, including the two forms that do not work, so they are not retried.

ibdev2netdev is not in Ubuntu's infiniband-diags; it ships in mlnx-tools from the DOCA-Host repository. On a host without that repository the package installs cleanly and the tool is still missing, which is how the MRRS/MPS/MTU checks came to be bypassed with only a warning that recommended the package that had already been installed. Correct the install list and the three tune_system.py messages, and add a sysfs fallback for the IB-device to netdev to PCIe mapping that needs no Mellanox tooling.

Also rename the platform-tab key igx-orin to igx-series in the TOC javascript and stylesheet. The key is positional, not derived from the label, so this is cosmetic.

No logic changes in tune_system.py; the guidance strings only. The per-GPU gating fix for check_bar1_size and check_gpu_nic_topology, which short-circuit on is_any_integrated_gpu() instead of iterating devices the way check_gpudirect_support already does, is left for a follow-up issue.

Assisted-by: Claude