### PR TITLE
Add bulk packet pointer access

### DIFF
--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -248,6 +248,13 @@ daqiri.free_rx_burst(burst)                  # metadata only
 addresses. They do not return Python-managed memory objects and they do not
 transfer ownership to Python.
 
+The bulk accessor returns the same integer addresses for the first `count`
+packets in one call:
+
+```python
+status, addresses = daqiri.get_segment_packet_ptrs(burst, seg=0, count=32)
+```
+
 Prefer the copy helpers unless the application deliberately needs raw addresses
 for CUDA or foreign-function interop. The copy helpers handle both CPU pointers
 and CUDA device pointers. Device copies use `cudaMemcpy` internally.
@@ -547,6 +554,7 @@ The workflow sections above show the common call order and ownership rules.
 | `get_burst_tot_byte(burst)` | Read total byte count for a burst. |
 | `get_packet_ptr(burst, idx)` | Return segment 0 packet address as an integer. |
 | `get_segment_packet_ptr(burst, seg, idx)` | Return segment packet address as an integer. |
+| `get_segment_packet_ptrs(burst, seg, count)` | Return `(Status, addresses)` for the first `count` packets in a segment. |
 | `get_packet_length(burst, idx)` / `get_segment_packet_length(burst, seg, idx)` | Read packet or segment length. |
 | `get_packet_flow_id(burst, idx)` | Read matched flow ID, or `0` when no flow matched. |
 | `get_packet_rx_timestamp(burst, idx)` | Return `(Status, timestamp_ns)`. |

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -148,6 +148,21 @@ template <typename Config> EngineType get_engine_type(const Config &config);
 void *get_segment_packet_ptr(BurstParams *burst, int seg, int idx);
 
 /**
+ * @brief Returns raw packet pointers for a segment of a burst
+ *
+ * This bulk form avoids repeated engine dispatch when an application needs all
+ * packet data pointers in a burst.
+ *
+ * @param burst Burst structure containing packets
+ * @param seg Segment of each packet
+ * @param ptrs Output array with room for count pointers
+ * @param count Number of packet pointers to return
+ * @return SUCCESS, NULL_PTR, or INVALID_PARAMETER
+ */
+Status get_segment_packet_ptrs(BurstParams *burst, int seg, void **ptrs,
+                               int count);
+
+/**
  * @brief Returns a raw packet pointer from a pointer in BurstParams
  *
  * The BurstParams structure contains pointers to opaque packets which are not

--- a/python/daqiri_common_pybind.cpp
+++ b/python/daqiri_common_pybind.cpp
@@ -23,6 +23,7 @@
 #include <pybind11/stl.h>
 #include <yaml-cpp/yaml.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -1054,6 +1055,34 @@ PYBIND11_MODULE(_daqiri, m) {
       },
       "burst"_a, "seg"_a, "idx"_a,
       "Return the packet segment data pointer as an integer address");
+  m.def(
+      "get_segment_packet_ptrs",
+      [](BurstParams *burst, int seg, int count) {
+        std::vector<uintptr_t> addresses;
+        if (burst == nullptr) {
+          return py::make_tuple(Status::NULL_PTR, addresses);
+        }
+        if (count < 0 ||
+            static_cast<size_t>(count) > burst->hdr.hdr.num_pkts) {
+          return py::make_tuple(Status::INVALID_PARAMETER, addresses);
+        }
+
+        // Keep storage non-empty so the C++ output pointer remains valid when
+        // count is zero.
+        std::vector<void *> ptrs(static_cast<size_t>(std::max(count, 1)),
+                                 nullptr);
+        const Status status =
+            get_segment_packet_ptrs(burst, seg, ptrs.data(), count);
+        if (status == Status::SUCCESS) {
+          addresses.reserve(static_cast<size_t>(count));
+          for (int idx = 0; idx < count; ++idx) {
+            addresses.push_back(reinterpret_cast<uintptr_t>(ptrs[idx]));
+          }
+        }
+        return py::make_tuple(status, addresses);
+      },
+      "burst"_a, "seg"_a, "count"_a,
+      "Return (Status, segment packet addresses) for the first count packets");
   m.def(
       "get_packet_ptr",
       [](BurstParams *burst, int idx) {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -544,6 +544,12 @@ void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) {
   return g_daqiri_engine->get_segment_packet_ptr(burst, seg, idx);
 }
 
+Status get_segment_packet_ptrs(BurstParams* burst, int seg, void** ptrs,
+                               int count) {
+  ASSERT_DAQIRI_ENGINE_INITIALIZED();
+  return g_daqiri_engine->get_segment_packet_ptrs(burst, seg, ptrs, count);
+}
+
 void* get_packet_ptr(BurstParams* burst, int idx) {
   ASSERT_DAQIRI_ENGINE_INITIALIZED();
   return g_daqiri_engine->get_packet_ptr(burst, idx);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -852,6 +852,24 @@ Status Engine::poll_flow_op(FlowOpResult* result) {
   return Status::NOT_SUPPORTED;
 }
 
+Status Engine::get_segment_packet_ptrs(BurstParams* burst, int seg,
+                                       void** ptrs, int count) {
+  if (burst == nullptr || ptrs == nullptr) {
+    return Status::NULL_PTR;
+  }
+  if (seg < 0 || seg >= burst->hdr.hdr.num_segs || count < 0 ||
+      static_cast<size_t>(count) > burst->hdr.hdr.num_pkts) {
+    return Status::INVALID_PARAMETER;
+  }
+  for (int idx = 0; idx < count; ++idx) {
+    ptrs[idx] = get_segment_packet_ptr(burst, seg, idx);
+    if (ptrs[idx] == nullptr) {
+      return Status::NULL_PTR;
+    }
+  }
+  return Status::SUCCESS;
+}
+
 Status Engine::get_tx_packet_burst_checked(BurstParams* burst) {
   if (!is_tx_burst_available(burst)) {
     return Status::NO_FREE_BURST_BUFFERS;

--- a/src/engine.h
+++ b/src/engine.h
@@ -66,6 +66,8 @@ class Engine {
   virtual void* get_packet_ptr(BurstParams* burst, int idx) = 0;
   virtual uint32_t get_packet_length(BurstParams* burst, int idx) = 0;
   virtual void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) = 0;
+  virtual Status get_segment_packet_ptrs(BurstParams* burst, int seg,
+                                         void** ptrs, int count);
   virtual uint32_t get_segment_packet_length(BurstParams* burst, int seg, int idx) = 0;
   virtual FlowId get_packet_flow_id(BurstParams* burst, int idx) = 0;
   virtual Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) = 0;

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -6499,6 +6499,31 @@ void* DpdkEngine::get_segment_packet_ptr(BurstParams* burst, int seg, int idx) {
   return rte_pktmbuf_mtod(reinterpret_cast<rte_mbuf*>(burst->pkts[seg][idx]), void*);
 }
 
+Status DpdkEngine::get_segment_packet_ptrs(BurstParams* burst, int seg,
+                                           void** ptrs, int count) {
+  if (burst == nullptr || ptrs == nullptr) { return Status::NULL_PTR; }
+  if (seg < 0 || seg >= burst->hdr.hdr.num_segs || count < 0 ||
+      static_cast<size_t>(count) > burst->hdr.hdr.num_pkts) {
+    return Status::INVALID_PARAMETER;
+  }
+  if ((burst->hdr.hdr.burst_flags & kBurstFlagDpdkReordered) != 0U) {
+    if (seg != 0 || burst->pkts[0] == nullptr) {
+      return Status::INVALID_PARAMETER;
+    }
+    for (int idx = 0; idx < count; ++idx) {
+      ptrs[idx] = burst->pkts[0][idx];
+    }
+    return Status::SUCCESS;
+  }
+  if (burst->pkts[seg] == nullptr) { return Status::NULL_PTR; }
+  const auto mbufs = reinterpret_cast<rte_mbuf**>(burst->pkts[seg]);
+  for (int idx = 0; idx < count; ++idx) {
+    if (mbufs[idx] == nullptr) { return Status::NULL_PTR; }
+    ptrs[idx] = rte_pktmbuf_mtod(mbufs[idx], void*);
+  }
+  return Status::SUCCESS;
+}
+
 void* DpdkEngine::get_packet_ptr(BurstParams* burst, int idx) {
   if (burst == nullptr || idx < 0) { return nullptr; }
   if ((burst->hdr.hdr.burst_flags & kBurstFlagDpdkReordered) != 0U) {

--- a/src/engines/dpdk/daqiri_dpdk_engine.h
+++ b/src/engines/dpdk/daqiri_dpdk_engine.h
@@ -120,6 +120,8 @@ class DpdkEngine : public Engine {
   static constexpr int MAX_ETH_HDR_SIZE = 18;
 
   void* get_segment_packet_ptr(BurstParams* burst, int seg, int idx) override;
+  Status get_segment_packet_ptrs(BurstParams* burst, int seg, void** ptrs,
+                                 int count) override;
   void* get_packet_ptr(BurstParams* burst, int idx) override;
   uint32_t get_segment_packet_length(BurstParams* burst, int seg, int idx) override;
   uint32_t get_packet_length(BurstParams* burst, int idx) override;


### PR DESCRIPTION
## Summary

- add a bulk packet-pointer accessor for a burst
- expose the accessor through the C++ and Python APIs
- retain the existing single-packet accessor

## Motivation

Applications that process a complete burst currently pay repeated API-call overhead to retrieve packet addresses one at a time. The bulk accessor provides the same pointers in one call without exposing engine-specific burst storage.

## Testing

- built `daqiri_common`, `daqiri_dpdk`, and `daqiri_ibverbs` in the CUDA 13.3 Aerial x86 container
- built and imported the Python extension, and verified `daqiri.get_segment_packet_ptrs` is registered
- compared Release builds at the full 22-queue profile with 1,690,000 measured cycles and zero dropped or skipped bursts
- DPDK bulk access reduced average acquisition time from 14.183 to 14.039 us on GH200 (1.0%) and from 15.888 to 15.292 us on x86 (3.8%)
- raw ibverbs uses the engine-neutral fallback loop and showed no material change: 7.836 versus 7.917 us on GH200 and 7.112 versus 7.043 us on x86