### PR TITLE
Register application-owned DPDK threads

### DIFF
--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -653,8 +653,22 @@ workflow sections above show the common call order and ownership rules.
 | `parse_network_config(...)` | Parse YAML into `NetworkConfig` without starting the engine. |
 | `get_engine_type()` | Return the active engine type after initialization. |
 | `get_engine_type(config)` | Return the engine type selected by a config object. |
+| `register_current_thread()` | Initialize engine-specific state for the calling application-owned data-plane thread. |
+| `unregister_current_thread()` | Release state acquired by `register_current_thread()` on the calling thread. |
 | `shutdown()` | Stop DAQIRI and release engine-owned resources. |
 | `print_stats()` | Print engine statistics. |
+
+Application-created threads that call data-plane APIs should call
+`register_current_thread()` after initialization and before their first packet
+operation, then call `unregister_current_thread()` on that same thread before
+`shutdown()`. Registration is per thread and idempotent.
+
+For the DPDK engine, registration makes an application-owned thread known to
+the DPDK EAL. If the thread is already EAL-managed, registration succeeds
+without taking ownership, and `unregister_current_thread()` leaves the existing
+EAL registration intact. DAQIRI-owned worker threads are managed internally.
+Engines that require no per-thread runtime state implement both calls as
+no-ops.
 
 ### Burst Metadata
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -263,6 +263,22 @@ queue requires `cpu_core` and `batch_size`; RX queues may also use `timeout_us`
 to return a partial batch. `indirect` mode also allows more processing jitter in the application threads by using a zero-copy ring in between DAQIRI and the user. This is the existing behavior and is supported by
 all applicable engines.
 
+#### Application-owned data-plane threads
+
+An application-created thread that calls packet burst APIs should call
+`register_current_thread()` after `daqiri_init()` and before its first
+data-plane operation. It must call `unregister_current_thread()` from that same
+thread before `shutdown()`. The lifecycle applies independently to every
+application-created data-plane thread; DAQIRI-owned queue workers are registered
+and released internally.
+
+The DPDK engine uses this lifecycle to register application-owned threads with
+the DPDK EAL. Registration is idempotent. If a thread is already EAL-managed,
+DAQIRI does not take ownership of that registration and therefore does not
+remove it during unregistration. Engines without per-thread runtime state treat
+the lifecycle calls as no-ops, allowing applications to use the same thread
+setup for every engine.
+
 In **direct mode**, there is no worker between the application and the queue.
 The application thread performs the queue work as part of its normal API calls:
 

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -278,6 +278,24 @@ Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_
 Status get_tx_packet_burst(BurstParams *burst);
 
 /**
+ * @brief Register the calling application-owned data-plane thread
+ *
+ * Engines that require per-thread runtime state initialize it for the calling
+ * thread. Other engines treat this as a no-op. A successful registration must
+ * be paired with unregister_current_thread() on the same thread before engine
+ * shutdown.
+ */
+Status register_current_thread();
+
+/**
+ * @brief Unregister the calling application-owned data-plane thread
+ *
+ * This only releases state acquired by register_current_thread() on the same
+ * thread; engine-owned worker threads are unaffected.
+ */
+void unregister_current_thread();
+
+/**
  * @brief Set IPv4 header in packet
  *
  * @param burst Burst structure to populate

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -447,6 +447,16 @@ Status get_tx_packet_burst(BurstParams* burst) {
   return g_daqiri_engine->get_tx_packet_burst_checked(burst);
 }
 
+Status register_current_thread() {
+  ASSERT_DAQIRI_ENGINE_INITIALIZED();
+  return g_daqiri_engine->register_current_thread();
+}
+
+void unregister_current_thread() {
+  ASSERT_DAQIRI_ENGINE_INITIALIZED();
+  g_daqiri_engine->unregister_current_thread();
+}
+
 Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) {
   ASSERT_DAQIRI_ENGINE_INITIALIZED();
   return g_daqiri_engine->set_eth_header(burst, idx, dst_addr);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -859,6 +859,12 @@ Status Engine::get_tx_packet_burst_checked(BurstParams* burst) {
   return get_tx_packet_burst(burst);
 }
 
+Status Engine::register_current_thread() { return Status::SUCCESS; }
+
+void Engine::unregister_current_thread() {
+  // Most engines do not require per-thread runtime state.
+}
+
 Status Engine::get_rx_burst(BurstParams** burst, int port_id) {
   // Check if the port_id is valid
   if (port_id < 0 || port_id >= static_cast<int>(cfg_.ifs_.size())) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -73,6 +73,8 @@ class Engine {
   virtual Status get_tx_packet_burst(BurstParams* burst) = 0;
   // Engines with richer availability states can override this checked entrypoint.
   virtual Status get_tx_packet_burst_checked(BurstParams* burst);
+  virtual Status register_current_thread();
+  virtual void unregister_current_thread();
   virtual Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) = 0;
   virtual Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
                                  unsigned int src_host, unsigned int dst_host) = 0;

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -6597,6 +6597,34 @@ void* DpdkEngine::get_packet_extra_info(BurstParams* burst, int idx) {
   return nullptr;
 }
 
+namespace {
+thread_local bool thread_registered_by_daqiri = false;
+}
+
+Status DpdkEngine::register_current_thread() {
+  if (rte_lcore_id() != LCORE_ID_ANY) {
+    return Status::SUCCESS;
+  }
+  if (rte_thread_register() != 0) {
+    DAQIRI_LOG_ERROR("Failed to register application thread with DPDK: errno={} ({})",
+                     rte_errno, rte_strerror(rte_errno));
+    return Status::INTERNAL_ERROR;
+  }
+  thread_registered_by_daqiri = true;
+  DAQIRI_LOG_DEBUG("Registered application thread as DPDK lcore {}", rte_lcore_id());
+  return Status::SUCCESS;
+}
+
+void DpdkEngine::unregister_current_thread() {
+  if (!thread_registered_by_daqiri) {
+    return;
+  }
+  const auto lcore_id = rte_lcore_id();
+  rte_thread_unregister();
+  thread_registered_by_daqiri = false;
+  DAQIRI_LOG_DEBUG("Unregistered application DPDK lcore {}", lcore_id);
+}
+
 Status DpdkEngine::get_tx_packet_burst(BurstParams* burst) {
   const uint32_t key = generate_queue_key(burst->hdr.hdr.port_id, burst->hdr.hdr.q_id);
   const auto q_it = tx_dpdk_q_map_.find(key);

--- a/src/engines/dpdk/daqiri_dpdk_engine.h
+++ b/src/engines/dpdk/daqiri_dpdk_engine.h
@@ -127,6 +127,8 @@ class DpdkEngine : public Engine {
   Status get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t* timestamp_ns) override;
   void* get_packet_extra_info(BurstParams* burst, int idx) override;
   Status get_tx_packet_burst(BurstParams* burst) override;
+  Status register_current_thread() override;
+  void unregister_current_thread() override;
   Status set_eth_header(BurstParams* burst, int idx, char* dst_addr) override;
   Status set_ipv4_header(BurstParams* burst, int idx, int ip_len, uint8_t proto,
                             unsigned int src_host, unsigned int dst_host) override;


### PR DESCRIPTION
## Summary

- add engine-level registration hooks for application-owned dataplane threads
- register and unregister non-EAL application threads with DPDK
- keep no-op defaults for engines that do not require per-thread runtime state

## Motivation

Applications may construct or process packets on their own worker threads. DPDK APIs require those threads to be registered before using per-lcore state; doing this through the Engine interface avoids engine checks in shared application code.

## Testing

- built `daqiri_common`, `daqiri_dpdk`, and `daqiri_ibverbs` in the CUDA 13.3 Aerial x86 container
- exercised with application-owned TX construction workers in 22-queue DPDK runs