### PR TITLE
Add Ethernet address flow matching

### DIFF
--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -276,6 +276,10 @@ RX flows can also perform hardware VLAN pop or tunnel decapsulation before queue
       - type: `string`
       - format: `xx:xx:xx:xx:xx:xx`
 
+    The `ethernet` match class is mutually exclusive with eCPRI, IPv4/UDP,
+    and flex-item criteria. A configuration that combines `match.ethernet`
+    with fields from another match class is rejected during parsing.
+
 For Raw Ethernet (`stream_type: "raw"`), each flow rule is programmed into the NIC during
 `daqiri_init()`. If any rule cannot be installed, or the send-to-kernel fallback cannot be
 created when `flow_isolation: true`, initialization fails with a critical log and

--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -229,8 +229,11 @@ RX flows can also perform hardware VLAN pop or tunnel decapsulation before queue
     - **`id`**: Queue ID under `rx.queues` on the same interface.
     - **`ids`**: Non-empty list of unique queue IDs under `rx.queues` on the same
       interface. One entry is direct steering. Two or more entries automatically
-      enable flow-affine Toeplitz RSS over source/destination IPv4 address and
-      source/destination UDP port. `id` and `ids` are mutually exclusive.
+      enable RSS. IP/UDP matches use flow-affine Toeplitz hashing over source and
+      destination IPv4 addresses and UDP ports. An Ethernet-only match remains
+      MAC-only; it does not implicitly add IPv4/UDP criteria, so matching non-IP
+      frames remain eligible for the RSS destination. `id` and `ids` are mutually
+      exclusive.
   - **`type: vlan_pop`**: Pop one VLAN tag in hardware.
   - **`type: tunnel_decap`**: Decapsulate a hardware tunnel before queue delivery.
     - **`tunnel.type`**: `vxlan`, `gre`, or `nvgre`.

--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -269,9 +269,9 @@ RX flows can also perform hardware VLAN pop or tunnel decapsulation before queue
       message type to locate the identifier in the eCPRI header).
       - type: `integer`
 
-  - **`ethernet`**: Raw Ethernet address match. Presence of this map selects the Ethernet
-    flow class. It cannot be combined with UDP/IP, flex-item, or eCPRI matching and must
-    contain at least one address.
+  - **`ethernet`**: Raw Ethernet address match. The map must contain at least one address.
+    It can be used alone or combined with IPv4/UDP, flex-item, or eCPRI criteria; all
+    configured criteria must match for the rule to apply.
     - **`src`**: Source MAC address to match. Optional.
       - type: `string`
       - format: `xx:xx:xx:xx:xx:xx`
@@ -279,9 +279,6 @@ RX flows can also perform hardware VLAN pop or tunnel decapsulation before queue
       - type: `string`
       - format: `xx:xx:xx:xx:xx:xx`
 
-    The `ethernet` match class is mutually exclusive with eCPRI, IPv4/UDP,
-    and flex-item criteria. A configuration that combines `match.ethernet`
-    with fields from another match class is rejected during parsing.
 
 For Raw Ethernet (`stream_type: "raw"`), each flow rule is programmed into the NIC during
 `daqiri_init()`. If any rule cannot be installed, or the send-to-kernel fallback cannot be
@@ -293,8 +290,9 @@ firmware steering, so any interface with eCPRI flows is automatically switched t
 `dv_flow_en=1` (logged as a warning); a side effect is that the async/template dynamic-RX-flow
 API is unavailable on that interface. The `ibverbs` engine has no such restriction.
 
-A single RX interface must use exactly one flow class: standard UDP/IP, flex-item, eCPRI, or
-Ethernet.
+A single RX interface must use exactly one protocol flow class: standard UDP/IP (including
+Ethernet-only rules), flex-item, or eCPRI. Ethernet address criteria may qualify a rule in
+any of these classes and do not select a separate class when protocol criteria are present.
 Each class installs its own DPDK group-0 jump rule, and these conflict when mixed, so only one
 class is reachable per interface. `daqiri_init` rejects mixed configs with a clear error.
 Flex-item flows cannot be combined with VLAN/tunnel transform actions in v1.

--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -266,6 +266,16 @@ RX flows can also perform hardware VLAN pop or tunnel decapsulation before queue
       message type to locate the identifier in the eCPRI header).
       - type: `integer`
 
+  - **`ethernet`**: Raw Ethernet address match. Presence of this map selects the Ethernet
+    flow class. It cannot be combined with UDP/IP, flex-item, or eCPRI matching and must
+    contain at least one address.
+    - **`src`**: Source MAC address to match. Optional.
+      - type: `string`
+      - format: `xx:xx:xx:xx:xx:xx`
+    - **`dst`**: Destination MAC address to match. Optional.
+      - type: `string`
+      - format: `xx:xx:xx:xx:xx:xx`
+
 For Raw Ethernet (`stream_type: "raw"`), each flow rule is programmed into the NIC during
 `daqiri_init()`. If any rule cannot be installed, or the send-to-kernel fallback cannot be
 created when `flow_isolation: true`, initialization fails with a critical log and
@@ -276,7 +286,8 @@ firmware steering, so any interface with eCPRI flows is automatically switched t
 `dv_flow_en=1` (logged as a warning); a side effect is that the async/template dynamic-RX-flow
 API is unavailable on that interface. The `ibverbs` engine has no such restriction.
 
-A single RX interface must use exactly one flow class: standard UDP/IP, flex-item, or eCPRI.
+A single RX interface must use exactly one flow class: standard UDP/IP, flex-item, eCPRI, or
+Ethernet.
 Each class installs its own DPDK group-0 jump rule, and these conflict when mixed, so only one
 class is reachable per interface. `daqiri_init` rejects mixed configs with a clear error.
 Flex-item flows cannot be combined with VLAN/tunnel transform actions in v1.

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -678,7 +678,7 @@ encapsulation/push rules are configured in YAML under `tx.flows`.
 | `SocketMode` | `CLIENT`, `SERVER`, `INVALID` |
 | `FlowType` | `QUEUE`, `VLAN_PUSH`, `VLAN_POP`, `TUNNEL_ENCAP`, `TUNNEL_DECAP` |
 | `TunnelType` | `NONE`, `VXLAN`, `GRE`, `NVGRE` |
-| `FlowMatchType` | `IPV4_UDP`, `FLEX_ITEM` |
+| `FlowMatchType` | `IPV4_UDP`, `FLEX_ITEM`, `ECPRI`, `ETHERNET` |
 | `FlowOpType` | `ADD_RX`, `ADD_RX_BATCH`, `DELETE` |
 | `ReorderMethod` | `INVALID`, `SEQ_BATCH_NUMBER`, `SEQ_PACKETS_PER_BATCH` |
 | `ReorderDataType` | `SAME`, `INT4`, `INT8`, `INT16`, `INT32`, `FP16`, `BF16`, `FP32`, `FP64`, `INVALID` |
@@ -712,7 +712,8 @@ names that mostly omit the trailing underscore from the C++ member name (e.g.
 | `VlanActionConfig` | VLAN push parameters: VLAN ID, priority, DEI, and ethertype. |
 | `TunnelConfig` | VXLAN, GRE, or NVGRE tunnel template fields for hardware encap/decap actions. |
 | `FlowAction` | Flow action type, scalar queue target `id`, queue-list target `ids`, optional VLAN config, and optional tunnel config. |
-| `FlowMatch` | Flow match fields for UDP, IPv4, and flex item matching. |
+| `EthernetMatch` | Optional source and destination MAC-address match fields. |
+| `FlowMatch` | Flow match fields for Ethernet, UDP, IPv4, eCPRI, and flex-item matching. |
 | `FlowConfig` | Static named flow rule combining legacy `action`, ordered `actions`, and match fields. |
 | `FlowRuleConfig` | Dynamic RX flow rule combining legacy `action`, ordered `actions`, and match fields. |
 | `FlowOpResult` | Dynamic flow operation completion. Batch adds return `flow_ids` in input order. |

--- a/include/daqiri/types.h
+++ b/include/daqiri/types.h
@@ -787,10 +787,18 @@ struct EcpriMatch {
   uint16_t id_ = 0;  // pc_id (msg type 0/1) or rtc_id (msg type 2), at eCPRI offset 4
 };
 
+struct EthernetMatch {
+  bool match_src_ = false;
+  std::array<uint8_t, 6> src_{};
+  bool match_dst_ = false;
+  std::array<uint8_t, 6> dst_{};
+};
+
 enum class FlowMatchType {
   IPV4_UDP,
   FLEX_ITEM,
   ECPRI,
+  ETHERNET,
 };
 
 struct FlowMatch {
@@ -802,6 +810,7 @@ struct FlowMatch {
   in_addr_t ipv4_dst_ = INADDR_ANY;
   FlexItemMatch flex_item_match_;
   EcpriMatch ecpri_match_;
+  EthernetMatch ethernet_match_;
 };
 struct FlowConfig {
   std::string name_;

--- a/python/daqiri_common_pybind.cpp
+++ b/python/daqiri_common_pybind.cpp
@@ -587,7 +587,9 @@ void bind_enums(py::module_ &m) {
 
   py::enum_<FlowMatchType>(m, "FlowMatchType")
       .value("IPV4_UDP", FlowMatchType::IPV4_UDP)
-      .value("FLEX_ITEM", FlowMatchType::FLEX_ITEM);
+      .value("FLEX_ITEM", FlowMatchType::FLEX_ITEM)
+      .value("ECPRI", FlowMatchType::ECPRI)
+      .value("ETHERNET", FlowMatchType::ETHERNET);
 
   py::enum_<FlowOpType>(m, "FlowOpType")
       .value("ADD_RX", FlowOpType::ADD_RX)
@@ -782,6 +784,13 @@ void bind_config_types(py::module_ &m) {
       .def_readwrite("vlan", &FlowAction::vlan_)
       .def_readwrite("tunnel", &FlowAction::tunnel_);
 
+  py::class_<EthernetMatch>(m, "EthernetMatch")
+      .def(py::init<>())
+      .def_readwrite("match_src", &EthernetMatch::match_src_)
+      .def_readwrite("src", &EthernetMatch::src_)
+      .def_readwrite("match_dst", &EthernetMatch::match_dst_)
+      .def_readwrite("dst", &EthernetMatch::dst_);
+
   py::class_<FlexItemMatch>(m, "FlexItemMatch")
       .def(py::init<>())
       .def_readwrite("flex_item_id", &FlexItemMatch::flex_item_id_)
@@ -796,7 +805,8 @@ void bind_config_types(py::module_ &m) {
       .def_readwrite("ipv4_len", &FlowMatch::ipv4_len_)
       .def_readwrite("ipv4_src", &FlowMatch::ipv4_src_)
       .def_readwrite("ipv4_dst", &FlowMatch::ipv4_dst_)
-      .def_readwrite("flex_item_match", &FlowMatch::flex_item_match_);
+      .def_readwrite("flex_item_match", &FlowMatch::flex_item_match_)
+      .def_readwrite("ethernet_match", &FlowMatch::ethernet_match_);
 
   py::class_<FlowConfig>(m, "FlowConfig")
       .def(py::init<>())

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -936,59 +936,11 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_flow_config(
   const YAML::Node ecpri_node = match["ecpri"];
   const YAML::Node ethernet_node = match["ethernet"];
   if (ethernet_node) {
-    static constexpr const char* kIncompatibleEthernetFields[] = {
-        "ecpri", "udp_src", "udp_dst", "ipv4_len", "ipv4_src", "ipv4_dst",
-        "flex_item_id", "val", "mask"};
-    for (const char* field : kIncompatibleEthernetFields) {
-      if (match[field]) {
-        DAQIRI_LOG_ERROR(
-            "Flow '{}' field 'match.ethernet' cannot be combined with 'match.{}'",
-            flow.name_, field);
-        return false;
-      }
-    }
-  }
-
-  // eCPRI-over-Ethernet match: selected by the presence of a `match.ecpri` map.
-  // Matches the eCPRI EtherType (0xAEFE) plus an optional common-header message
-  // type and message identifier (pc_id/rtc_id). Detected before the UDP/IP and
-  // flex-item paths because it is a distinct, mutually exclusive match class.
-  if (ecpri_node && ecpri_node.IsMap()) {
-    flow.match_.type_ = daqiri::FlowMatchType::ECPRI;
-    if (ecpri_node["msg_type"]) {
-      flow.match_.ecpri_match_.msg_type_ =
-          static_cast<uint8_t>(ecpri_node["msg_type"].as<uint16_t>() & 0xff);
-      flow.match_.ecpri_match_.match_msg_type_ = true;
-    }
-    // pc_id (msg type 0/1) and rtc_id (msg type 2) name the same 16-bit field.
-    const YAML::Node id_node = ecpri_node["pc_id"] ? ecpri_node["pc_id"] : ecpri_node["rtc_id"];
-    if (id_node) {
-      flow.match_.ecpri_match_.id_ = id_node.as<uint16_t>();
-      flow.match_.ecpri_match_.match_id_ = true;
-    }
-    if (flow.match_.ecpri_match_.match_id_ && !flow.match_.ecpri_match_.match_msg_type_) {
-      DAQIRI_LOG_ERROR(
-          "eCPRI flow '{}' matches pc_id/rtc_id but no msg_type; matching the eCPRI message "
-          "identifier requires a msg_type",
-          flow.name_);
-      return false;
-    }
-    DAQIRI_LOG_INFO("Using eCPRI match: msg_type={} (matched={}), id={} (matched={})",
-                    flow.match_.ecpri_match_.msg_type_, flow.match_.ecpri_match_.match_msg_type_,
-                    flow.match_.ecpri_match_.id_, flow.match_.ecpri_match_.match_id_);
-    return true;
-  }
-
-  // Raw Ethernet address match: selected by the presence of a
-  // `match.ethernet` map. Keep it mutually exclusive with the other match
-  // classes, just like eCPRI and flex-item matching.
-  if (ethernet_node) {
     if (!ethernet_node.IsMap()) {
       DAQIRI_LOG_ERROR("Flow '{}' field 'match.ethernet' must be a map", flow.name_);
       return false;
     }
 
-    flow.match_.type_ = daqiri::FlowMatchType::ETHERNET;
     auto parse_address = [&](const char* key, bool& enabled,
                              std::array<uint8_t, 6>& address) {
       const YAML::Node address_node = ethernet_node[key];
@@ -1019,6 +971,35 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_flow_config(
                        flow.name_);
       return false;
     }
+  }
+
+  // eCPRI-over-Ethernet match: selected by the presence of a `match.ecpri` map.
+  // Matches the eCPRI EtherType (0xAEFE) plus an optional common-header message
+  // type and message identifier (pc_id/rtc_id). Detected before the UDP/IP and
+  // flex-item paths because it is a distinct, mutually exclusive match class.
+  if (ecpri_node && ecpri_node.IsMap()) {
+    flow.match_.type_ = daqiri::FlowMatchType::ECPRI;
+    if (ecpri_node["msg_type"]) {
+      flow.match_.ecpri_match_.msg_type_ =
+          static_cast<uint8_t>(ecpri_node["msg_type"].as<uint16_t>() & 0xff);
+      flow.match_.ecpri_match_.match_msg_type_ = true;
+    }
+    // pc_id (msg type 0/1) and rtc_id (msg type 2) name the same 16-bit field.
+    const YAML::Node id_node = ecpri_node["pc_id"] ? ecpri_node["pc_id"] : ecpri_node["rtc_id"];
+    if (id_node) {
+      flow.match_.ecpri_match_.id_ = id_node.as<uint16_t>();
+      flow.match_.ecpri_match_.match_id_ = true;
+    }
+    if (flow.match_.ecpri_match_.match_id_ && !flow.match_.ecpri_match_.match_msg_type_) {
+      DAQIRI_LOG_ERROR(
+          "eCPRI flow '{}' matches pc_id/rtc_id but no msg_type; matching the eCPRI message "
+          "identifier requires a msg_type",
+          flow.name_);
+      return false;
+    }
+    DAQIRI_LOG_INFO("Using eCPRI match: msg_type={} (matched={}), id={} (matched={})",
+                    flow.match_.ecpri_match_.msg_type_, flow.match_.ecpri_match_.match_msg_type_,
+                    flow.match_.ecpri_match_.id_, flow.match_.ecpri_match_.match_id_);
     return true;
   }
 
@@ -1081,6 +1062,10 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_flow_config(
                        flow.match_.flex_item_match_.flex_item_id_,
                        flow.match_.flex_item_match_.val_,
                        flow.match_.flex_item_match_.mask_);
+  } else if (ethernet_node && flow.match_.udp_src_ == 0 && flow.match_.udp_dst_ == 0 &&
+             flow.match_.ipv4_len_ == 0 && flow.match_.ipv4_src_ == INADDR_ANY &&
+             flow.match_.ipv4_dst_ == INADDR_ANY) {
+    flow.match_.type_ = daqiri::FlowMatchType::ETHERNET;
   }
 
   return true;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -964,6 +964,50 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_flow_config(
     return true;
   }
 
+  // Raw Ethernet address match: selected by the presence of a
+  // `match.ethernet` map. Keep it mutually exclusive with the other match
+  // classes, just like eCPRI and flex-item matching.
+  const YAML::Node ethernet_node = match["ethernet"];
+  if (ethernet_node) {
+    if (!ethernet_node.IsMap()) {
+      DAQIRI_LOG_ERROR("Flow '{}' field 'match.ethernet' must be a map", flow.name_);
+      return false;
+    }
+
+    flow.match_.type_ = daqiri::FlowMatchType::ETHERNET;
+    auto parse_address = [&](const char* key, bool& enabled,
+                             std::array<uint8_t, 6>& address) {
+      const YAML::Node address_node = ethernet_node[key];
+      if (!address_node) { return true; }
+
+      std::array<char, daqiri::kEthAddrLength> parsed = {};
+      const std::string text = address_node.as<std::string>();
+      if (daqiri::parse_eth_addr(&parsed, text) != daqiri::Status::SUCCESS) {
+        DAQIRI_LOG_ERROR("Flow '{}' has invalid match.ethernet.{} address '{}'",
+                         flow.name_, key, text);
+        return false;
+      }
+      std::transform(parsed.begin(), parsed.end(), address.begin(),
+                     [](char octet) { return static_cast<uint8_t>(octet); });
+      enabled = true;
+      return true;
+    };
+
+    if (!parse_address("src", flow.match_.ethernet_match_.match_src_,
+                       flow.match_.ethernet_match_.src_) ||
+        !parse_address("dst", flow.match_.ethernet_match_.match_dst_,
+                       flow.match_.ethernet_match_.dst_)) {
+      return false;
+    }
+    if (!flow.match_.ethernet_match_.match_src_ &&
+        !flow.match_.ethernet_match_.match_dst_) {
+      DAQIRI_LOG_ERROR("Flow '{}' Ethernet match requires 'src' and/or 'dst'",
+                       flow.name_);
+      return false;
+    }
+    return true;
+  }
+
   try {
     flow.match_.udp_src_ = match["udp_src"].as<uint16_t>();
   } catch (const std::exception& e) {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -933,11 +933,26 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_flow_config(
 
   const YAML::Node match = flow_item["match"];
 
+  const YAML::Node ecpri_node = match["ecpri"];
+  const YAML::Node ethernet_node = match["ethernet"];
+  if (ethernet_node) {
+    static constexpr const char* kIncompatibleEthernetFields[] = {
+        "ecpri", "udp_src", "udp_dst", "ipv4_len", "ipv4_src", "ipv4_dst",
+        "flex_item_id", "val", "mask"};
+    for (const char* field : kIncompatibleEthernetFields) {
+      if (match[field]) {
+        DAQIRI_LOG_ERROR(
+            "Flow '{}' field 'match.ethernet' cannot be combined with 'match.{}'",
+            flow.name_, field);
+        return false;
+      }
+    }
+  }
+
   // eCPRI-over-Ethernet match: selected by the presence of a `match.ecpri` map.
   // Matches the eCPRI EtherType (0xAEFE) plus an optional common-header message
   // type and message identifier (pc_id/rtc_id). Detected before the UDP/IP and
   // flex-item paths because it is a distinct, mutually exclusive match class.
-  const YAML::Node ecpri_node = match["ecpri"];
   if (ecpri_node && ecpri_node.IsMap()) {
     flow.match_.type_ = daqiri::FlowMatchType::ECPRI;
     if (ecpri_node["msg_type"]) {
@@ -967,7 +982,6 @@ bool YAML::convert<daqiri::NetworkConfig>::parse_flow_config(
   // Raw Ethernet address match: selected by the presence of a
   // `match.ethernet` map. Keep it mutually exclusive with the other match
   // classes, just like eCPRI and flex-item matching.
-  const YAML::Node ethernet_node = match["ethernet"];
   if (ethernet_node) {
     if (!ethernet_node.IsMap()) {
       DAQIRI_LOG_ERROR("Flow '{}' field 'match.ethernet' must be a map", flow.name_);

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -3243,6 +3243,10 @@ bool DpdkEngine::validate_dynamic_rx_flow(int port, const FlowRuleConfig& flow) 
     return false;
   }
   if (is_ipv4_udp_flow_match(flow.match_)) { return true; }
+  if (flow.match_.type_ == FlowMatchType::ETHERNET) {
+    return flow.match_.ethernet_match_.match_src_ ||
+           flow.match_.ethernet_match_.match_dst_;
+  }
   if (flow.match_.type_ == FlowMatchType::FLEX_ITEM) {
     if (find_flex_item_config(cfg_, port, flow.match_.flex_item_match_.flex_item_id_) == nullptr) {
       DAQIRI_LOG_ERROR("Dynamic RX flow references invalid flex item ID {}",
@@ -4919,6 +4923,8 @@ struct rte_flow* DpdkEngine::add_flow(int port,
   DpdkRxDestination destination(flow_queue_action(flow_actions), hash_inner ? 2 : 0);
   struct rte_flow_action_mark  mark = {.id = cfg.id_};
   struct rte_flow_error error {};
+  struct rte_flow_item_eth eth_spec {};
+  struct rte_flow_item_eth eth_mask {};
   struct rte_flow_item_udp udp_spec {};
   struct rte_flow_item_udp udp_mask {};
   struct rte_flow_item_ipv4 ip_spec {};
@@ -4963,7 +4969,25 @@ struct rte_flow* DpdkEngine::add_flow(int port,
       has_outer_transform = true;
     }
   }
-  pattern[pi++].type = RTE_FLOW_ITEM_TYPE_ETH;
+  pattern[pi].type = RTE_FLOW_ITEM_TYPE_ETH;
+  if (cfg.match_.type_ == FlowMatchType::ETHERNET) {
+    const auto& ethernet = cfg.match_.ethernet_match_;
+    if (ethernet.match_dst_) {
+      std::memcpy(eth_spec.hdr.dst_addr.addr_bytes, ethernet.dst_.data(),
+                  ethernet.dst_.size());
+      std::memset(eth_mask.hdr.dst_addr.addr_bytes, 0xff,
+                  ethernet.dst_.size());
+    }
+    if (ethernet.match_src_) {
+      std::memcpy(eth_spec.hdr.src_addr.addr_bytes, ethernet.src_.data(),
+                  ethernet.src_.size());
+      std::memset(eth_mask.hdr.src_addr.addr_bytes, 0xff,
+                  ethernet.src_.size());
+    }
+    pattern[pi].spec = &eth_spec;
+    pattern[pi].mask = &eth_mask;
+  }
+  ++pi;
   append_normal_match(pattern, &pi, cfg.match_, &ip_spec, &ip_mask, &udp_spec, &udp_mask, use_rss);
   pattern[pi].type = RTE_FLOW_ITEM_TYPE_END;
 

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -4937,20 +4937,21 @@ struct rte_flow* DpdkEngine::add_flow(int port,
   resource->action_storage.reserve(flow_actions.size() * 2 + 2);
 
   const bool use_rss = destination.queue_ids.size() > 1;
-  int required_pattern_items = 1 + normal_match_pattern_item_count(cfg.match_, use_rss) + 1;
+  const bool force_ipv4_udp = use_rss && cfg.match_.type_ != FlowMatchType::ETHERNET;
+  int required_pattern_items = 1 + normal_match_pattern_item_count(cfg.match_, force_ipv4_udp) + 1;
   int required_action_items = 2 + 1;
   for (const auto& flow_action : flow_actions) {
     required_pattern_items += transform_pattern_item_count(flow_action);
     required_action_items += transform_action_item_count(flow_action);
   }
   if (required_pattern_items > MAX_PATTERN_NUM) {
-    DAQIRI_LOG_CRITICAL("RX flow '{}' requires {} DPDK pattern entries, maximum is {}",
-                        cfg.name_, required_pattern_items, MAX_PATTERN_NUM);
+    DAQIRI_LOG_CRITICAL("RX flow '{}' requires {} DPDK pattern entries, maximum is {}", cfg.name_,
+                        required_pattern_items, MAX_PATTERN_NUM);
     return nullptr;
   }
   if (required_action_items > MAX_ACTION_NUM) {
-    DAQIRI_LOG_CRITICAL("RX flow '{}' requires {} DPDK action entries, maximum is {}",
-                        cfg.name_, required_action_items, MAX_ACTION_NUM);
+    DAQIRI_LOG_CRITICAL("RX flow '{}' requires {} DPDK action entries, maximum is {}", cfg.name_,
+                        required_action_items, MAX_ACTION_NUM);
     return nullptr;
   }
 
@@ -4973,27 +4974,26 @@ struct rte_flow* DpdkEngine::add_flow(int port,
   if (cfg.match_.type_ == FlowMatchType::ETHERNET) {
     const auto& ethernet = cfg.match_.ethernet_match_;
     if (ethernet.match_dst_) {
-      std::memcpy(eth_spec.hdr.dst_addr.addr_bytes, ethernet.dst_.data(),
-                  ethernet.dst_.size());
-      std::memset(eth_mask.hdr.dst_addr.addr_bytes, 0xff,
-                  ethernet.dst_.size());
+      std::memcpy(eth_spec.hdr.dst_addr.addr_bytes, ethernet.dst_.data(), ethernet.dst_.size());
+      std::memset(eth_mask.hdr.dst_addr.addr_bytes, 0xff, ethernet.dst_.size());
     }
     if (ethernet.match_src_) {
-      std::memcpy(eth_spec.hdr.src_addr.addr_bytes, ethernet.src_.data(),
-                  ethernet.src_.size());
-      std::memset(eth_mask.hdr.src_addr.addr_bytes, 0xff,
-                  ethernet.src_.size());
+      std::memcpy(eth_spec.hdr.src_addr.addr_bytes, ethernet.src_.data(), ethernet.src_.size());
+      std::memset(eth_mask.hdr.src_addr.addr_bytes, 0xff, ethernet.src_.size());
     }
     pattern[pi].spec = &eth_spec;
     pattern[pi].mask = &eth_mask;
   }
   ++pi;
-  append_normal_match(pattern, &pi, cfg.match_, &ip_spec, &ip_mask, &udp_spec, &udp_mask, use_rss);
+  append_normal_match(pattern, &pi, cfg.match_, &ip_spec, &ip_mask, &udp_spec, &udp_mask,
+                      force_ipv4_udp);
   pattern[pi].type = RTE_FLOW_ITEM_TYPE_END;
 
   int ai = 0;
   for (const auto& flow_action : flow_actions) {
-    if (flow_action.type_ == FlowType::QUEUE) { continue; }
+    if (flow_action.type_ == FlowType::QUEUE) {
+      continue;
+    }
     if (!append_transform_action(action, &ai, *resource, flow_action)) {
       DAQIRI_LOG_CRITICAL("Failed to build RX action '{}' for flow '{}'",
                           flow_type_to_string(flow_action.type_), cfg.name_);

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -2772,8 +2772,8 @@ void DpdkEngine::initialize() {
         struct rte_flow* created = nullptr;
         const FlowAction queue_action = flow_queue_action(flow_config_actions(flow));
         if (flow.match_.type_ == FlowMatchType::FLEX_ITEM) {
-          created = add_flex_item_flow(intf.port_id_, flow.match_.flex_item_match_, queue_action,
-                                       flow.id_);
+          created = add_flex_item_flow(intf.port_id_, flow.match_.flex_item_match_,
+                                       flow.match_.ethernet_match_, queue_action, flow.id_);
           if (created != nullptr) {
             has_flex_item_flows = true;
           }
@@ -3566,7 +3566,8 @@ Status DpdkEngine::create_dynamic_flow_legacy_locked(int port,
   struct rte_flow* rte_flow = nullptr;
   std::shared_ptr<DpdkFlowResource> resource;
   if (cfg.match_.type_ == FlowMatchType::FLEX_ITEM) {
-    rte_flow = add_flex_item_flow(port, cfg.match_.flex_item_match_, cfg.action_, cfg.id_, false);
+    rte_flow = add_flex_item_flow(port, cfg.match_.flex_item_match_,
+                                  cfg.match_.ethernet_match_, cfg.action_, cfg.id_, false);
   } else if (cfg.match_.type_ == FlowMatchType::ECPRI) {
     rte_flow = add_ecpri_flow(port, cfg, false);
   } else {
@@ -4403,6 +4404,7 @@ void DpdkEngine::destroy_owned_flows() {
 }
 
 struct rte_flow* DpdkEngine::add_flex_item_flow(int port, const FlexItemMatch& match_info,
+                                                const EthernetMatch& ethernet_match,
                                                 const FlowAction& queue_action, FlowId mark_id,
                                                 bool track) {
   /* Declaring structs being used. 8< */
@@ -4413,6 +4415,8 @@ struct rte_flow* DpdkEngine::add_flex_item_flow(int port, const FlexItemMatch& m
   DpdkRxDestination destination(queue_action);
   struct rte_flow_action_mark mark = {.id = mark_id};
   struct rte_flow_error error;
+  struct rte_flow_item_eth eth_spec;
+  struct rte_flow_item_eth eth_mask;
   struct rte_flow_item_udp udp_spec;
   struct rte_flow_item_udp udp_mask;
   struct rte_flow_item_ipv4  ip_spec;
@@ -4429,6 +4433,8 @@ struct rte_flow* DpdkEngine::add_flex_item_flow(int port, const FlexItemMatch& m
   memset(pattern, 0, sizeof(pattern));
   memset(action, 0, sizeof(action));
   memset(&attr, 0, sizeof(struct rte_flow_attr));
+  memset(&eth_spec, 0, sizeof(struct rte_flow_item_eth));
+  memset(&eth_mask, 0, sizeof(struct rte_flow_item_eth));
   memset(&ip_spec, 0, sizeof(struct rte_flow_item_ipv4));
   memset(&ip_mask, 0, sizeof(struct rte_flow_item_ipv4));
   memset(&udp_spec, 0, sizeof(struct rte_flow_item_udp));
@@ -4443,6 +4449,20 @@ struct rte_flow* DpdkEngine::add_flex_item_flow(int port, const FlexItemMatch& m
   action[action_index].type = RTE_FLOW_ACTION_TYPE_END;
 
   pattern[0].type = RTE_FLOW_ITEM_TYPE_ETH;
+  if (ethernet_match.match_dst_) {
+    std::memcpy(eth_spec.hdr.dst_addr.addr_bytes, ethernet_match.dst_.data(),
+                ethernet_match.dst_.size());
+    std::memset(eth_mask.hdr.dst_addr.addr_bytes, 0xff, ethernet_match.dst_.size());
+  }
+  if (ethernet_match.match_src_) {
+    std::memcpy(eth_spec.hdr.src_addr.addr_bytes, ethernet_match.src_.data(),
+                ethernet_match.src_.size());
+    std::memset(eth_mask.hdr.src_addr.addr_bytes, 0xff, ethernet_match.src_.size());
+  }
+  if (ethernet_match.match_src_ || ethernet_match.match_dst_) {
+    pattern[0].spec = &eth_spec;
+    pattern[0].mask = &eth_mask;
+  }
   pattern[1].type = RTE_FLOW_ITEM_TYPE_IPV4;
   //  pattern[3].type = RTE_FLOW_ITEM_TYPE_FLEX; // defined later
   pattern[4].type = RTE_FLOW_ITEM_TYPE_END;
@@ -4971,8 +4991,8 @@ struct rte_flow* DpdkEngine::add_flow(int port,
     }
   }
   pattern[pi].type = RTE_FLOW_ITEM_TYPE_ETH;
-  if (cfg.match_.type_ == FlowMatchType::ETHERNET) {
-    const auto& ethernet = cfg.match_.ethernet_match_;
+  const auto& ethernet = cfg.match_.ethernet_match_;
+  if (ethernet.match_src_ || ethernet.match_dst_) {
     if (ethernet.match_dst_) {
       std::memcpy(eth_spec.hdr.dst_addr.addr_bytes, ethernet.dst_.data(), ethernet.dst_.size());
       std::memset(eth_mask.hdr.dst_addr.addr_bytes, 0xff, ethernet.dst_.size());
@@ -5139,6 +5159,15 @@ struct rte_flow* DpdkEngine::add_ecpri_flow(int port, const FlowConfig& cfg, boo
   action[action_index].type = RTE_FLOW_ACTION_TYPE_END;
 
   // Pin the eCPRI EtherType so the rule only fires on eCPRI-over-Ethernet frames.
+  const auto& ethernet = cfg.match_.ethernet_match_;
+  if (ethernet.match_dst_) {
+    std::memcpy(eth_spec.hdr.dst_addr.addr_bytes, ethernet.dst_.data(), ethernet.dst_.size());
+    std::memset(eth_mask.hdr.dst_addr.addr_bytes, 0xff, ethernet.dst_.size());
+  }
+  if (ethernet.match_src_) {
+    std::memcpy(eth_spec.hdr.src_addr.addr_bytes, ethernet.src_.data(), ethernet.src_.size());
+    std::memset(eth_mask.hdr.src_addr.addr_bytes, 0xff, ethernet.src_.size());
+  }
   eth_spec.hdr.ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ECPRI);
   eth_mask.hdr.ether_type = 0xffff;
   pattern[0].type = RTE_FLOW_ITEM_TYPE_ETH;

--- a/src/engines/dpdk/daqiri_dpdk_engine.h
+++ b/src/engines/dpdk/daqiri_dpdk_engine.h
@@ -213,6 +213,7 @@ class DpdkEngine : public Engine {
                                        Direction direction);
 
   struct rte_flow* add_flex_item_flow(int port, const FlexItemMatch& match,
+                                      const EthernetMatch& ethernet_match,
                                       const FlowAction& queue_action, FlowId mark_id = 0,
                                       bool track = true);
 

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -109,6 +109,14 @@ constexpr uint64_t empw_burst_wqebbs(uint64_t packets) {
   }
   return total;
 }
+
+static std::pair<uint32_t, uint16_t> split_mac_address(const std::array<uint8_t, 6>& mac) {
+  const uint32_t high = (static_cast<uint32_t>(mac[0]) << 24) |
+                        (static_cast<uint32_t>(mac[1]) << 16) |
+                        (static_cast<uint32_t>(mac[2]) << 8) | static_cast<uint32_t>(mac[3]);
+  const uint16_t low = (static_cast<uint16_t>(mac[4]) << 8) | static_cast<uint16_t>(mac[5]);
+  return {high, low};
+}
 static_assert(empw_wqebbs(1) == 1);
 static_assert(empw_wqebbs(32) == 9);
 static_assert(empw_burst_wqebbs(33) == 10);
@@ -1514,20 +1522,11 @@ Status IbverbsEngine::install_flow_rule_locked(int port, PortSteering& st,
   bool any = false;
   auto* mask_buf = reinterpret_cast<uint8_t*>(mask.buf);
   auto* value_buf = reinterpret_cast<uint8_t*>(value.buf);
-  const auto split_mac = [](const std::array<uint8_t, 6>& mac) {
-    const uint32_t high = (static_cast<uint32_t>(mac[0]) << 24) |
-                          (static_cast<uint32_t>(mac[1]) << 16) |
-                          (static_cast<uint32_t>(mac[2]) << 8) |
-                          static_cast<uint32_t>(mac[3]);
-    const uint16_t low = (static_cast<uint16_t>(mac[4]) << 8) |
-                         static_cast<uint16_t>(mac[5]);
-    return std::pair<uint32_t, uint16_t>{high, low};
-  };
 
   if (mt.type_ == FlowMatchType::ETHERNET) {
     const auto& ethernet = mt.ethernet_match_;
     if (ethernet.match_dst_) {
-      const auto [high, low] = split_mac(ethernet.dst_);
+      const auto [high, low] = split_mac_address(ethernet.dst_);
       DEVX_SET(fte_match_set_lyr_2_4, mask_buf, dmac_47_16, 0xffffffff);
       DEVX_SET(fte_match_set_lyr_2_4, mask_buf, dmac_15_0, 0xffff);
       DEVX_SET(fte_match_set_lyr_2_4, value_buf, dmac_47_16, high);
@@ -1535,7 +1534,7 @@ Status IbverbsEngine::install_flow_rule_locked(int port, PortSteering& st,
       any = true;
     }
     if (ethernet.match_src_) {
-      const auto [high, low] = split_mac(ethernet.src_);
+      const auto [high, low] = split_mac_address(ethernet.src_);
       DEVX_SET(fte_match_set_lyr_2_4, mask_buf, smac_47_16, 0xffffffff);
       DEVX_SET(fte_match_set_lyr_2_4, mask_buf, smac_15_0, 0xffff);
       DEVX_SET(fte_match_set_lyr_2_4, value_buf, smac_47_16, high);
@@ -2073,20 +2072,11 @@ Status IbverbsEngine::install_port_flows() {
       bool any = false;
       auto* mk = reinterpret_cast<uint8_t*>(mask.buf);
       auto* vl = reinterpret_cast<uint8_t*>(val.buf);
-      const auto split_mac = [](const std::array<uint8_t, 6>& mac) {
-        const uint32_t high = (static_cast<uint32_t>(mac[0]) << 24) |
-                              (static_cast<uint32_t>(mac[1]) << 16) |
-                              (static_cast<uint32_t>(mac[2]) << 8) |
-                              static_cast<uint32_t>(mac[3]);
-        const uint16_t low = (static_cast<uint16_t>(mac[4]) << 8) |
-                             static_cast<uint16_t>(mac[5]);
-        return std::pair<uint32_t, uint16_t>{high, low};
-      };
 
       if (mt.type_ == FlowMatchType::ETHERNET) {
         const auto& ethernet = mt.ethernet_match_;
         if (ethernet.match_dst_) {
-          const auto [high, low] = split_mac(ethernet.dst_);
+          const auto [high, low] = split_mac_address(ethernet.dst_);
           DEVX_SET(fte_match_set_lyr_2_4, mk, dmac_47_16, 0xffffffff);
           DEVX_SET(fte_match_set_lyr_2_4, mk, dmac_15_0, 0xffff);
           DEVX_SET(fte_match_set_lyr_2_4, vl, dmac_47_16, high);
@@ -2094,7 +2084,7 @@ Status IbverbsEngine::install_port_flows() {
           any = true;
         }
         if (ethernet.match_src_) {
-          const auto [high, low] = split_mac(ethernet.src_);
+          const auto [high, low] = split_mac_address(ethernet.src_);
           DEVX_SET(fte_match_set_lyr_2_4, mk, smac_47_16, 0xffffffff);
           DEVX_SET(fte_match_set_lyr_2_4, mk, smac_15_0, 0xffff);
           DEVX_SET(fte_match_set_lyr_2_4, vl, smac_47_16, high);

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -1523,8 +1523,8 @@ Status IbverbsEngine::install_flow_rule_locked(int port, PortSteering& st,
   auto* mask_buf = reinterpret_cast<uint8_t*>(mask.buf);
   auto* value_buf = reinterpret_cast<uint8_t*>(value.buf);
 
-  if (mt.type_ == FlowMatchType::ETHERNET) {
-    const auto& ethernet = mt.ethernet_match_;
+  const auto& ethernet = mt.ethernet_match_;
+  if (ethernet.match_src_ || ethernet.match_dst_) {
     if (ethernet.match_dst_) {
       const auto [high, low] = split_mac_address(ethernet.dst_);
       DEVX_SET(fte_match_set_lyr_2_4, mask_buf, dmac_47_16, 0xffffffff);
@@ -2073,8 +2073,8 @@ Status IbverbsEngine::install_port_flows() {
       auto* mk = reinterpret_cast<uint8_t*>(mask.buf);
       auto* vl = reinterpret_cast<uint8_t*>(val.buf);
 
-      if (mt.type_ == FlowMatchType::ETHERNET) {
-        const auto& ethernet = mt.ethernet_match_;
+      const auto& ethernet = mt.ethernet_match_;
+      if (ethernet.match_src_ || ethernet.match_dst_) {
         if (ethernet.match_dst_) {
           const auto [high, low] = split_mac_address(ethernet.dst_);
           DEVX_SET(fte_match_set_lyr_2_4, mk, dmac_47_16, 0xffffffff);

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -1555,7 +1555,7 @@ Status IbverbsEngine::install_flow_rule_locked(int port, PortSteering& st,
     DEVX_SET(fte_match_set_lyr_2_4, value_buf, ip_protocol, MLX5_IP_PROTOCOL_UDP);
   };
 
-  if (rss_destination != nullptr) {
+  if (rss_destination != nullptr && mt.type_ != FlowMatchType::ETHERNET) {
     pin_ipv4_udp();
   }
 
@@ -2104,7 +2104,7 @@ Status IbverbsEngine::install_port_flows() {
         DEVX_SET(fte_match_set_lyr_2_4, mk, ip_protocol, 0xff);
         DEVX_SET(fte_match_set_lyr_2_4, vl, ip_protocol, MLX5_IP_PROTOCOL_UDP);
       };
-      if (rss_destination != nullptr) {
+      if (rss_destination != nullptr && mt.type_ != FlowMatchType::ETHERNET) {
         pin_ipv4_udp();
       }
       if (mt.udp_src_ > 0) {

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -1514,6 +1514,36 @@ Status IbverbsEngine::install_flow_rule_locked(int port, PortSteering& st,
   bool any = false;
   auto* mask_buf = reinterpret_cast<uint8_t*>(mask.buf);
   auto* value_buf = reinterpret_cast<uint8_t*>(value.buf);
+  const auto split_mac = [](const std::array<uint8_t, 6>& mac) {
+    const uint32_t high = (static_cast<uint32_t>(mac[0]) << 24) |
+                          (static_cast<uint32_t>(mac[1]) << 16) |
+                          (static_cast<uint32_t>(mac[2]) << 8) |
+                          static_cast<uint32_t>(mac[3]);
+    const uint16_t low = (static_cast<uint16_t>(mac[4]) << 8) |
+                         static_cast<uint16_t>(mac[5]);
+    return std::pair<uint32_t, uint16_t>{high, low};
+  };
+
+  if (mt.type_ == FlowMatchType::ETHERNET) {
+    const auto& ethernet = mt.ethernet_match_;
+    if (ethernet.match_dst_) {
+      const auto [high, low] = split_mac(ethernet.dst_);
+      DEVX_SET(fte_match_set_lyr_2_4, mask_buf, dmac_47_16, 0xffffffff);
+      DEVX_SET(fte_match_set_lyr_2_4, mask_buf, dmac_15_0, 0xffff);
+      DEVX_SET(fte_match_set_lyr_2_4, value_buf, dmac_47_16, high);
+      DEVX_SET(fte_match_set_lyr_2_4, value_buf, dmac_15_0, low);
+      any = true;
+    }
+    if (ethernet.match_src_) {
+      const auto [high, low] = split_mac(ethernet.src_);
+      DEVX_SET(fte_match_set_lyr_2_4, mask_buf, smac_47_16, 0xffffffff);
+      DEVX_SET(fte_match_set_lyr_2_4, mask_buf, smac_15_0, 0xffff);
+      DEVX_SET(fte_match_set_lyr_2_4, value_buf, smac_47_16, high);
+      DEVX_SET(fte_match_set_lyr_2_4, value_buf, smac_15_0, low);
+      any = true;
+    }
+    criteria |= MLX5_DR_MATCH_CRITERIA_OUTER;
+  }
 
   auto pin_ipv4 = [&]() {
     DEVX_SET(fte_match_set_lyr_2_4, mask_buf, ethertype, 0xffff);
@@ -2043,6 +2073,36 @@ Status IbverbsEngine::install_port_flows() {
       bool any = false;
       auto* mk = reinterpret_cast<uint8_t*>(mask.buf);
       auto* vl = reinterpret_cast<uint8_t*>(val.buf);
+      const auto split_mac = [](const std::array<uint8_t, 6>& mac) {
+        const uint32_t high = (static_cast<uint32_t>(mac[0]) << 24) |
+                              (static_cast<uint32_t>(mac[1]) << 16) |
+                              (static_cast<uint32_t>(mac[2]) << 8) |
+                              static_cast<uint32_t>(mac[3]);
+        const uint16_t low = (static_cast<uint16_t>(mac[4]) << 8) |
+                             static_cast<uint16_t>(mac[5]);
+        return std::pair<uint32_t, uint16_t>{high, low};
+      };
+
+      if (mt.type_ == FlowMatchType::ETHERNET) {
+        const auto& ethernet = mt.ethernet_match_;
+        if (ethernet.match_dst_) {
+          const auto [high, low] = split_mac(ethernet.dst_);
+          DEVX_SET(fte_match_set_lyr_2_4, mk, dmac_47_16, 0xffffffff);
+          DEVX_SET(fte_match_set_lyr_2_4, mk, dmac_15_0, 0xffff);
+          DEVX_SET(fte_match_set_lyr_2_4, vl, dmac_47_16, high);
+          DEVX_SET(fte_match_set_lyr_2_4, vl, dmac_15_0, low);
+          any = true;
+        }
+        if (ethernet.match_src_) {
+          const auto [high, low] = split_mac(ethernet.src_);
+          DEVX_SET(fte_match_set_lyr_2_4, mk, smac_47_16, 0xffffffff);
+          DEVX_SET(fte_match_set_lyr_2_4, mk, smac_15_0, 0xffff);
+          DEVX_SET(fte_match_set_lyr_2_4, vl, smac_47_16, high);
+          DEVX_SET(fte_match_set_lyr_2_4, vl, smac_15_0, low);
+          any = true;
+        }
+        crit |= MLX5_DR_MATCH_CRITERIA_OUTER;
+      }
       // L3/L4 matches imply IPv4 + UDP -- pin those so the match is unambiguous.
       auto pin_ipv4 = [&]() {
         DEVX_SET(fte_match_set_lyr_2_4, mk, ethertype, 0xffff);


### PR DESCRIPTION
## Summary

- add source and destination Ethernet-address match fields to DAQIRI flow configuration
- implement matching in the DPDK and raw-ibverbs engines
- expose the fields through YAML and Python configuration APIs
- allow Ethernet criteria to qualify IP/UDP, flex-item, or eCPRI matches so MAC addresses can be combined with protocol-specific steering
- keep multi-queue Ethernet RSS rules MAC-only instead of implicitly adding IPv4/UDP criteria

## Motivation

Raw Ethernet benchmarks need deterministic per-queue steering without depending on IP/UDP headers. Matching distinct destination MAC addresses provides the same steering model on both supported raw engines.

## Testing

- built both raw engines and all C++ examples in the CUDA 13.3 Aerial ARM container
- built the Python extension and verified YAML `match.ethernet` parses as `FlowMatchType.ETHERNET` with both MAC addresses intact
- compiled the combined Ethernet/IP/UDP, Ethernet/flex-item, and Ethernet/eCPRI rule-construction paths for both raw engines
- validated 22 distinct flows with zero loss in DPDK and raw-ibverbs hardware runs