### PR TITLE
Clarify timestamp format

### DIFF
--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -347,10 +347,11 @@ a template table.
 
 `rx.hardware_timestamps:` Enable per-packet hardware RX timestamps for Raw Ethernet
 (`stream_type: "raw"`).
-When enabled, DAQIRI requires `RTE_ETH_RX_OFFLOAD_TIMESTAMP` support from the NIC/PMD and
-initialization fails if DAQIRI cannot provide nanosecond timestamps for the selected PMD.
-Timestamps are returned by `get_packet_rx_timestamp()` in nanoseconds in the NIC timestamp
-clock domain, not wall-clock time.
+When enabled, DAQIRI requires hardware timestamp support from the NIC and driver.
+Timestamps returned by `get_packet_rx_timestamp()` are unsigned 64-bit PTP epoch
+nanoseconds in the same clock domain as a PTP-synchronized `CLOCK_REALTIME`.
+**PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
+configuration. Timestamp values are invalid if the clocks are not PTP-synchronized.
 
 - type: `boolean`
 - default: `false`
@@ -512,8 +513,12 @@ pre-encap (TX) frame.
 
 ### Accurate Send
 
-`tx.accurate_send:` Enable hardware-timed packet transmission using PTP timestamps. When
-enabled, use `set_packet_tx_time()` to schedule packets. Requires ConnectX-7 or later.
+`tx.accurate_send:` Enable hardware-timed packet transmission. When enabled, use
+`set_packet_tx_time()` to schedule packets. The supplied timestamp is always an unsigned
+64-bit PTP epoch-nanosecond value in the same clock domain as a PTP-synchronized
+`CLOCK_REALTIME`. **PTP synchronization is required.** DAQIRI does not validate the NIC or
+system clock configuration. Scheduled transmission is invalid if the clocks are not
+PTP-synchronized. Requires ConnectX-7 or later.
 
 - type: `boolean`
 - default: `false`

--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -111,18 +111,19 @@ for (int i = 0; i < daqiri::get_num_packets(burst); i++) {
     daqiri::FlowId flow = daqiri::get_packet_flow_id(burst, i);
     uint64_t rx_ts_ns = 0;
     if (daqiri::get_packet_rx_timestamp(burst, i, &rx_ts_ns) == daqiri::Status::SUCCESS) {
-        // rx_ts_ns is in the NIC timestamp clock domain.
+        // rx_ts_ns is a PTP epoch timestamp in nanoseconds.
     }
     // process packet...
 }
 ```
 
 RX hardware timestamps are available only when Raw Ethernet (`stream_type: "raw"`) is
-configured with `rx.hardware_timestamps: true` and the NIC supports
-`RTE_ETH_RX_OFFLOAD_TIMESTAMP`. DAQIRI converts the NIC timestamp counter to nanoseconds
-internally using the matching device clock when available, or the PMD's nanosecond
-timestamp format when the driver already supplies nanoseconds. DAQIRI does not expose NIC clock reads or
-convert timestamps to wall-clock time. For reordered aggregate bursts,
+configured with `rx.hardware_timestamps: true` and the NIC and driver support hardware
+timestamps. DAQIRI returns unsigned 64-bit PTP epoch nanoseconds in the same clock domain as
+a PTP-synchronized `CLOCK_REALTIME`. Device-clock ticks are not part of the public API.
+**PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
+configuration. Timestamp values are invalid if the clocks are not PTP-synchronized.
+For reordered aggregate bursts,
 `get_packet_rx_timestamp(burst, 0, &ts)` returns the timestamp of the first source
 packet accepted into the aggregate.
 
@@ -432,8 +433,13 @@ returns `NOT_READY`; zero- or multi-packet direct requests return `INVALID_PARAM
 For precise packet scheduling (requires ConnectX-7+):
 
 ```cpp
-daqiri::set_packet_tx_time(burst, idx, ptp_timestamp);
+daqiri::set_packet_tx_time(burst, idx, ptp_timestamp_ns);
 ```
+
+`ptp_timestamp_ns` is an unsigned 64-bit PTP epoch-nanosecond value in the same clock
+domain as a PTP-synchronized `CLOCK_REALTIME`. Device-clock ticks are not accepted.
+**PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
+configuration. Scheduled transmission is invalid if the clocks are not PTP-synchronized.
 
 ## Writing Bursts to Storage
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -353,6 +353,24 @@ rejects a rule. The YAML options are documented in
 ![Flow steering](images/packet_diagrams/flow_steering/flow-steering.webp)
 </div>
 
+## Raw ibverbs hardware timestamp domain
+
+The raw ibverbs engine uses PTP epoch nanoseconds in the
+`CLOCK_REALTIME` domain for both timed transmission and receive timestamps.
+For accurate transmission, DAQIRI selects the mlx5 wall-clock completion-queue
+domain and converts the supplied linear nanosecond value to the UTC encoding
+required by the WAIT-on-time WQE. For receive timestamping, DAQIRI requests
+mlx5 real-time CQEs and converts their `seconds << 32 | nanoseconds` encoding
+back to linear epoch nanoseconds before returning it from
+`get_packet_rx_timestamp()`.
+
+**PTP synchronization is required.** The host and NIC clocks must be
+synchronized, for example with `ptp4l` and `phc2sys`. DAQIRI does not validate
+that synchronization is working. Without it, receive timestamps and scheduled
+transmit times are invalid and may behave unpredictably. Applications pass a
+`CLOCK_REALTIME` nanosecond value directly to `set_packet_tx_time()`; no
+engine-specific conversion is required.
+
 ## Memory Regions
 
 A **memory region** is a named pool of buffers where packet data lives.

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -246,8 +246,9 @@ Status poll_flow_op(FlowOpResult *result);
  *
  * Retrieves the 64-bit receive timestamp for a packet when the DPDK engine
  * was configured with rx.hardware_timestamps enabled and the NIC provided a
- * timestamp for this packet. The value is converted to nanoseconds in the NIC
- * timestamp clock domain; it is not converted to wall-clock or PTP time.
+ * timestamp for this packet as PTP epoch nanoseconds. DAQIRI assumes that the
+ * NIC clock and CLOCK_REALTIME are PTP-synchronized and does not validate
+ * synchronization. The result is invalid without working PTP.
  *
  * @param burst Burst structure containing packets
  * @param idx Index of packet
@@ -405,7 +406,10 @@ Status set_all_packet_lengths(BurstParams *burst,
 /**
  * @brief Set packet TX time
  *
- * Sets the transmit time (in PTP time) to transmit the packet. Every packet
+ * Sets the transmit time, as PTP epoch nanoseconds, to transmit the packet.
+ * DAQIRI assumes that the NIC clock and CLOCK_REALTIME are PTP-synchronized
+ * and does not validate synchronization. Scheduled transmission is invalid
+ * without working PTP. Every packet
  * transmitted after this one in the same queue will be transmitted no earlier
  * than the time listed in the function call. This feature is only available on
  * ConnectX-7 or BlueField 3 and higher cards.

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -1879,81 +1879,6 @@ bool DpdkEngine::setup_rx_timestamp_dynfield() {
   return true;
 }
 
-bool DpdkEngine::calibrate_rx_timestamp_clock(uint16_t port_id) {
-  uint64_t start_clock = 0;
-  int ret = rte_eth_read_clock(port_id, &start_clock);
-  if (ret < 0) {
-    rte_eth_dev_info dev_info{};
-    const int info_ret = rte_eth_dev_info_get(port_id, &dev_info);
-    const std::string driver_name =
-        (info_ret == 0 && dev_info.driver_name != nullptr) ? dev_info.driver_name : "";
-    if (ret == -ENOTSUP && driver_name.find("mlx5") != std::string::npos) {
-      rx_timestamp_conversions_[port_id].valid = true;
-      rx_timestamp_conversions_[port_id].ticks_per_second = 1000000000ULL;
-      DAQIRI_LOG_WARN(
-          "rte_eth_read_clock() is not supported on mlx5 port {}; treating PMD-provided "
-          "RX hardware timestamps as nanoseconds",
-          port_id);
-      return true;
-    }
-
-    DAQIRI_LOG_CRITICAL(
-        "RX hardware timestamps require rte_eth_read_clock() for nanosecond conversion, "
-        "but port {} returned err={} ({})",
-        port_id,
-        ret,
-        rte_strerror(-ret));
-    return false;
-  }
-
-  const auto start_time = std::chrono::steady_clock::now();
-  rte_delay_us_block(100000);
-
-  uint64_t end_clock = 0;
-  ret = rte_eth_read_clock(port_id, &end_clock);
-  if (ret < 0) {
-    DAQIRI_LOG_CRITICAL(
-        "RX hardware timestamp clock calibration failed on port {}: err={} ({})",
-        port_id,
-        ret,
-        rte_strerror(-ret));
-    return false;
-  }
-
-  const auto elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                              std::chrono::steady_clock::now() - start_time)
-                              .count();
-  if (elapsed_ns <= 0 || end_clock <= start_clock) {
-    DAQIRI_LOG_CRITICAL(
-        "RX hardware timestamp clock calibration produced an invalid sample on port {} "
-        "(start={}, end={}, elapsed_ns={})",
-        port_id,
-        start_clock,
-        end_clock,
-        elapsed_ns);
-    return false;
-  }
-
-  const uint64_t delta_ticks = end_clock - start_clock;
-  const auto ticks_per_second =
-      (static_cast<unsigned __int128>(delta_ticks) * 1000000000ULL +
-       static_cast<uint64_t>(elapsed_ns / 2)) /
-      static_cast<uint64_t>(elapsed_ns);
-  if (ticks_per_second == 0 ||
-      ticks_per_second > static_cast<unsigned __int128>(std::numeric_limits<uint64_t>::max())) {
-    DAQIRI_LOG_CRITICAL(
-        "RX hardware timestamp clock calibration produced an invalid frequency on port {}",
-        port_id);
-    return false;
-  }
-
-  rx_timestamp_conversions_[port_id].valid = true;
-  rx_timestamp_conversions_[port_id].ticks_per_second = static_cast<uint64_t>(ticks_per_second);
-  DAQIRI_LOG_INFO("Calibrated RX timestamp clock for port {} at {} ticks/second",
-                  port_id,
-                  rx_timestamp_conversions_[port_id].ticks_per_second);
-  return true;
-}
 
 bool DpdkEngine::setup_tx_timestamp_dynfield() {
   static bool done = false;
@@ -2759,7 +2684,20 @@ void DpdkEngine::initialize() {
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[4],
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[5]);
 
-      if (rx.hardware_timestamps_ && !calibrate_rx_timestamp_clock(intf.port_id_)) { return; }
+      if (rx.hardware_timestamps_ || tx.accurate_send_) {
+        DAQIRI_LOG_WARN(
+            "PTP REQUIRED on port {}: DAQIRI assumes the NIC clock and CLOCK_REALTIME are "
+            "PTP-synchronized and does not validate synchronization. RX timestamps and "
+            "scheduled transmit times are invalid without working PTP.",
+            intf.port_id_);
+      }
+      if (rx.hardware_timestamps_) {
+        rx_timestamp_conversions_[intf.port_id_].valid = true;
+        rx_timestamp_conversions_[intf.port_id_].ticks_per_second = 1000000000ULL;
+        DAQIRI_LOG_INFO(
+            "Using driver-provided RX hardware timestamps as PTP epoch nanoseconds on port {}",
+            intf.port_id_);
+      }
 
       // Standard (group 3), flex-item (group 1) and eCPRI (group 2) flows use
       // separate DPDK flow groups with conflicting group-0 jump rules;

--- a/src/engines/dpdk/daqiri_dpdk_engine.h
+++ b/src/engines/dpdk/daqiri_dpdk_engine.h
@@ -187,7 +187,6 @@ class DpdkEngine : public Engine {
   static void flush_port_queue_impl(int port, int queue);
   bool setup_rx_timestamp_dynfield();
   bool setup_tx_timestamp_dynfield();
-  bool calibrate_rx_timestamp_clock(uint16_t port_id);
   // Current NIC clock for `port` in nanoseconds, for packet-pacing scheduling.
   // Uses rte_eth_read_clock + the calibrated ticks/sec where supported; falls
   // back to CLOCK_MONOTONIC (the NIC PTP clock free-runs from driver load unless


### PR DESCRIPTION
## Summary

- define the public DPDK hardware timestamp contract as linear PTP epoch nanoseconds
- pass accurate-send timestamps directly to the DPDK timestamp dynamic field
- return driver-provided RX timestamps directly as nanoseconds
- perform no runtime clock-synchronization validation or calibration
- prominently document that timestamped I/O requires the NIC clock and `CLOCK_REALTIME` to be PTP-synchronized
- document the PTP clock-domain contract for DPDK and raw ibverbs

## Motivation

DAQIRI documents PTP-synchronized operation, but the DPDK engine left the unit and epoch of its public timestamp values implicit. A fixed linear-nanosecond contract lets callers compare received timestamps with `CLOCK_REALTIME` and schedule packets from that same clock without an engine-specific conversion.

## Compatibility

This is an intentional contract clarification: hardware timestamps are PTP epoch nanoseconds. DAQIRI does not validate that the NIC clock and `CLOCK_REALTIME` are synchronized. Timestamped operation without working PTP is unsupported and may produce incorrect scheduling and latency values. This requirement is documented prominently; DAQIRI performs no runtime validation or warning.

## Testing

- built both raw engines and all C++ examples in the CUDA 13.3 Aerial ARM container
- built the downstream dual-engine integration on ARM and x86
- validated full 22-queue bidirectional DPDK traffic with zero loss and zero timestamp failures on BlueField-3 integrated ConnectX-7 hardware