### PR TITLE
Preserve CUDA memory-region context ownership

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -210,6 +210,13 @@ can have one segment or multiple segments:
   region. The memory regions can be of any kind (CPU or GPU) in any
   order. A common use case is *header-data split* (HDS) below.
 
+Each GPU device-memory region records the CUDA context that owns its
+allocation. When regions target different GPUs, DAQIRI temporarily activates
+each target GPU's primary context and restores the context that was current on
+entry. This preserves application-created and MPS contexts while allowing
+independent regions to use different GPUs. Cleanup similarly activates each
+region's recorded context only for the duration of the corresponding free.
+
 ### Header-Data Split (HDS)
 
 **Header-data split** is the canonical multi-segment configuration:

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -191,12 +191,27 @@ void Engine::free_memory_regions() noexcept {
         }
         cudaFreeHost(region.ptr_);
         break;
-      case AllocRegion::Deallocator::CUDA_DEVICE:
-        if (region.affinity_ >= 0) {
-          cudaSetDevice(region.affinity_);
+      case AllocRegion::Deallocator::CUDA_DEVICE: {
+        CUcontext previous = nullptr;
+        const CUresult get_result = cuCtxGetCurrent(&previous);
+        if (get_result != CUDA_SUCCESS) {
+          DAQIRI_LOG_ERROR("Could not query current CUDA context while freeing MR {}", name);
+          break;
         }
-        cuMemFree(reinterpret_cast<CUdeviceptr>(region.ptr_));
+        if (region.cuda_context_ != nullptr && previous != region.cuda_context_) {
+          if (cuCtxSetCurrent(region.cuda_context_) != CUDA_SUCCESS) {
+            DAQIRI_LOG_ERROR("Could not activate owning CUDA context while freeing MR {}", name);
+            break;
+          }
+        }
+        if (cuMemFree(reinterpret_cast<CUdeviceptr>(region.ptr_)) != CUDA_SUCCESS) {
+          DAQIRI_LOG_ERROR("Could not free CUDA device memory for MR {}", name);
+        }
+        if (previous != region.cuda_context_ && cuCtxSetCurrent(previous) != CUDA_SUCCESS) {
+          DAQIRI_LOG_ERROR("Could not restore CUDA context after freeing MR {}", name);
+        }
         break;
+      }
       case AllocRegion::Deallocator::MUNMAP:
         munmap(region.ptr_, region.size_);
         break;
@@ -447,9 +462,41 @@ Status Engine::allocate_memory_regions() {
           unsigned int flag = 1;
           const auto align = align_ceil(mr.second.ttl_size_, GPU_PAGE_SIZE);
           CUdeviceptr cuptr;
+          CUcontext current = nullptr;
 
-          cudaSetDevice(mr.second.affinity_);
-          cudaFree(0);  // Create primary context if it doesn't exist
+          const auto current_res = cuCtxGetCurrent(&current);
+          if (current_res != CUDA_SUCCESS) {
+            DAQIRI_LOG_CRITICAL("Could not query the current CUDA context");
+            return Status::NULL_PTR;
+          }
+          if (current == nullptr) {
+            const auto set_res = cudaSetDevice(mr.second.affinity_);
+            if (set_res != cudaSuccess) {
+              DAQIRI_LOG_CRITICAL("Could not select CUDA device {}: {}", mr.second.affinity_,
+                                  cudaGetErrorString(set_res));
+              return Status::NULL_PTR;
+            }
+            const auto init_res = cudaFree(0);  // Create the primary context if needed.
+            if (init_res != cudaSuccess || cuCtxGetCurrent(&current) != CUDA_SUCCESS ||
+                current == nullptr) {
+              DAQIRI_LOG_CRITICAL("Could not initialize the CUDA primary context for device {}",
+                                  mr.second.affinity_);
+              return Status::NULL_PTR;
+            }
+          } else {
+            CUdevice current_device;
+            if (cuCtxGetDevice(&current_device) != CUDA_SUCCESS) {
+              DAQIRI_LOG_CRITICAL("Could not query the device for the current CUDA context");
+              return Status::NULL_PTR;
+            }
+            if (current_device != mr.second.affinity_) {
+              DAQIRI_LOG_CRITICAL(
+                  "Current CUDA context belongs to device {}, but MR {} requests device {}",
+                  current_device, mr.second.name_, mr.second.affinity_);
+              return Status::INVALID_PARAMETER;
+            }
+          }
+          ar.cuda_context_ = current;
           const auto alloc_res = cuMemAlloc(&cuptr, align);
 
           if (alloc_res != CUDA_SUCCESS) {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -469,7 +469,16 @@ Status Engine::allocate_memory_regions() {
             DAQIRI_LOG_CRITICAL("Could not query the current CUDA context");
             return Status::NULL_PTR;
           }
-          if (current == nullptr) {
+          bool select_device = current == nullptr;
+          if (current != nullptr) {
+            CUdevice current_device;
+            if (cuCtxGetDevice(&current_device) != CUDA_SUCCESS) {
+              DAQIRI_LOG_CRITICAL("Could not query the device for the current CUDA context");
+              return Status::NULL_PTR;
+            }
+            select_device = current_device != mr.second.affinity_;
+          }
+          if (select_device) {
             const auto set_res = cudaSetDevice(mr.second.affinity_);
             if (set_res != cudaSuccess) {
               DAQIRI_LOG_CRITICAL("Could not select CUDA device {}: {}", mr.second.affinity_,
@@ -483,18 +492,6 @@ Status Engine::allocate_memory_regions() {
                                   mr.second.affinity_);
               return Status::NULL_PTR;
             }
-          } else {
-            CUdevice current_device;
-            if (cuCtxGetDevice(&current_device) != CUDA_SUCCESS) {
-              DAQIRI_LOG_CRITICAL("Could not query the device for the current CUDA context");
-              return Status::NULL_PTR;
-            }
-            if (current_device != mr.second.affinity_) {
-              DAQIRI_LOG_CRITICAL(
-                  "Current CUDA context belongs to device {}, but MR {} requests device {}",
-                  current_device, mr.second.name_, mr.second.affinity_);
-              return Status::INVALID_PARAMETER;
-            }
           }
           ar.cuda_context_ = current;
           const auto alloc_res = cuMemAlloc(&cuptr, align);
@@ -502,8 +499,8 @@ Status Engine::allocate_memory_regions() {
           if (alloc_res != CUDA_SUCCESS) {
             const char* err_str = nullptr;
             cuGetErrorString(alloc_res, &err_str);
-            DAQIRI_LOG_CRITICAL(
-                "Could not allocate {:.2f}MB of GPU memory. Error: {}", align / 1e6, err_str);
+            DAQIRI_LOG_CRITICAL("Could not allocate {:.2f}MB of GPU memory. Error: {}", align / 1e6,
+                                err_str);
             return Status::NULL_PTR;
           }
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -469,6 +469,18 @@ Status Engine::allocate_memory_regions() {
             DAQIRI_LOG_CRITICAL("Could not query the current CUDA context");
             return Status::NULL_PTR;
           }
+          const CUcontext previous = current;
+          const auto restore_previous = [&]() {
+            CUcontext active = nullptr;
+            if (cuCtxGetCurrent(&active) != CUDA_SUCCESS ||
+                (active != previous && cuCtxSetCurrent(previous) != CUDA_SUCCESS)) {
+              DAQIRI_LOG_CRITICAL(
+                  "Could not restore the CUDA context after allocating memory region {}",
+                  mr.first);
+              return false;
+            }
+            return true;
+          };
           bool select_device = current == nullptr;
           if (current != nullptr) {
             CUdevice current_device;
@@ -483,6 +495,7 @@ Status Engine::allocate_memory_regions() {
             if (set_res != cudaSuccess) {
               DAQIRI_LOG_CRITICAL("Could not select CUDA device {}: {}", mr.second.affinity_,
                                   cudaGetErrorString(set_res));
+              restore_previous();
               return Status::NULL_PTR;
             }
             const auto init_res = cudaFree(0);  // Create the primary context if needed.
@@ -490,6 +503,7 @@ Status Engine::allocate_memory_regions() {
                 current == nullptr) {
               DAQIRI_LOG_CRITICAL("Could not initialize the CUDA primary context for device {}",
                                   mr.second.affinity_);
+              restore_previous();
               return Status::NULL_PTR;
             }
           }
@@ -501,6 +515,7 @@ Status Engine::allocate_memory_regions() {
             cuGetErrorString(alloc_res, &err_str);
             DAQIRI_LOG_CRITICAL("Could not allocate {:.2f}MB of GPU memory. Error: {}", align / 1e6,
                                 err_str);
+            restore_previous();
             return Status::NULL_PTR;
           }
 
@@ -511,9 +526,18 @@ Status Engine::allocate_memory_regions() {
           if (attr_res != CUDA_SUCCESS) {
             DAQIRI_LOG_CRITICAL("Could not set pointer attributes");
             cuMemFree(cuptr);
+            restore_previous();
             return Status::NULL_PTR;
           }
           ar.deallocator_ = AllocRegion::Deallocator::CUDA_DEVICE;
+          if (!restore_previous()) {
+            if (cuCtxSetCurrent(ar.cuda_context_) == CUDA_SUCCESS) {
+              cuMemFree(cuptr);
+            }
+            ar.cuda_context_ = nullptr;
+            ar.deallocator_ = AllocRegion::Deallocator::NONE;
+            return Status::NULL_PTR;
+          }
           break;
         }
         default:

--- a/src/engine.h
+++ b/src/engine.h
@@ -19,6 +19,7 @@
 
 #include "src/daqiri_ring.h"
 #include <daqiri/types.h>
+#include <cuda.h>
 #include <optional>
 
 // Forward declarations of the DPDK types used only by the DPDK engine. Keeping
@@ -46,6 +47,7 @@ struct AllocRegion {
   void* ptr_ = nullptr;
   size_t size_ = 0;
   int affinity_ = -1;
+  CUcontext cuda_context_ = nullptr;
   Deallocator deallocator_ = Deallocator::NONE;
 };
 

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -523,6 +523,23 @@ Status IbverbsEngine::register_mr(struct ibv_pd* pd, const std::string& mr_name,
   if (mr.kind_ == MemoryKind::DEVICE) {
     // GPUDirect: export the CUDA allocation as a dma-buf fd and register it so
     // the NIC DMAs packets straight to/from GPU memory.
+    CUcontext previous = nullptr;
+    const auto current_res = cuCtxGetCurrent(&previous);
+    if (current_res != CUDA_SUCCESS) {
+      DAQIRI_LOG_CRITICAL("Could not query the current CUDA context for MR {}", mr_name);
+      return Status::INTERNAL_ERROR;
+    }
+    const CUcontext owning = ar_[mr_name].cuda_context_;
+    if (owning == nullptr) {
+      DAQIRI_LOG_CRITICAL("Device MR {} has no owning CUDA context", mr_name);
+      return Status::INTERNAL_ERROR;
+    }
+    const bool switched = previous != owning;
+    if (switched && cuCtxSetCurrent(owning) != CUDA_SUCCESS) {
+      DAQIRI_LOG_CRITICAL("Could not activate the owning CUDA context for MR {}", mr_name);
+      return Status::INTERNAL_ERROR;
+    }
+
     const size_t page = sysconf(_SC_PAGESIZE);
     const auto va = reinterpret_cast<uintptr_t>(base);
     const uintptr_t aligned = va & ~(static_cast<uintptr_t>(page) - 1);
@@ -532,14 +549,22 @@ Status IbverbsEngine::register_mr(struct ibv_pd* pd, const std::string& mr_name,
     CUresult cres =
         cuMemGetHandleForAddressRange(&dmabuf_fd, static_cast<CUdeviceptr>(aligned), aligned_size,
                                       CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+    const CUresult restore_res = switched ? cuCtxSetCurrent(previous) : CUDA_SUCCESS;
+    if (restore_res != CUDA_SUCCESS) {
+      if (dmabuf_fd >= 0) {
+        close(dmabuf_fd);
+      }
+      DAQIRI_LOG_CRITICAL("Could not restore the CUDA context after exporting MR {}", mr_name);
+      return Status::INTERNAL_ERROR;
+    }
+
     if (cres != CUDA_SUCCESS) {
       const char* es = nullptr;
       cuGetErrorString(cres, &es);
       DAQIRI_LOG_CRITICAL(
           "cuMemGetHandleForAddressRange failed for MR {}: {}. CUDA DMA-BUF export requires "
           "Linux kernel 5.12 or newer and the NVIDIA open kernel driver",
-          mr_name,
-          es ? es : "?");
+          mr_name, es ? es : "?");
       return Status::GENERIC_FAILURE;
     }
     struct ibv_mr* gmr = ibv_reg_dmabuf_mr(pd, offset, mr.ttl_size_, va, dmabuf_fd, access);

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -523,7 +523,6 @@ Status IbverbsEngine::register_mr(struct ibv_pd* pd, const std::string& mr_name,
   if (mr.kind_ == MemoryKind::DEVICE) {
     // GPUDirect: export the CUDA allocation as a dma-buf fd and register it so
     // the NIC DMAs packets straight to/from GPU memory.
-    cudaSetDevice(mr.affinity_);
     const size_t page = sysconf(_SC_PAGESIZE);
     const auto va = reinterpret_cast<uintptr_t>(base);
     const uintptr_t aligned = va & ~(static_cast<uintptr_t>(page) - 1);


### PR DESCRIPTION
## Summary

- record the CUDA context that owns each device memory region
- allocate in an existing application/MPS context instead of unconditionally switching to the primary context
- reactivate the owning context while freeing device memory, then restore the caller's context
- avoid changing CUDA contexts while raw ibverbs registers GPUDirect memory

## Motivation

Calling `cudaSetDevice()` during allocation, registration, or destruction can replace an application's current MPS subcontext with the device primary context. CUDA device pointers are context-owned, so later GPUDirect registration or cleanup can run against the wrong context and fail or corrupt resource lifetime.

## Compatibility

Callers without a current CUDA context retain primary-context initialization. For every configured region, DAQIRI selects the owning GPU context only for allocation and restores the context that was current on entry, including when consecutive regions target different GPUs.

## Testing

- built `daqiri_common` and `daqiri_dpdk` standalone in the CUDA 13.3 Aerial x86 container
- exercised the combined change in validated 22-queue DPDK and raw-ibverbs hardware runs using separate MPS contexts