### PR TITLE
Drain TX before releasing engine resources

### DIFF
--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -364,11 +364,12 @@ void free_segment_packets_and_burst(BurstParams *burst, int seg);
 void free_all_packets_and_burst_rx(BurstParams *burst);
 
 /**
- * @brief Free all packets and a TX burst
+ * @brief Free an unsent TX burst and all of its packet buffers
  *
- * Frees all packets in a burst of packets and the associated burst buffer
+ * Releases all packet storage and TX burst metadata without submitting any
+ * packets for transmission.
  *
- * @param burst Burst structure containing packet lists
+ * @param burst Unsubmitted TX burst containing packet lists
  */
 void free_all_packets_and_burst_tx(BurstParams *burst);
 
@@ -772,6 +773,18 @@ void set_num_packets(BurstParams *burst, int64_t num);
  *    NOT_READY: direct queue called concurrently or from a non-owner thread; burst not consumed
  */
 Status send_tx_burst(BurstParams *burst);
+
+/**
+ * @brief Wait until all previously submitted TX packets have completed.
+ *
+ * This is a synchronization boundary for applications that must keep a peer
+ * receiver alive until asynchronous TX workers and the NIC have drained.
+ *
+ * @param timeout_ms Maximum time to wait in milliseconds.
+ * @return SUCCESS when idle, NOT_READY on timeout, or NOT_SUPPORTED when the
+ *         selected engine does not implement completion draining.
+ */
+Status wait_for_tx_idle(uint32_t timeout_ms);
 
 /**
  * @brief Get a RX burst

--- a/python/daqiri_common_pybind.cpp
+++ b/python/daqiri_common_pybind.cpp
@@ -1216,6 +1216,7 @@ PYBIND11_MODULE(_daqiri, m) {
   m.def("free_all_packets_and_burst_rx", &free_all_packets_and_burst_rx,
         "burst"_a);
   m.def("free_all_packets_and_burst_tx", &free_all_packets_and_burst_tx,
+        "Release an unsubmitted TX burst and all of its packet buffers.",
         "burst"_a);
   m.def("free_segment_packets_and_burst", &free_segment_packets_and_burst,
         "burst"_a, "seg"_a);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -560,6 +560,11 @@ Status send_tx_burst(BurstParams* burst) {
   return g_daqiri_engine->send_tx_burst(burst);
 }
 
+Status wait_for_tx_idle(uint32_t timeout_ms) {
+  ASSERT_DAQIRI_ENGINE_INITIALIZED();
+  return g_daqiri_engine->wait_for_tx_idle(timeout_ms);
+}
+
 Status get_rx_burst(BurstParams** burst, int port, int q) {
   ASSERT_DAQIRI_ENGINE_INITIALIZED();
   return g_daqiri_engine->get_rx_burst(burst, port, q);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -935,6 +935,11 @@ Status Engine::get_tx_packet_burst_checked(BurstParams* burst) {
   return get_tx_packet_burst(burst);
 }
 
+Status Engine::wait_for_tx_idle(uint32_t timeout_ms) {
+  (void)timeout_ms;
+  return Status::NOT_SUPPORTED;
+}
+
 Status Engine::get_rx_burst(BurstParams** burst, int port_id) {
   // Check if the port_id is valid
   if (port_id < 0 || port_id >= static_cast<int>(cfg_.ifs_.size())) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -110,6 +110,7 @@ class Engine {
   virtual void free_tx_metadata(BurstParams* burst) = 0;
   virtual Status get_tx_metadata_buffer(BurstParams** burst) = 0;
   virtual Status send_tx_burst(BurstParams* burst) = 0;
+  virtual Status wait_for_tx_idle(uint32_t timeout_ms);
   virtual Status get_mac_addr(int port, char* mac) = 0;
   virtual Status drop_all_traffic(int port);
   virtual Status allow_all_traffic(int port);

--- a/src/engine.h
+++ b/src/engine.h
@@ -108,7 +108,6 @@ class Engine {
   virtual Status get_reorder_burst_info(BurstParams* burst, ReorderBurstInfo* info);
   virtual void free_rx_metadata(BurstParams* burst) = 0;
   virtual void free_tx_metadata(BurstParams* burst) = 0;
-  virtual Status get_tx_metadata_buffer(BurstParams** burst) = 0;
   virtual Status send_tx_burst(BurstParams* burst) = 0;
   virtual Status wait_for_tx_idle(uint32_t timeout_ms);
   virtual Status get_mac_addr(int port, char* mac) = 0;

--- a/src/engine_dpdk.cpp
+++ b/src/engine_dpdk.cpp
@@ -192,7 +192,10 @@ void Engine::cleanup_eal() {
   // rte_eal_cleanup() releases EAL state and (on DPDK >= 22.07) unlinks the
   // per-segment hugepage files this process created. Older DPDK leaves them
   // behind, so we also do a best-effort unlink targeted at our --file-prefix.
-  rte_eal_cleanup();
+  const int cleanup_ret = rte_eal_cleanup();
+  if (cleanup_ret != 0) {
+    DAQIRI_LOG_WARN("DPDK EAL cleanup returned {}", cleanup_ret);
+  }
 
   // The patched rte_extmem_register_dmabuf() stores caller-provided fd values
   // for deferred driver DMA mapping; it does not duplicate them. They must

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -6905,18 +6905,152 @@ void DpdkEngine::free_tx_metadata(BurstParams* burst) {
   rte_mempool_put(tx_metadata, burst);
 }
 
-Status DpdkEngine::get_tx_metadata_buffer(BurstParams** burst) {
-  if (rte_mempool_get(tx_metadata, reinterpret_cast<void**>(burst)) != 0) {
-    DAQIRI_LOG_CRITICAL("Running out of TX meta buffers due to high rates. Either increase "\
-      "your number of metadata buffers (current: {}) with `tx_meta_buffers` (will "\
-      "increase memory usage) or increase your `batch_size` for port {} queue {} (will increase "\
-      "latency)", cfg_.tx_meta_buffers_, (*burst)->hdr.hdr.port_id, (*burst)->hdr.hdr.q_id);
+Status DpdkEngine::get_tx_metadata_buffer(BurstParams **burst) {
+  if (burst == nullptr) {
+    return Status::NULL_PTR;
+  }
+  *burst = nullptr;
+  if (rte_mempool_get(tx_metadata, reinterpret_cast<void **>(burst)) != 0) {
+    // No metadata object exists on this path, so port and queue fields are not
+    // available to report.
+    DAQIRI_LOG_CRITICAL(
+        "Running out of TX meta buffers due to high rates. Either increase "
+        "your number of metadata buffers (current: {}) with `tx_meta_buffers` "
+        "(will increase memory usage) or increase your `batch_size` (will "
+        "increase latency)",
+        cfg_.tx_meta_buffers_);
     return Status::NO_FREE_BURST_BUFFERS;
   }
   // Clear the recycled running L2 byte total (see create_tx_burst_params).
   (*burst)->hdr.hdr.nbytes = 0;
 
   return Status::SUCCESS;
+}
+
+Status DpdkEngine::wait_for_tx_idle(uint32_t timeout_ms) {
+  const auto pool_is_full = [](const rte_mempool *pool) {
+    return pool == nullptr || rte_mempool_full(pool) != 0;
+  };
+  const auto idle = [&]() {
+    // A full metadata pool proves that no worker holds an active burst. Empty
+    // handoff rings alone are insufficient because a worker may have already
+    // dequeued a burst and be waiting for its scheduled transmit time.
+    if (!pool_is_full(tx_metadata)) {
+      return false;
+    }
+    for (const auto &[key, ring] : tx_rings) {
+      (void)key;
+      if (ring != nullptr && !rte_ring_empty(ring)) {
+        return false;
+      }
+    }
+    for (const auto &[key, pool] : tx_burst_buffers) {
+      (void)key;
+      if (!pool_is_full(pool)) {
+        return false;
+      }
+    }
+    // PMDs commonly reclaim TX descriptors from a later tx_burst call. At
+    // end-of-run there is no later burst, so explicitly reap the final
+    // completion batch before testing the packet pools. This is safe here
+    // because full metadata/pointer pools and empty rings prove the workers
+    // no longer hold or submit bursts.
+    for (const auto &intf : cfg_.ifs_) {
+      for (const auto &queue : intf.tx_.queues_) {
+        (void)rte_eth_tx_done_cleanup(intf.port_id_, queue.common_.id_, 0);
+      }
+    }
+
+    // Descriptor status is the authoritative completion signal when the PMD
+    // implements it. Offset (ring size - 1) is the descriptor immediately
+    // preceding the tail (the next-send position). TX completion is ordered
+    // within a queue, so DONE there proves all prior submissions completed.
+    bool saw_descriptor_status = false;
+    bool all_descriptors_done = true;
+    for (const auto &intf : cfg_.ifs_) {
+      for (const auto &queue : intf.tx_.queues_) {
+        const int status = rte_eth_tx_descriptor_status(
+            intf.port_id_, queue.common_.id_, default_num_tx_desc - 1);
+        if (status == RTE_ETH_TX_DESC_FULL) {
+          return false;
+        }
+        if (status == RTE_ETH_TX_DESC_DONE) {
+          saw_descriptor_status = true;
+        } else {
+          all_descriptors_done = false;
+        }
+      }
+    }
+    if (saw_descriptor_status && all_descriptors_done) {
+      return true;
+    }
+
+    // TX mbufs are returned to these pools only after the PMD has reclaimed
+    // the corresponding descriptors. Requiring every pool to be full makes
+    // this a NIC-completion boundary, not merely a software-ring boundary.
+    for (const auto &[key, queue] : tx_dpdk_q_map_) {
+      (void)key;
+      if (queue == nullptr) {
+        continue;
+      }
+      for (const auto *pool : queue->pools) {
+        if (!pool_is_full(pool)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  };
+
+  const auto deadline = steady_clock::now() + milliseconds(timeout_ms);
+  do {
+    if (idle()) {
+      return Status::SUCCESS;
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(50));
+  } while (steady_clock::now() < deadline);
+
+  if (tx_metadata != nullptr && !rte_mempool_full(tx_metadata)) {
+    DAQIRI_LOG_WARN("TX idle timeout: metadata pool available={}/{}",
+                    rte_mempool_avail_count(tx_metadata), tx_metadata->size);
+  }
+  for (const auto &intf : cfg_.ifs_) {
+    for (const auto &queue : intf.tx_.queues_) {
+      DAQIRI_LOG_WARN(
+          "TX idle timeout: descriptor status port={} queue={} tail={} next={} previous={}",
+          intf.port_id_, queue.common_.id_,
+          rte_eth_tx_descriptor_status(intf.port_id_, queue.common_.id_, 0),
+          rte_eth_tx_descriptor_status(intf.port_id_, queue.common_.id_, 1),
+          rte_eth_tx_descriptor_status(intf.port_id_, queue.common_.id_,
+                                       default_num_tx_desc - 1));
+    }
+  }
+  for (const auto &[key, ring] : tx_rings) {
+    if (ring != nullptr && !rte_ring_empty(ring)) {
+      DAQIRI_LOG_WARN("TX idle timeout: ring key={} count={}", key,
+                      rte_ring_count(ring));
+    }
+  }
+  for (const auto &[key, pool] : tx_burst_buffers) {
+    if (pool != nullptr && !rte_mempool_full(pool)) {
+      DAQIRI_LOG_WARN("TX idle timeout: burst pool key={} available={}/{}", key,
+                      rte_mempool_avail_count(pool), pool->size);
+    }
+  }
+  for (const auto &[key, queue] : tx_dpdk_q_map_) {
+    if (queue == nullptr) {
+      continue;
+    }
+    for (std::size_t segment = 0; segment < queue->pools.size(); ++segment) {
+      const auto *pool = queue->pools[segment];
+      if (pool != nullptr && !rte_mempool_full(pool)) {
+        DAQIRI_LOG_WARN(
+            "TX idle timeout: packet pool key={} segment={} available={}/{}",
+            key, segment, rte_mempool_avail_count(pool), pool->size);
+      }
+    }
+  }
+  return Status::NOT_READY;
 }
 
 Status DpdkEngine::send_tx_burst(BurstParams* burst) {
@@ -6953,6 +7087,11 @@ void DpdkEngine::shutdown() {
     cleanup_reorder_state();
     force_quit.store(true);
 
+    // Remote workers may still be reading queue rings or submitting packets.
+    // Wait for every launched lcore before releasing any worker-visible object
+    // or asking the PMD to stop its queues.
+    rte_eal_mp_wait_lcore();
+
     stats_.Shutdown();
     stats_thread_.join();
 
@@ -6970,7 +7109,29 @@ void DpdkEngine::shutdown() {
 
     cleanup_dynamic_flows();
     destroy_all_flow_rules();
+
+    // rte_eal_cleanup() cannot close a started Ethernet device. Leaving the
+    // device started also leaves PMD/EAL resources referring to registered
+    // external GPU memory, which makes a later CUDA-context teardown unsafe.
+    for (const auto &intf : cfg_.ifs_) {
+      const int stop_ret = rte_eth_dev_stop(intf.port_id_);
+      if (stop_ret != 0) {
+        DAQIRI_LOG_WARN("Failed to stop DPDK port {}: {}", intf.port_id_,
+                        stop_ret);
+      }
+      const int close_ret = rte_eth_dev_close(intf.port_id_);
+      if (close_ret != 0) {
+        DAQIRI_LOG_WARN("Failed to close DPDK port {}: {}", intf.port_id_,
+                        close_ret);
+      }
+    }
+
     cleanup_eal();
+
+    // External-memory registration is gone, so CUDA device allocations can
+    // now be released while the caller-owned CUDA context is still current.
+    // Do not defer this to Engine::~Engine(), which may run after that context.
+    free_memory_regions();
     initialized_ = false;
   }
 }

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -6905,28 +6905,6 @@ void DpdkEngine::free_tx_metadata(BurstParams* burst) {
   rte_mempool_put(tx_metadata, burst);
 }
 
-Status DpdkEngine::get_tx_metadata_buffer(BurstParams **burst) {
-  if (burst == nullptr) {
-    return Status::NULL_PTR;
-  }
-  *burst = nullptr;
-  if (rte_mempool_get(tx_metadata, reinterpret_cast<void **>(burst)) != 0) {
-    // No metadata object exists on this path, so port and queue fields are not
-    // available to report.
-    DAQIRI_LOG_CRITICAL(
-        "Running out of TX meta buffers due to high rates. Either increase "
-        "your number of metadata buffers (current: {}) with `tx_meta_buffers` "
-        "(will increase memory usage) or increase your `batch_size` (will "
-        "increase latency)",
-        cfg_.tx_meta_buffers_);
-    return Status::NO_FREE_BURST_BUFFERS;
-  }
-  // Clear the recycled running L2 byte total (see create_tx_burst_params).
-  (*burst)->hdr.hdr.nbytes = 0;
-
-  return Status::SUCCESS;
-}
-
 Status DpdkEngine::wait_for_tx_idle(uint32_t timeout_ms) {
   const auto pool_is_full = [](const rte_mempool *pool) {
     return pool == nullptr || rte_mempool_full(pool) != 0;

--- a/src/engines/dpdk/daqiri_dpdk_engine.h
+++ b/src/engines/dpdk/daqiri_dpdk_engine.h
@@ -155,7 +155,6 @@ class DpdkEngine : public Engine {
   Status set_packet_tx_time(BurstParams* burst, int idx, uint64_t timestamp);
   void free_rx_metadata(BurstParams* burst) override;
   void free_tx_metadata(BurstParams* burst) override;
-  Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
   Status wait_for_tx_idle(uint32_t timeout_ms) override;
   Status get_mac_addr(int port, char* mac) override;

--- a/src/engines/dpdk/daqiri_dpdk_engine.h
+++ b/src/engines/dpdk/daqiri_dpdk_engine.h
@@ -157,6 +157,7 @@ class DpdkEngine : public Engine {
   void free_tx_metadata(BurstParams* burst) override;
   Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
+  Status wait_for_tx_idle(uint32_t timeout_ms) override;
   Status get_mac_addr(int port, char* mac) override;
   Status drop_all_traffic(int port) override;
   Status allow_all_traffic(int port) override;

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -4784,11 +4784,6 @@ BurstParams* IbverbsEngine::create_tx_burst_params() {
   return burst;
 }
 
-Status IbverbsEngine::get_tx_metadata_buffer(BurstParams** burst) {
-  *burst = create_tx_burst_params();
-  return *burst ? Status::SUCCESS : Status::NO_FREE_BURST_BUFFERS;
-}
-
 bool IbverbsEngine::is_tx_burst_available(BurstParams* burst) {
   if (burst == nullptr) {
     return false;

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -4106,6 +4106,27 @@ bool IbverbsEngine::validate_config() const {
   return true;
 }
 
+Status IbverbsEngine::wait_for_tx_idle(uint32_t timeout_ms) {
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+  for (;;) {
+    bool idle = true;
+    for (const auto& q : tx_queues_) {
+      if (q->completed_tail.load(std::memory_order_acquire) != q->alloc_head) {
+        idle = false;
+        break;
+      }
+    }
+    if (idle) {
+      return Status::SUCCESS;
+    }
+    if (std::chrono::steady_clock::now() >= deadline) {
+      return Status::NOT_READY;
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(50));
+  }
+}
+
 void IbverbsEngine::print_stats() {
   for (auto& q : rx_queues_) {
     DAQIRI_LOG_INFO(

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.h
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.h
@@ -382,6 +382,7 @@ class IbverbsEngine : public Engine {
   Status get_rx_burst(BurstParams** burst, int port, int q) override;
   Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
+  Status wait_for_tx_idle(uint32_t timeout_ms) override;
   BurstParams* create_tx_burst_params() override;
   uint64_t get_burst_tot_byte(BurstParams* burst) override;
 

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.h
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.h
@@ -380,7 +380,6 @@ class IbverbsEngine : public Engine {
 
   // Burst retrieval / submission
   Status get_rx_burst(BurstParams** burst, int port, int q) override;
-  Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
   Status wait_for_tx_idle(uint32_t timeout_ms) override;
   BurstParams* create_tx_burst_params() override;

--- a/src/engines/rdma/daqiri_rdma_engine.cpp
+++ b/src/engines/rdma/daqiri_rdma_engine.cpp
@@ -1825,13 +1825,6 @@ void RdmaEngine::free_tx_metadata(BurstParams* burst) {
   tx_meta->put(burst);
 }
 
-Status RdmaEngine::get_tx_metadata_buffer(BurstParams** burst) {
-  if (burst == nullptr) { return Status::INVALID_PARAMETER; }
-  *burst = create_tx_burst_params();
-  if (*burst == nullptr) { return Status::NO_FREE_BURST_BUFFERS; }
-  return Status::SUCCESS;
-}
-
 void RdmaEngine::print_stats() {
   DAQIRI_LOG_INFO("daqiri RDMA engine stats");
 

--- a/src/engines/rdma/daqiri_rdma_engine.h
+++ b/src/engines/rdma/daqiri_rdma_engine.h
@@ -151,7 +151,6 @@ class RdmaEngine : public Engine {
   };
   void free_rx_metadata(BurstParams* burst) override;
   void free_tx_metadata(BurstParams* burst) override;
-  Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
   uint64_t get_burst_tot_byte(BurstParams* burst) override;
   BurstParams* create_tx_burst_params() override;

--- a/src/engines/socket/daqiri_socket_engine.cpp
+++ b/src/engines/socket/daqiri_socket_engine.cpp
@@ -677,21 +677,6 @@ void SocketEngine::free_tx_metadata(BurstParams* burst) {
   delete burst;
 }
 
-Status SocketEngine::get_tx_metadata_buffer(BurstParams** burst) {
-  if (is_roce_protocol()) {
-#if DAQIRI_ENGINE_RDMA
-    return roce_engine_ != nullptr ? roce_engine_->get_tx_metadata_buffer(burst)
-                                : roce_not_initialized("get_tx_metadata_buffer");
-#else
-    return roce_not_initialized("get_tx_metadata_buffer");
-#endif
-  }
-
-  if (burst == nullptr) { return Status::INVALID_PARAMETER; }
-  *burst = create_tx_burst_params();
-  return Status::SUCCESS;
-}
-
 SocketEngine::EndpointState* SocketEngine::endpoint_for_port(uint16_t port) {
   for (auto& ep : endpoints_) {
     if (ep != nullptr && ep->port == port) { return ep.get(); }

--- a/src/engines/socket/daqiri_socket_engine.h
+++ b/src/engines/socket/daqiri_socket_engine.h
@@ -81,7 +81,6 @@ class SocketEngine : public Engine {
 
   void free_rx_metadata(BurstParams* burst) override;
   void free_tx_metadata(BurstParams* burst) override;
-  Status get_tx_metadata_buffer(BurstParams** burst) override;
   Status send_tx_burst(BurstParams* burst) override;
   Status get_mac_addr(int port, char* mac) override;
 


### PR DESCRIPTION
## Summary

- add an Engine API for waiting until submitted TX work is idle
- implement drain checks for DPDK and raw ibverbs
- stop and join workers before destroying flows, ports, rings, EAL state, and registered memory
- propagate TX-idle timeout failures instead of silently continuing teardown

## Motivation

The previous shutdown sequence could free rings, ports, or memory registrations while TX workers or the NIC still referenced them. This caused intermittent shutdown crashes and resource-lifetime violations.

## Testing

- built `daqiri_common`, `daqiri_dpdk`, and `daqiri_ibverbs` in the CUDA 13.3 Aerial x86 container
- validated clean startup/shutdown after full 22-queue DPDK and raw-ibverbs runs