### PR TITLE
Add selectable raw-ibverbs TX clock domains

### DIFF
--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -499,6 +499,20 @@ enabled, use `set_packet_tx_time()` to schedule packets. Requires ConnectX-7 or 
 - type: `boolean`
 - default: `false`
 
+`tx.hardware_timestamp_format:` Select the clock domain accepted by
+`set_packet_tx_time()` when accurate send is enabled. The default
+`device_clock_ticks` preserves the historical raw-ibverbs contract and creates
+the TX CQ with device-clock completion timestamps. Selecting `nanoseconds`
+creates the raw-ibverbs TX CQ with wall-clock timestamps, so scheduled values
+are Unix-epoch nanoseconds compatible with `CLOCK_REALTIME` on a synchronized
+PTP/phc2sys system.
+
+- type: `string`
+- options: `device_clock_ticks`, `nanoseconds`
+- default: `device_clock_ticks`
+
+DAQIRI does not convert supplied scheduled values between these clock domains.
+
 ## Complete Example (Raw Ethernet, Header-Data Split)
 
 ```yaml

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -378,6 +378,12 @@ For precise packet scheduling (requires ConnectX-7+):
 daqiri.set_packet_tx_time(burst, idx, ptp_timestamp_ns)
 ```
 
+Set `TxConfig.hardware_timestamp_format` to
+`TxTimestampFormat.NANOSECONDS` when the value is a Unix-epoch nanosecond
+timestamp on a PTP/phc2sys-synchronized system. The default
+`DEVICE_CLOCK_TICKS` preserves the historical NIC device-clock contract.
+DAQIRI does not convert scheduled values between these clock domains.
+
 ## Writing Bursts to Storage
 
 Received bursts can be written to local storage as raw packet data or as a
@@ -704,7 +710,7 @@ names that mostly omit the trailing underscore from the C++ member name (e.g.
 | `CommonConfig` | Global stream type, engine selection, direction, loopback, and core settings. (Transport protocol is derived from the endpoint URI scheme.) |
 | `InterfaceConfig` | Per-interface address, socket/RoCE/RDMA, RX, and TX configuration. |
 | `RxConfig` | RX flow isolation, timestamps, queues, flows, flex items, and reorder configs. |
-| `TxConfig` | TX accurate-send flag, queues, and flows. |
+| `TxConfig` | TX accurate-send flag, `hardware_timestamp_format`, queues, and flows. |
 | `CommonQueueConfig` | Shared queue fields: name, ID, batch size, split boundary, CPU core, memory regions, and offloads. |
 | `RxQueueConfig` | RX queue wrapper with common queue fields, timeout, and `QueuePollMode`. |
 | `TxQueueConfig` | TX queue wrapper with common queue fields and `QueuePollMode`. |

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -1337,6 +1337,31 @@ template <> struct YAML::convert<daqiri::NetworkConfig> {
             } catch (const std::exception& e) { rx_cfg.flow_isolation_ = false; }
 
             try {
+              rx_cfg.hardware_timestamps_ = rx["hardware_timestamps"].as<bool>();
+            } catch (const std::exception& e) { rx_cfg.hardware_timestamps_ = false; }
+
+            try {
+              const auto format =
+                  rx["hardware_timestamp_format"].as<std::string>();
+              if (format == "device_clock_ticks") {
+                rx_cfg.hardware_timestamp_format_ =
+                    daqiri::RxTimestampFormat::DEVICE_CLOCK_TICKS;
+              } else if (format == "nanoseconds") {
+                rx_cfg.hardware_timestamp_format_ =
+                    daqiri::RxTimestampFormat::NANOSECONDS;
+              } else {
+                DAQIRI_LOG_ERROR(
+                    "Invalid rx.hardware_timestamp_format '{}' for interface '{}': "
+                    "expected 'device_clock_ticks' or 'nanoseconds'",
+                    format, ifcfg.name_);
+                return false;
+              }
+            } catch (const std::exception& e) {
+              rx_cfg.hardware_timestamp_format_ =
+                  daqiri::RxTimestampFormat::DEVICE_CLOCK_TICKS;
+            }
+
+            try {
               rx_cfg.dynamic_flow_capacity_ =
                   rx["dynamic_flow_capacity"].as<uint32_t>();
             } catch (const std::exception& e) {
@@ -1421,6 +1446,27 @@ template <> struct YAML::convert<daqiri::NetworkConfig> {
               tx_cfg.accurate_send_ = tx["accurate_send"].as<bool>();
             } catch (const std::exception &e) {
               tx_cfg.accurate_send_ = false;
+            }
+
+            try {
+              const std::string format =
+                  tx["hardware_timestamp_format"].as<std::string>();
+              if (format == "device_clock_ticks") {
+                tx_cfg.hardware_timestamp_format_ =
+                    daqiri::TxTimestampFormat::DEVICE_CLOCK_TICKS;
+              } else if (format == "nanoseconds") {
+                tx_cfg.hardware_timestamp_format_ =
+                    daqiri::TxTimestampFormat::NANOSECONDS;
+              } else {
+                DAQIRI_LOG_ERROR(
+                    "Invalid tx.hardware_timestamp_format '{}' for interface '{}': "
+                    "expected 'device_clock_ticks' or 'nanoseconds'",
+                    format, ifcfg.name_);
+                return false;
+              }
+            } catch (const std::exception& e) {
+              tx_cfg.hardware_timestamp_format_ =
+                  daqiri::TxTimestampFormat::DEVICE_CLOCK_TICKS;
             }
 
             for (const auto &q_item : tx["queues"]) {

--- a/include/daqiri/types.h
+++ b/include/daqiri/types.h
@@ -1141,9 +1141,20 @@ struct ReorderConfig {
   ReorderDataTypesConfig data_types_;
 };
 
+enum class RxTimestampFormat {
+  DEVICE_CLOCK_TICKS,
+  NANOSECONDS,
+};
+
+enum class TxTimestampFormat {
+  DEVICE_CLOCK_TICKS,
+  NANOSECONDS,
+};
+
 struct RxConfig {
   bool flow_isolation_ = false;
   bool hardware_timestamps_ = false;
+  RxTimestampFormat hardware_timestamp_format_ = RxTimestampFormat::DEVICE_CLOCK_TICKS;
   uint32_t dynamic_flow_capacity_ = DEFAULT_DYNAMIC_FLOW_CAPACITY;
   std::vector<RxQueueConfig> queues_;
   std::vector<FlowConfig> flows_;
@@ -1153,6 +1164,7 @@ struct RxConfig {
 
 struct TxConfig {
   bool accurate_send_ = false;
+  TxTimestampFormat hardware_timestamp_format_ = TxTimestampFormat::DEVICE_CLOCK_TICKS;
   std::vector<TxQueueConfig> queues_;
   std::vector<FlowConfig> flows_;
 };

--- a/python/daqiri_common_pybind.cpp
+++ b/python/daqiri_common_pybind.cpp
@@ -902,10 +902,20 @@ void bind_config_types(py::module_ &m) {
                      &ReorderConfig::seq_packets_per_batch_)
       .def_readwrite("data_types", &ReorderConfig::data_types_);
 
+  py::enum_<RxTimestampFormat>(m, "RxTimestampFormat")
+      .value("DEVICE_CLOCK_TICKS", RxTimestampFormat::DEVICE_CLOCK_TICKS)
+      .value("NANOSECONDS", RxTimestampFormat::NANOSECONDS);
+
+  py::enum_<TxTimestampFormat>(m, "TxTimestampFormat")
+      .value("DEVICE_CLOCK_TICKS", TxTimestampFormat::DEVICE_CLOCK_TICKS)
+      .value("NANOSECONDS", TxTimestampFormat::NANOSECONDS);
+
   py::class_<RxConfig>(m, "RxConfig")
       .def(py::init<>())
       .def_readwrite("flow_isolation", &RxConfig::flow_isolation_)
       .def_readwrite("hardware_timestamps", &RxConfig::hardware_timestamps_)
+      .def_readwrite("hardware_timestamp_format",
+                     &RxConfig::hardware_timestamp_format_)
       .def_readwrite("dynamic_flow_capacity",
                      &RxConfig::dynamic_flow_capacity_)
       .def_readwrite("queues", &RxConfig::queues_)
@@ -916,6 +926,8 @@ void bind_config_types(py::module_ &m) {
   py::class_<TxConfig>(m, "TxConfig")
       .def(py::init<>())
       .def_readwrite("accurate_send", &TxConfig::accurate_send_)
+      .def_readwrite("hardware_timestamp_format",
+                     &TxConfig::hardware_timestamp_format_)
       .def_readwrite("queues", &TxConfig::queues_)
       .def_readwrite("flows", &TxConfig::flows_);
 

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -2759,7 +2759,17 @@ void DpdkEngine::initialize() {
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[4],
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[5]);
 
-      if (rx.hardware_timestamps_ && !calibrate_rx_timestamp_clock(intf.port_id_)) { return; }
+      if (rx.hardware_timestamps_) {
+        if (rx.hardware_timestamp_format_ == RxTimestampFormat::NANOSECONDS) {
+          rx_timestamp_conversions_[intf.port_id_].valid = true;
+          rx_timestamp_conversions_[intf.port_id_].ticks_per_second = 1000000000ULL;
+          DAQIRI_LOG_INFO(
+              "Using PMD-provided RX hardware timestamps as nanoseconds on port {}",
+              intf.port_id_);
+        } else if (!calibrate_rx_timestamp_clock(intf.port_id_)) {
+          return;
+        }
+      }
 
       // Standard (group 3), flex-item (group 1) and eCPRI (group 2) flows use
       // separate DPDK flow groups with conflicting group-0 jump rules;

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -4227,9 +4227,24 @@ Status IbverbsEngine::create_tx_raw_qp(IbvTxQueue& q) {
         device_attr.max_qp_wr / 2);
   }
 
-  q.cq = ibv_create_cq(q.ctx, static_cast<int>(q.num_slots) + 1, nullptr, nullptr, 0);
+  if (q.accurate_send) {
+    // mlx5 derives a raw-packet QP/SQ timestamp domain from its send CQ. Keep
+    // the historical device-clock mode as the default, and select wall-clock
+    // explicitly for callers that pass epoch nanoseconds.
+    struct ibv_cq_init_attr_ex cq_attr {};
+    cq_attr.cqe = static_cast<uint32_t>(q.num_slots) + 1;
+    cq_attr.wc_flags =
+        q.timestamp_format == TxTimestampFormat::NANOSECONDS
+            ? IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK
+            : IBV_WC_EX_WITH_COMPLETION_TIMESTAMP;
+    struct ibv_cq_ex* cq_ex = ibv_create_cq_ex(q.ctx, &cq_attr);
+    q.cq = cq_ex == nullptr ? nullptr : ibv_cq_ex_to_cq(cq_ex);
+  } else {
+    q.cq = ibv_create_cq(q.ctx, static_cast<int>(q.num_slots) + 1, nullptr, nullptr, 0);
+  }
   if (q.cq == nullptr) {
-    DAQIRI_LOG_CRITICAL("TX ibv_create_cq failed: {}", strerror(errno));
+    DAQIRI_LOG_CRITICAL("TX ibv_create_cq failed (accurate_send={}): {}",
+                        q.accurate_send, strerror(errno));
     return Status::GENERIC_FAILURE;
   }
   struct ibv_qp_init_attr attr {};
@@ -4310,9 +4325,10 @@ Status IbverbsEngine::create_tx_raw_qp(IbvTxQueue& q) {
   q.slots_posted = 0;
   q.wqe_slot_cum.assign(q.dv_qp.sq.wqe_cnt, 0);
   q.wqe_wqebb_cum.assign(q.dv_qp.sq.wqe_cnt, 0);
-  DAQIRI_LOG_INFO("TX SQ mapped q{}: sqn {}, wqe_cnt {}, stride {}, bf.size {}, cqe_cnt {}",
-                  q.queue_id, q.sqn, q.dv_qp.sq.wqe_cnt, q.dv_qp.sq.stride, q.dv_qp.bf.size,
-                  q.dv_txcq.cqe_cnt);
+  DAQIRI_LOG_INFO("TX SQ mapped q{}: sqn {}, wqe_cnt {}, stride {}, bf.reg {}, bf.size {}, "
+                  "uar_mmap_offset {:#x}, cqe_cnt {}",
+                  q.queue_id, q.sqn, q.dv_qp.sq.wqe_cnt, q.dv_qp.sq.stride, q.dv_qp.bf.reg,
+                  q.dv_qp.bf.size, q.dv_qp.uar_mmap_offset, q.dv_txcq.cqe_cnt);
   return Status::SUCCESS;
 }
 
@@ -4321,6 +4337,8 @@ Status IbverbsEngine::setup_tx_queue(IbvTxQueue& q, const InterfaceConfig& intf,
   q.port_id = intf.port_id_;
   q.queue_id = qcfg.common_.id_;
   q.poll_mode = qcfg.poll_mode_;
+  q.accurate_send = intf.tx_.accurate_send_;
+  q.timestamp_format = intf.tx_.hardware_timestamp_format_;
   q.batch_size = q.poll_mode == QueuePollMode::DIRECT ? 1 : std::max(1, qcfg.common_.batch_size_);
   if (!qcfg.common_.cpu_core_.empty()) {
     q.cpu_core = std::stoi(qcfg.common_.cpu_core_);

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.h
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.h
@@ -299,6 +299,8 @@ struct IbvTxQueue {
   std::vector<uint64_t> wqe_slot_cum;
   std::vector<uint64_t> wqe_wqebb_cum;
   uint64_t slots_posted = 0;
+  bool accurate_send = false;
+  TxTimestampFormat timestamp_format = TxTimestampFormat::DEVICE_CLOCK_TICKS;
   bool send_scheduling = false;  // HCA wait_on_time present + real-time clock
   uint64_t rt_timemask = 0;      // wait segment comparison mask
   bool empw_enabled = false;


### PR DESCRIPTION
## Summary

- select the raw-ibverbs send CQ timestamp domain from TX configuration
- preserve device-clock ticks as the default
- request a wall-clock send CQ so mlx5 interprets WAIT values in its UTC domain when `nanoseconds` is selected

## Motivation

mlx5 derives the WAIT-on-time clock domain from the send CQ. Epoch nanoseconds must use a wall-clock CQ and mlx5 UTC encoding; otherwise the scheduled timestamp is interpreted in the legacy device-clock domain.

## Compatibility

Existing callers keep the historical device-clock behavior. Epoch/PTP scheduling is opt-in through `tx.hardware_timestamp_format: nanoseconds`.

## Testing

- built `daqiri_common`, `daqiri_dpdk`, and `daqiri_ibverbs` in the CUDA 13.3 Aerial x86 container
- validated epoch-timed transmit in full 22-queue raw-ibverbs hardware runs