### PR TITLE
Flush raw-ibverbs BlueFlame writes

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -419,6 +419,14 @@ for the configuration constraints and
 [C++ API Usage → Reordered RX bursts](api-reference/cpp.md#reordered-rx-bursts)
 for how to consume them from C++.
 
+### Raw ibverbs BlueFlame ordering
+
+Raw ibverbs transmit posting copies each control segment to the mlx5 BlueFlame
+write-combining mapping. DAQIRI issues the required write-combining flush before
+reusing the alternating BlueFlame offset, ensuring the device observes one
+complete doorbell record before the next record can overwrite it.
+
+
 ## See also
 
 - [API Guide](api-reference/index.md): the 6-step DAQIRI application

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -142,6 +142,20 @@ static inline void doorbell_store_barrier() {
 #endif
 }
 
+// Flush writes to the BlueFlame write-combining MMIO mapping. A DMA/store
+// barrier orders descriptors and the doorbell record, but on Arm it does not
+// guarantee that a WC MMIO write has reached the device before the BF offset
+// is reused. Match rdma-core's mmio_wc_start()/mmio_flush_writes() contract.
+static inline void doorbell_mmio_flush() {
+#if defined(__aarch64__)
+  asm volatile("dsb st" ::: "memory");
+#elif defined(__x86_64__) || defined(__i386__)
+  asm volatile("sfence" ::: "memory");
+#else
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+#endif
+}
+
 static void append_bytes(std::vector<uint8_t>& dst, const void* src, size_t len) {
   const auto* bytes = static_cast<const uint8_t*>(src);
   dst.insert(dst.end(), bytes, bytes + len);
@@ -4846,9 +4860,10 @@ void IbverbsEngine::post_tx_burst_empw(IbvTxQueue& q, BurstParams* burst) {
   doorbell_store_barrier();
   q.dv_qp.dbrec[MLX5_SND_DBR] = htobe32(static_cast<uint32_t>(q.sq_pi) & 0xffff);
   doorbell_store_barrier();
+  doorbell_mmio_flush();
   *reinterpret_cast<volatile uint64_t*>(static_cast<uint8_t*>(q.dv_qp.bf.reg) + q.bf_offset) =
       *reinterpret_cast<uint64_t*>(last_ctrl);
-  doorbell_store_barrier();
+  doorbell_mmio_flush();
   q.bf_offset ^= q.dv_qp.bf.size;
 }
 
@@ -4924,9 +4939,10 @@ void IbverbsEngine::post_tx_burst(IbvTxQueue& q, BurstParams* burst) {
   doorbell_store_barrier();  // WQEs visible before the doorbell record
   q.dv_qp.dbrec[MLX5_SND_DBR] = htobe32(static_cast<uint32_t>(q.sq_pi) & 0xffff);
   doorbell_store_barrier();  // doorbell record visible before the BF write
+  doorbell_mmio_flush();
   *reinterpret_cast<volatile uint64_t*>(static_cast<uint8_t*>(q.dv_qp.bf.reg) + q.bf_offset) =
       *reinterpret_cast<uint64_t*>(last_ctrl);
-  doorbell_store_barrier();
+  doorbell_mmio_flush();
   q.bf_offset ^= q.dv_qp.bf.size;
 }
 


### PR DESCRIPTION
## Summary

- add an architecture-specific write-combining MMIO flush helper
- order the mlx5 doorbell record and BlueFlame write
- flush the BlueFlame write before reusing the alternating BF offset
- document the write-combining ordering requirement

## Motivation

A DMA/store barrier orders descriptors and the doorbell record but does not guarantee that a write-combining MMIO store has reached the device. This is observable on Arm when the BlueFlame offset is reused quickly.

## Testing

- built `daqiri_common`, `daqiri_dpdk`, and `daqiri_ibverbs` in the CUDA 13.3 Aerial x86 container
- exercised on GH200 during sustained 22-queue raw-ibverbs accurate-TX runs