### PR TITLE
Clarify use of PTP epoch nanoseconds for hardware timestamps

### DIFF
--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -345,12 +345,12 @@ a template table.
 
 ### Hardware Timestamps
 
-`rx.hardware_timestamps:` Enable per-packet hardware RX timestamps for Raw Ethernet
-(`stream_type: "raw"`).
-When enabled, DAQIRI requires `RTE_ETH_RX_OFFLOAD_TIMESTAMP` support from the NIC/PMD and
-initialization fails if DAQIRI cannot provide nanosecond timestamps for the selected PMD.
-Timestamps are returned by `get_packet_rx_timestamp()` in nanoseconds in the NIC timestamp
-clock domain, not wall-clock time.
+`rx.hardware_timestamps:` Enable per-packet hardware RX timestamps.
+When enabled, DAQIRI requires hardware timestamp support from the NIC and driver.
+Timestamps returned by `get_packet_rx_timestamp()` are unsigned 64-bit PTP epoch
+nanoseconds in the same clock domain as a PTP-synchronized `CLOCK_REALTIME`.
+**WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
+configuration. Timestamp values are invalid if the clocks are not PTP-synchronized.
 
 - type: `boolean`
 - default: `false`
@@ -512,8 +512,12 @@ pre-encap (TX) frame.
 
 ### Accurate Send
 
-`tx.accurate_send:` Enable hardware-timed packet transmission using PTP timestamps. When
-enabled, use `set_packet_tx_time()` to schedule packets. Requires ConnectX-7 or later.
+`tx.accurate_send:` Enable hardware-timed packet transmission. When enabled, use
+`set_packet_tx_time()` to schedule packets. The supplied timestamp is always an unsigned
+64-bit PTP epoch-nanosecond value in the same clock domain as a PTP-synchronized
+`CLOCK_REALTIME`. **WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or
+system clock configuration. Scheduled transmission is invalid if the clocks are not
+PTP-synchronized. Requires ConnectX-7 or later.
 
 - type: `boolean`
 - default: `false`

--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -111,18 +111,19 @@ for (int i = 0; i < daqiri::get_num_packets(burst); i++) {
     daqiri::FlowId flow = daqiri::get_packet_flow_id(burst, i);
     uint64_t rx_ts_ns = 0;
     if (daqiri::get_packet_rx_timestamp(burst, i, &rx_ts_ns) == daqiri::Status::SUCCESS) {
-        // rx_ts_ns is in the NIC timestamp clock domain.
+        // rx_ts_ns is a PTP epoch timestamp in nanoseconds.
     }
     // process packet...
 }
 ```
 
-RX hardware timestamps are available only when Raw Ethernet (`stream_type: "raw"`) is
-configured with `rx.hardware_timestamps: true` and the NIC supports
-`RTE_ETH_RX_OFFLOAD_TIMESTAMP`. DAQIRI converts the NIC timestamp counter to nanoseconds
-internally using the matching device clock when available, or the PMD's nanosecond
-timestamp format when the driver already supplies nanoseconds. DAQIRI does not expose NIC clock reads or
-convert timestamps to wall-clock time. For reordered aggregate bursts,
+RX hardware timestamps are available only when DAQIRI is configured with
+`rx.hardware_timestamps: true` and the NIC and driver support hardware timestamps.
+DAQIRI returns unsigned 64-bit PTP epoch nanoseconds in the same clock domain as
+a PTP-synchronized `CLOCK_REALTIME`. Device-clock ticks are not part of the public API.
+**WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
+configuration. Timestamp values are invalid if the clocks are not PTP-synchronized.
+For reordered aggregate bursts,
 `get_packet_rx_timestamp(burst, 0, &ts)` returns the timestamp of the first source
 packet accepted into the aggregate.
 
@@ -432,8 +433,13 @@ returns `NOT_READY`; zero- or multi-packet direct requests return `INVALID_PARAM
 For precise packet scheduling (requires ConnectX-7+):
 
 ```cpp
-daqiri::set_packet_tx_time(burst, idx, ptp_timestamp);
+daqiri::set_packet_tx_time(burst, idx, ptp_timestamp_ns);
 ```
+
+`ptp_timestamp_ns` is an unsigned 64-bit PTP epoch-nanosecond value in the same clock
+domain as a PTP-synchronized `CLOCK_REALTIME`. Device-clock ticks are not accepted.
+**WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
+configuration. Scheduled transmission is invalid if the clocks are not PTP-synchronized.
 
 ## Writing Bursts to Storage
 

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -215,11 +215,12 @@ flow    = daqiri.get_packet_flow_id(burst, idx)
 status, rx_ts_ns = daqiri.get_packet_rx_timestamp(burst, idx)
 ```
 
-RX hardware timestamps are available only when the DPDK engine is configured
-with `rx.hardware_timestamps: true` and the NIC supports
-`RTE_ETH_RX_OFFLOAD_TIMESTAMP`. See
-[C++ API Usage → Receiving Packets](cpp.md#receiving-packets) for the clock
-semantics. The Python wrapper exposes the same timestamps in nanoseconds.
+RX hardware timestamps are available only when DAQIRI is configured with
+`rx.hardware_timestamps: true` and the NIC and driver support hardware timestamps.
+DAQIRI returns unsigned 64-bit PTP epoch nanoseconds in the same clock domain as
+a PTP-synchronized `CLOCK_REALTIME`. Device-clock ticks are not part of the public API.
+**WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
+configuration. Timestamp values are invalid if the clocks are not PTP-synchronized.
 
 `RxQueueConfig.poll_mode` accepts `QueuePollMode.INDIRECT` (the default) or
 `QueuePollMode.DIRECT`. Direct mode is available only on raw ibverbs RX queues and makes the
@@ -377,6 +378,11 @@ For precise packet scheduling (requires ConnectX-7+):
 ```python
 daqiri.set_packet_tx_time(burst, idx, ptp_timestamp_ns)
 ```
+
+`ptp_timestamp_ns` is an unsigned 64-bit PTP epoch-nanosecond value in the same clock
+domain as a PTP-synchronized `CLOCK_REALTIME`. Device-clock ticks are not accepted.
+**WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
+configuration. Scheduled transmission is invalid if the clocks are not PTP-synchronized.
 
 ## Writing Bursts to Storage
 
@@ -549,14 +555,14 @@ The workflow sections above show the common call order and ownership rules.
 | `get_segment_packet_ptr(burst, seg, idx)` | Return segment packet address as an integer. |
 | `get_packet_length(burst, idx)` / `get_segment_packet_length(burst, seg, idx)` | Read packet or segment length. |
 | `get_packet_flow_id(burst, idx)` | Read matched flow ID, or `0` when no flow matched. |
-| `get_packet_rx_timestamp(burst, idx)` | Return `(Status, timestamp_ns)`. |
+| `get_packet_rx_timestamp(burst, idx)` | Return `(Status, timestamp_ns)` with a PTP epoch-nanosecond timestamp. |
 | `copy_buffer_to_packet(burst, idx, data, nbytes=None, src_offset=0, dst_offset=0)` | Copy a Python buffer into segment 0. |
 | `copy_buffer_to_segment_packet(burst, seg, idx, data, nbytes=None, src_offset=0, dst_offset=0)` | Copy a Python buffer into a specific segment. |
 | `get_packet_bytes(burst, idx, nbytes=None, src_offset=0)` | Return `(Status, bytes)` from segment 0. |
 | `get_segment_packet_bytes(burst, seg, idx, nbytes=None, src_offset=0)` | Return `(Status, bytes)` from a segment. |
 | `set_packet_lengths(burst, idx, lens)` | Set segment lengths for one packet. |
 | `set_all_packet_lengths(burst, lens)` | Set segment lengths for every packet. |
-| `set_packet_tx_time(burst, idx, time)` | Set scheduled TX time for one packet. |
+| `set_packet_tx_time(burst, idx, time)` | Set one packet's scheduled TX time as PTP epoch nanoseconds. |
 
 ### RX and Reorder
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -353,6 +353,22 @@ rejects a rule. The YAML options are documented in
 ![Flow steering](images/packet_diagrams/flow_steering/flow-steering.webp)
 </div>
 
+## Timed Transmission and Receive Timestamps
+
+DAQIRI uses PTP epoch nanoseconds in the `CLOCK_REALTIME` domain for both timed
+transmission and receive timestamps.
+
+When hardware receive timestamps are enabled, applications use
+`get_packet_rx_timestamp()` to read each packet's PTP epoch-nanosecond timestamp.
+
+For timed transmission, applications pass the desired PTP epoch-nanosecond value
+directly to `set_packet_tx_time()`.
+
+**WARNING: PTP synchronization is required.** The host and NIC clocks must be
+synchronized, for example with `ptp4l` and `phc2sys`. DAQIRI does not validate
+that synchronization is working. Without it, receive timestamps and scheduled
+transmit times are invalid and may behave unpredictably.
+
 ## Memory Regions
 
 A **memory region** is a named pool of buffers where packet data lives.

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -244,10 +244,11 @@ Status poll_flow_op(FlowOpResult *result);
 /**
  * @brief Get the hardware RX timestamp of a packet in nanoseconds
  *
- * Retrieves the 64-bit receive timestamp for a packet when the DPDK engine
- * was configured with rx.hardware_timestamps enabled and the NIC provided a
- * timestamp for this packet. The value is converted to nanoseconds in the NIC
- * timestamp clock domain; it is not converted to wall-clock or PTP time.
+ * Retrieves the 64-bit receive timestamp for a packet when DAQIRI is configured
+ * with rx.hardware_timestamps enabled and the NIC and driver provide hardware
+ * timestamps as PTP epoch nanoseconds. DAQIRI assumes that the
+ * NIC clock and CLOCK_REALTIME are PTP-synchronized and does not validate
+ * synchronization. The result is invalid without working PTP.
  *
  * @param burst Burst structure containing packets
  * @param idx Index of packet
@@ -405,7 +406,10 @@ Status set_all_packet_lengths(BurstParams *burst,
 /**
  * @brief Set packet TX time
  *
- * Sets the transmit time (in PTP time) to transmit the packet. Every packet
+ * Sets the transmit time, as PTP epoch nanoseconds, to transmit the packet.
+ * DAQIRI assumes that the NIC clock and CLOCK_REALTIME are PTP-synchronized
+ * and does not validate synchronization. Scheduled transmission is invalid
+ * without working PTP. Every packet
  * transmitted after this one in the same queue will be transmitted no earlier
  * than the time listed in the function call. This feature is only available on
  * ConnectX-7 or BlueField 3 and higher cards.

--- a/src/engines/dpdk/daqiri_dpdk_engine.cpp
+++ b/src/engines/dpdk/daqiri_dpdk_engine.cpp
@@ -499,26 +499,19 @@ struct UDPPkt {
   uint8_t payload[];
 } __attribute__((packed));
 
-static inline uint64_t convert_rx_timestamp_ticks_to_ns(uint64_t timestamp,
-                                                        const RxTimestampConversion& conversion) {
-  if (!conversion.valid || conversion.ticks_per_second == 0) { return 0; }
-  const auto ns = (static_cast<unsigned __int128>(timestamp) * 1000000000ULL) /
-                  conversion.ticks_per_second;
-  return static_cast<uint64_t>(ns);
-}
-
+// The DPDK timestamp dynamic field is the public timestamp value: unsigned
+// 64-bit PTP epoch nanoseconds in the PTP-synchronized CLOCK_REALTIME domain.
+// Do not calibrate or scale it. DAQIRI relies on external PTP synchronization
+// and does not validate that synchronization here.
 static inline bool extract_mbuf_rx_timestamp_ns(struct rte_mbuf* mbuf,
                                                 int timestamp_offset,
                                                 uint64_t timestamp_mask,
-                                                const RxTimestampConversion& conversion,
                                                 uint64_t* timestamp_ns) {
   if (mbuf == nullptr || timestamp_ns == nullptr || timestamp_offset < 0 || timestamp_mask == 0) {
     return false;
   }
-  if (!conversion.valid || conversion.ticks_per_second == 0) { return false; }
   if ((mbuf->ol_flags & timestamp_mask) == 0) { return false; }
-  const uint64_t timestamp_ticks = *RTE_MBUF_DYNFIELD(mbuf, timestamp_offset, uint64_t*);
-  *timestamp_ns = convert_rx_timestamp_ticks_to_ns(timestamp_ticks, conversion);
+  *timestamp_ns = *RTE_MBUF_DYNFIELD(mbuf, timestamp_offset, uint64_t*);
   return true;
 }
 
@@ -1144,7 +1137,6 @@ Status DpdkEngine::append_reorder_packet(ReorderPlanRuntime& plan,
         extract_mbuf_rx_timestamp_ns(mbuf,
                                      timestamp_dynfield_offset_,
                                      rx_timestamp_dynflag_mask_,
-                                     rx_timestamp_conversions_[plan.port_id],
                                      &batch.first_packet_rx_timestamp_ns);
     const uint32_t pkt_len = mbuf != nullptr ? mbuf->pkt_len : 0U;
     uint32_t copy_len = 0;
@@ -1879,81 +1871,6 @@ bool DpdkEngine::setup_rx_timestamp_dynfield() {
   return true;
 }
 
-bool DpdkEngine::calibrate_rx_timestamp_clock(uint16_t port_id) {
-  uint64_t start_clock = 0;
-  int ret = rte_eth_read_clock(port_id, &start_clock);
-  if (ret < 0) {
-    rte_eth_dev_info dev_info{};
-    const int info_ret = rte_eth_dev_info_get(port_id, &dev_info);
-    const std::string driver_name =
-        (info_ret == 0 && dev_info.driver_name != nullptr) ? dev_info.driver_name : "";
-    if (ret == -ENOTSUP && driver_name.find("mlx5") != std::string::npos) {
-      rx_timestamp_conversions_[port_id].valid = true;
-      rx_timestamp_conversions_[port_id].ticks_per_second = 1000000000ULL;
-      DAQIRI_LOG_WARN(
-          "rte_eth_read_clock() is not supported on mlx5 port {}; treating PMD-provided "
-          "RX hardware timestamps as nanoseconds",
-          port_id);
-      return true;
-    }
-
-    DAQIRI_LOG_CRITICAL(
-        "RX hardware timestamps require rte_eth_read_clock() for nanosecond conversion, "
-        "but port {} returned err={} ({})",
-        port_id,
-        ret,
-        rte_strerror(-ret));
-    return false;
-  }
-
-  const auto start_time = std::chrono::steady_clock::now();
-  rte_delay_us_block(100000);
-
-  uint64_t end_clock = 0;
-  ret = rte_eth_read_clock(port_id, &end_clock);
-  if (ret < 0) {
-    DAQIRI_LOG_CRITICAL(
-        "RX hardware timestamp clock calibration failed on port {}: err={} ({})",
-        port_id,
-        ret,
-        rte_strerror(-ret));
-    return false;
-  }
-
-  const auto elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                              std::chrono::steady_clock::now() - start_time)
-                              .count();
-  if (elapsed_ns <= 0 || end_clock <= start_clock) {
-    DAQIRI_LOG_CRITICAL(
-        "RX hardware timestamp clock calibration produced an invalid sample on port {} "
-        "(start={}, end={}, elapsed_ns={})",
-        port_id,
-        start_clock,
-        end_clock,
-        elapsed_ns);
-    return false;
-  }
-
-  const uint64_t delta_ticks = end_clock - start_clock;
-  const auto ticks_per_second =
-      (static_cast<unsigned __int128>(delta_ticks) * 1000000000ULL +
-       static_cast<uint64_t>(elapsed_ns / 2)) /
-      static_cast<uint64_t>(elapsed_ns);
-  if (ticks_per_second == 0 ||
-      ticks_per_second > static_cast<unsigned __int128>(std::numeric_limits<uint64_t>::max())) {
-    DAQIRI_LOG_CRITICAL(
-        "RX hardware timestamp clock calibration produced an invalid frequency on port {}",
-        port_id);
-    return false;
-  }
-
-  rx_timestamp_conversions_[port_id].valid = true;
-  rx_timestamp_conversions_[port_id].ticks_per_second = static_cast<uint64_t>(ticks_per_second);
-  DAQIRI_LOG_INFO("Calibrated RX timestamp clock for port {} at {} ticks/second",
-                  port_id,
-                  rx_timestamp_conversions_[port_id].ticks_per_second);
-  return true;
-}
 
 bool DpdkEngine::setup_tx_timestamp_dynfield() {
   static bool done = false;
@@ -1993,14 +1910,8 @@ uint64_t DpdkEngine::now_tx_ns(uint16_t port) {
   // clock, so prefer it.
   uint64_t clk = 0;
   if (rte_eth_read_clock(port, &clk) == 0) {
-    const uint64_t tps =
-        (port < rx_timestamp_conversions_.size() && rx_timestamp_conversions_[port].valid)
-            ? rx_timestamp_conversions_[port].ticks_per_second
-            : 0;
-    // With REAL_TIME_CLOCK_ENABLE the device clock already counts nanoseconds, so
-    // an uncalibrated tps (no RX-timestamp path active) means clk is ns as-is.
-    if (tps == 0 || tps == 1000000000ULL) { return clk; }
-    return static_cast<uint64_t>(static_cast<unsigned __int128>(clk) * 1000000000ULL / tps);
+    // REAL_TIME_CLOCK_ENABLE exposes the NIC PTP clock directly in nanoseconds.
+    return clk;
   }
   // Fallback: rte_eth_read_clock unsupported. The NIC PTP clock free-runs from ~0
   // at driver load (unless a PTP daemon disciplines it), tracking CLOCK_MONOTONIC,
@@ -2759,7 +2670,11 @@ void DpdkEngine::initialize() {
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[4],
                         conf_ports_eth_addr[intf.port_id_].addr_bytes[5]);
 
-      if (rx.hardware_timestamps_ && !calibrate_rx_timestamp_clock(intf.port_id_)) { return; }
+      if (rx.hardware_timestamps_) {
+        DAQIRI_LOG_INFO(
+            "Using driver-provided RX hardware timestamps as PTP epoch nanoseconds on port {}",
+            intf.port_id_);
+      }
 
       // Standard (group 3), flex-item (group 1) and eCPRI (group 2) flows use
       // separate DPDK flow groups with conflicting group-0 jump rules;
@@ -6607,14 +6522,11 @@ Status DpdkEngine::get_packet_rx_timestamp(BurstParams* burst, int idx, uint64_t
 
   if (burst->pkts[0] == nullptr) { return Status::INVALID_PARAMETER; }
   auto* mbuf = reinterpret_cast<rte_mbuf*>(burst->pkts[0][idx]);
-  if (mbuf == nullptr || burst->hdr.hdr.port_id >= rx_timestamp_conversions_.size()) {
-    return Status::INVALID_PARAMETER;
-  }
+  if (mbuf == nullptr) { return Status::INVALID_PARAMETER; }
 
   if (!extract_mbuf_rx_timestamp_ns(mbuf,
                                     timestamp_dynfield_offset_,
                                     rx_timestamp_dynflag_mask_,
-                                    rx_timestamp_conversions_[burst->hdr.hdr.port_id],
                                     timestamp_ns)) {
     return Status::NOT_SUPPORTED;
   }
@@ -6629,6 +6541,9 @@ Status DpdkEngine::set_packet_tx_time(BurstParams* burst, int idx, uint64_t time
   if (timestamp_dynfield_offset_ < 0 || tx_timestamp_dynflag_mask_ == 0) {
     return Status::NOT_SUPPORTED;
   }
+  // Preserve the public PTP epoch-nanosecond value exactly. The mlx5 real-time
+  // clock configuration consumes this linear CLOCK_REALTIME-domain value
+  // directly; DAQIRI performs no tick-rate conversion or synchronization check.
   reinterpret_cast<struct rte_mbuf**>(burst->pkts[0])[idx]->ol_flags |= tx_timestamp_dynflag_mask_;
   *RTE_MBUF_DYNFIELD(
       reinterpret_cast<rte_mbuf**>(burst->pkts[0])[idx],

--- a/src/engines/dpdk/daqiri_dpdk_engine.h
+++ b/src/engines/dpdk/daqiri_dpdk_engine.h
@@ -88,11 +88,6 @@ struct FlexItemHandle {
   struct rte_flow_item_flex_handle* handle;
 };
 
-struct RxTimestampConversion {
-  bool valid = false;
-  uint64_t ticks_per_second = 0;
-};
-
 class DpdkEngine : public Engine {
  public:
   struct DpdkFlowResource;
@@ -187,11 +182,9 @@ class DpdkEngine : public Engine {
   static void flush_port_queue_impl(int port, int queue);
   bool setup_rx_timestamp_dynfield();
   bool setup_tx_timestamp_dynfield();
-  bool calibrate_rx_timestamp_clock(uint16_t port_id);
-  // Current NIC clock for `port` in nanoseconds, for packet-pacing scheduling.
-  // Uses rte_eth_read_clock + the calibrated ticks/sec where supported; falls
-  // back to CLOCK_MONOTONIC (the NIC PTP clock free-runs from driver load unless
-  // a PTP daemon disciplines it, so it tracks CLOCK_MONOTONIC, not CLOCK_REALTIME).
+  // Current NIC PTP clock for packet-pacing scheduling.
+  // REAL_TIME_CLOCK_ENABLE exposes rte_eth_read_clock values as nanoseconds.
+  // Falls back to CLOCK_MONOTONIC when the driver does not support that clock.
   uint64_t now_tx_ns(uint16_t port);
   int setup_pools_and_rings(int max_rx_batch, int max_tx_batch);
   struct rte_flow* add_flow(int port,
@@ -527,7 +520,6 @@ class DpdkEngine : public Engine {
   int timestamp_dynfield_offset_{-1};
   uint64_t rx_timestamp_dynflag_mask_{0};
   uint64_t tx_timestamp_dynflag_mask_{0};
-  std::array<RxTimestampConversion, RTE_MAX_ETHPORTS> rx_timestamp_conversions_{};
   std::array<struct rte_eth_conf, MAX_INTERFACES> local_port_conf;
   DpdkStats stats_;
   struct rte_ring* loopback_ring;


### PR DESCRIPTION
## Summary

- define the public DPDK hardware timestamp contract as linear PTP epoch nanoseconds
- pass accurate-send timestamps directly to the DPDK timestamp dynamic field
- return driver-provided RX timestamps directly as nanoseconds
- remove generic tick conversion and per-port timestamp-frequency state
- perform no runtime clock-synchronization validation or calibration
- prominently document that timestamped I/O requires the NIC clock and `CLOCK_REALTIME` to be PTP-synchronized
- document the PTP clock-domain contract for DPDK and raw ibverbs

## Motivation

DAQIRI documents PTP-synchronized operation, but the DPDK engine left the unit and epoch of its public timestamp values implicit. A fixed linear-nanosecond contract lets callers compare received timestamps with `CLOCK_REALTIME` and schedule packets from that same clock without an engine-specific conversion.

## Compatibility

This is an intentional contract clarification: hardware timestamps are PTP epoch nanoseconds. DAQIRI does not validate that the NIC clock and `CLOCK_REALTIME` are synchronized. Timestamped operation without working PTP is unsupported and may produce incorrect scheduling and latency values. This requirement is documented prominently; DAQIRI performs no runtime validation or warning.

## Testing

- built both raw engines and all C++ examples in the CUDA 13.3 Aerial ARM container
- built the downstream dual-engine integration on ARM and x86
- passed all runnable downstream integration tests on ARM and x86
- validated full four-application, 22-queue bidirectional DPDK traffic with CPU RX memory: zero loss, skips, late events, or timestamp failures
- validated full four-application, 22-queue bidirectional DPDK traffic with GH200 GPU RX memory and the results writer disabled: zero loss, skips, late events, or timestamp failures

This replaces #262 