### PR TITLE
#283 - Gate ibverbs real-time RX timestamps

### DIFF
--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -349,6 +349,10 @@ a template table.
 When enabled, DAQIRI requires hardware timestamp support from the NIC and driver.
 Timestamps returned by `get_packet_rx_timestamp()` are unsigned 64-bit PTP epoch
 nanoseconds in the same clock domain as a PTP-synchronized `CLOCK_REALTIME`.
+The raw ibverbs engine requests the mlx5 real-time CQ timestamp format only when
+the device advertises it; otherwise it uses the default mlx5 device-clock CQ
+format and converts those ticks to nanoseconds internally. Device-clock ticks are
+not exposed by the public API.
 **WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
 configuration. Timestamp values are invalid if the clocks are not PTP-synchronized.
 

--- a/docs/api-reference/cpp.md
+++ b/docs/api-reference/cpp.md
@@ -121,6 +121,10 @@ RX hardware timestamps are available only when DAQIRI is configured with
 `rx.hardware_timestamps: true` and the NIC and driver support hardware timestamps.
 DAQIRI returns unsigned 64-bit PTP epoch nanoseconds in the same clock domain as
 a PTP-synchronized `CLOCK_REALTIME`. Device-clock ticks are not part of the public API.
+On the raw ibverbs engine, DAQIRI requests mlx5 real-time CQ timestamps only when
+the device advertises that format. Devices without that capability stay on the
+default mlx5 device-clock CQ format, and DAQIRI converts those raw ticks to
+nanoseconds before returning them.
 **WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
 configuration. Timestamp values are invalid if the clocks are not PTP-synchronized.
 For reordered aggregate bursts,

--- a/docs/api-reference/python.md
+++ b/docs/api-reference/python.md
@@ -219,6 +219,10 @@ RX hardware timestamps are available only when DAQIRI is configured with
 `rx.hardware_timestamps: true` and the NIC and driver support hardware timestamps.
 DAQIRI returns unsigned 64-bit PTP epoch nanoseconds in the same clock domain as
 a PTP-synchronized `CLOCK_REALTIME`. Device-clock ticks are not part of the public API.
+On the raw ibverbs engine, DAQIRI requests mlx5 real-time CQ timestamps only when
+the device advertises that format. Devices without that capability stay on the
+default mlx5 device-clock CQ format, and DAQIRI converts those raw ticks to
+nanoseconds before returning them.
 **WARNING: PTP synchronization is required.** DAQIRI does not validate the NIC or system clock
 configuration. Timestamp values are invalid if the clocks are not PTP-synchronized.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -365,6 +365,10 @@ transmission and receive timestamps.
 
 When hardware receive timestamps are enabled, applications use
 `get_packet_rx_timestamp()` to read each packet's PTP epoch-nanosecond timestamp.
+Raw ibverbs devices that support mlx5 real-time CQ timestamps produce that
+representation directly; devices without that capability use the default mlx5
+device-clock CQ format, which DAQIRI converts internally before returning the
+timestamp. Applications never handle raw device-clock ticks.
 
 For timed transmission, applications pass the desired PTP epoch-nanosecond value
 directly to `set_packet_tx_time()`.

--- a/include/daqiri/common.h
+++ b/include/daqiri/common.h
@@ -246,8 +246,9 @@ Status poll_flow_op(FlowOpResult *result);
  *
  * Retrieves the 64-bit receive timestamp for a packet when DAQIRI is configured
  * with rx.hardware_timestamps enabled and the NIC and driver provide hardware
- * timestamps as PTP epoch nanoseconds. DAQIRI assumes that the
- * NIC clock and CLOCK_REALTIME are PTP-synchronized and does not validate
+ * timestamps. DAQIRI returns PTP epoch nanoseconds; engines that receive raw
+ * device-clock ticks convert them before returning. DAQIRI assumes that the NIC
+ * clock and CLOCK_REALTIME are PTP-synchronized and does not validate
  * synchronization. The result is invalid without working PTP.
  *
  * @param burst Burst structure containing packets

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -1005,7 +1005,7 @@ Status IbverbsEngine::devx_create_rq(IbvRxQueue& q, uint32_t stride_log, uint32_
     // the public PTP epoch-nanosecond timestamp contract.
     DEVX_SET(rqc, rqc, ts_format, MLX5_RQC_TIMESTAMP_FORMAT_REAL_TIME);
   } else {
-    DAQIRI_LOG_WARN(
+    DAQIRI_LOG_CRITICAL(
         "RX queue {}: real-time CQ timestamps are unsupported; using the device clock format",
         q.queue_id);
   }

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.cpp
@@ -997,17 +997,25 @@ Status IbverbsEngine::devx_create_rq(IbvRxQueue& q, uint32_t stride_log, uint32_
   DEVX_SET(rqc, rqc, cqn, q.dv_cq.cqn);
   DEVX_SET(rqc, rqc, flush_in_error_en, 1);
   DEVX_SET(rqc, rqc, vsd, 1);  // do not strip VLAN
-  // The public timestamp contract is PTP epoch nanoseconds. Request mlx5
-  // real-time CQEs, whose timestamp field uses UTC encoding
-  // (seconds << 32 | nanoseconds).
-  DEVX_SET(rqc, rqc, ts_format, MLX5_RQC_TIMESTAMP_FORMAT_REAL_TIME);
+  struct mlx5dv_context dv_ctx {};
+  q.realtime_timestamps = mlx5dv_query_device(q.ctx, &dv_ctx) == 0 &&
+                          (dv_ctx.flags & MLX5DV_CONTEXT_FLAGS_REAL_TIME_TS) != 0;
+  if (q.realtime_timestamps) {
+    // Real-time CQEs use UTC encoding (seconds << 32 | nanoseconds), matching
+    // the public PTP epoch-nanosecond timestamp contract.
+    DEVX_SET(rqc, rqc, ts_format, MLX5_RQC_TIMESTAMP_FORMAT_REAL_TIME);
+  } else {
+    DAQIRI_LOG_WARN(
+        "RX queue {}: real-time CQ timestamps are unsupported; using the device clock format",
+        q.queue_id);
+  }
 
   DEVX_SET(wq, wq, wq_type, q.striding ? MLX5_WQ_TYPE_CYCLIC_STRIDING_RQ : MLX5_WQ_TYPE_CYCLIC);
   DEVX_SET(wq, wq, log_wq_stride, log2_floor(q.wqe_stride));
   DEVX_SET(wq, wq, log_wq_sz, log2_floor(q.num_wqe));
   DEVX_SET(wq, wq, pd, dvpd.pdn);
-  // WQ page size is encoded relative to the mlx5 4 KiB adapter page, not the
-  // operating-system page size (which is 64 KiB on GH200).
+  // The PRM field is relative to the mlx5 4 KiB adapter page, independent of
+  // the operating-system page size used to register the UMEM.
   DEVX_SET(wq, wq, log_wq_pg_sz, MLX5_ADAPTER_PAGE_SIZE_4_KIB);
   DEVX_SET64(wq, wq, dbr_addr, dbr_off);
   DEVX_SET(wq, wq, dbr_umem_id, q.wq_umem->umem_id);
@@ -3748,6 +3756,10 @@ Status IbverbsEngine::get_packet_rx_timestamp(BurstParams* burst, int idx, uint6
     return Status::INVALID_PARAMETER;
   }
   const uint64_t raw_timestamp = burst_ts_arr(burst)[idx];
+  if (!q->realtime_timestamps) {
+    *timestamp_ns = ts_to_ns(q->ctx, raw_timestamp);
+    return Status::SUCCESS;
+  }
   // mlx5 real-time CQEs use UTC encoding; expose the public API's linear PTP
   // epoch-nanosecond representation.
   const uint64_t seconds = raw_timestamp >> 32;

--- a/src/engines/ibverbs/daqiri_ibverbs_engine.h
+++ b/src/engines/ibverbs/daqiri_ibverbs_engine.h
@@ -198,6 +198,7 @@ struct IbvRxQueue {
   // Direct mlx5dv views (we own the CQ consumer index; rdma-core owns the RQ).
   struct mlx5dv_cq dv_cq {};
   uint32_t cq_ci = 0;  // CQ consumer index (monotonic)
+  bool realtime_timestamps = false;
 
   // Per-WQE stride accounting for the reclaim path. Indexed by WQE/region.
   std::vector<uint32_t> consumed_strides;  // strides handed to the app (verbs path)


### PR DESCRIPTION
Fixes #283.

## Summary

- Request mlx5 real-time CQ timestamps only when `mlx5dv_query_device()` advertises `MLX5DV_CONTEXT_FLAGS_REAL_TIME_TS`.
- Retain the default device-clock CQ format on unsupported devices and convert those timestamps through the existing `mlx5dv_ts_to_ns()` path.
- Preserve the valid #281 RX WQ UMEM access flags, adapter-relative page-size encoding, and reduced 64-stride region geometry.

## Failure and expected behavior

After #281, raw ibverbs RX fails inside `daqiri_init()` before any traffic measurement:

```text
CREATE_RQ (DevX) failed: Remote I/O error (syndrome 0x43d98f)
```

The identical configuration initializes with a pre-#281 image. Raw RX should also initialize on devices whose firmware does not support real-time CQ timestamps; those devices should use the free-running device clock and DAQIRI's existing clock conversion.

## Root cause and isolation

#281 unconditionally set `MLX5_RQC_TIMESTAMP_FORMAT_REAL_TIME` in the DevX RQ context. The affected device does not advertise the corresponding mlx5dv capability, and firmware rejects the unsupported RQ context during `CREATE_RQ`.

The RX-side changes were restored independently in diagnostic container builds:

| Diagnostic change | Result |
| --- | --- |
| Unmodified `main` | `CREATE_RQ` fails, syndrome `0x43d98f` |
| Restore pre-#281 512-stride region geometry | Same failure |
| Restore pre-#281 RX WQ UMEM access flags | Same failure |
| Restore both geometry and UMEM flags | Same failure |
| Omit only the unsupported real-time timestamp request | Initialization succeeds |
| Capability-gated timestamp request with #281 UMEM flags and 64-stride geometry | Initialization succeeds |

Increasing the RX buffer count to restore the old effective queue depth likewise does not change the failure.

The old setup succeeds because it leaves the RQ in the default free-running timestamp format. The corrected setup makes the same choice only when required by device capability; capable devices retain the real-time format and its direct UTC decode.

`log_wq_pg_sz` remains encoded relative to the mlx5 adapter's fixed 4-KiB page, rather than the operating-system page used to align and register the UMEM. This is why the adapter-relative value remains valid on ARM64 kernels using larger pages. The currently reachable validation systems report 4-KiB kernel pages, so a live 64-KiB-kernel confirmation remains explicitly outstanding while this PR is a draft.

## Validation

### Build

The final commit was built and installed successfully with the project container:

```bash
IMAGE_TAG=daqiri:ibverbs-rx-init-fix-final \
BASE_TARGET=dpdk \
DAQIRI_ENGINE="dpdk ibverbs" \
scripts/build-container.sh
```

`git-clang-format --diff origin/main` reports no changes, and `git diff --check` passes.

### Initialization correctness proof

An RX-only raw ibverbs run on the affected hardware created the CQ and 64-stride DevX RQ, installed the flow, started the worker, and exited cleanly after five seconds:

```text
Striding RQ: stride=8192B strides/WQE=64 region=524288B num_wqe=512
real-time CQ timestamps are unsupported; using the device clock format
DevX striding RQ ready
ibverbs backend initialized with 1 RX queue(s), 0 TX queue(s)
RX complete: packets=0 bytes=0 bursts=0
```

The zero-packet RX-only run proves initialization only; it is not a throughput result.

### Physical cross-host completion and throughput proof

A subsequent physical cross-host raw ibverbs TX/RX run used the final fixed image on RX and an unchanged existing ibverbs image on TX. No benchmark configuration or harness semantics were changed.

- Active TX interval: 10.0131 seconds
- Application TX: 14,860,288 packets, 119,833,362,432 bytes
- Application RX: 14,860,288 packets, 119,833,362,432 bytes
- Application payload throughput over the active interval: 95.741 Gb/s TX and RX
- PHY TX delta: 14,860,292 packets, 119,892,804,548 bytes
- PHY RX delta: 14,860,292 packets, 119,892,804,548 bytes
- The four extra PHY packets and 964 bytes are background control traffic; the data-packet PHY byte count is exactly the application packet count multiplied by the 8,068-byte wire frame.
- Stable one-second physical samples were approximately 97.0-97.4 Gb/s TX and 96.6-97.3 Gb/s RX.
- RX `out_of_buffer` remained flat; CQ errors and application-ring-full drops were zero.

This physical run proves that the corrected RX path receives and completes cross-host traffic at line-rate-class load. It is separate from the initialization proof and does not update or replace the published performance tables.

## Environment

- ARM64 NVIDIA DGX Spark
- Ubuntu 24.04.4 LTS
- Kernel `6.17.0-1014-nvidia`
- NVIDIA ConnectX-7 MT2910 family (`15b3:1021`)
- Firmware `28.45.4028`
- rdma-core/libibverbs/providers `2407mlnx52-1.2407061`

## Regression coverage

The failure occurs in device firmware during DevX object creation and there is no hardware-backed unit-test framework in the repository. The initialization and physical cross-host procedures above provide the regression check for this draft. A live run on a 64-KiB ARM64 kernel remains the only outstanding validation item.

## Scope

This PR changes only the ibverbs raw-RX timestamp-format selection and matching decode path. It does not alter TCP/socket behavior, benchmark documentation, published performance tables, or cross-host harness semantics.
