### PR TITLE
#294 - Fix RDMA client queue indexing

### DIFF
--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -172,6 +172,12 @@ engine.
   - type: `string`
   - values: `RC` (Reliable Connected), `UC` (Unreliable Connected)
 
+Each RoCE client connection consumes a TX queue position on the interface
+selected by `socket_config.local_addr`. Queue positions are scoped per interface:
+the first connection on each interface uses position 0, while further connections
+on that interface use the next free position. A connection fails with
+`NO_SPACE_AVAILABLE` when that interface has no free TX queue.
+
 ## Receive Configuration (rx)
 
 ### Queues

--- a/docs/api-reference/configuration.md
+++ b/docs/api-reference/configuration.md
@@ -172,11 +172,15 @@ engine.
   - type: `string`
   - values: `RC` (Reliable Connected), `UC` (Unreliable Connected)
 
-Each RoCE client connection consumes a TX queue position on the interface
-selected by `socket_config.local_addr`. Queue positions are scoped per interface:
-the first connection on each interface uses position 0, while further connections
-on that interface use the next free position. A connection fails with
-`NO_SPACE_AVAILABLE` when that interface has no free TX queue.
+Each RoCE client connection uses one TX queue from the interface whose `address`
+field matches the connection's local IP address. An application can choose that
+local IP by passing a source address to `rdma_connect_to_server`. If it does not,
+Linux chooses the local IP and network interface it would normally use to reach the
+server.
+Queue positions are independent for each interface: the first connection through
+an interface uses position 0, and later connections through the same interface use
+the lowest unused position. A connection fails with `NO_SPACE_AVAILABLE` when all
+TX queues on that interface are already in use.
 
 ## Receive Configuration (rx)
 

--- a/src/engines/rdma/daqiri_rdma_engine.cpp
+++ b/src/engines/rdma/daqiri_rdma_engine.cpp
@@ -21,6 +21,7 @@
 #include <unistd.h>
 #include <mqueue.h>
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -29,6 +30,7 @@
 #include "src/daqiri_pool.h"
 #include "src/metrics.h"
 #include "daqiri_rdma_engine.h"
+#include "rdma_queue_index.h"
 
 /* The ordering of most RDMA/CM setup follows the ordering specified here:
    https://man7.org/linux/man-pages/man7/rdma_cm.7.html
@@ -40,6 +42,17 @@ namespace daqiri {
 std::atomic<bool> rdma_force_quit = false;
 
 namespace {
+
+constexpr std::array<detail::RdmaClientQueueAssignment, 1> kQueueOnInterfaceZero{{{0, 0}}};
+static_assert(detail::first_available_rdma_client_queue(1, 1, kQueueOnInterfaceZero) == 0);
+static_assert(detail::first_available_rdma_client_queue(0, 2, kQueueOnInterfaceZero) == 1);
+
+constexpr std::array<detail::RdmaClientQueueAssignment, 2> kQueuesZeroAndTwo{{{0, 0}, {0, 2}}};
+static_assert(detail::first_available_rdma_client_queue(0, 3, kQueuesZeroAndTwo) == 1);
+
+constexpr std::array<detail::RdmaClientQueueAssignment, 2> kTwoQueuesOnInterfaceZero{
+    {{0, 0}, {0, 1}}};
+static_assert(detail::first_available_rdma_client_queue(0, 2, kTwoQueuesOnInterfaceZero) == -1);
 
 void reset_rdma_burst_metadata(BurstParams* burst) {
   if (burst == nullptr) { return; }
@@ -1115,23 +1128,45 @@ Status RdmaEngine::rdma_connect_to_server(const std::string& dst_addr, uint16_t 
     return Status::INVALID_PARAMETER;
   }
 
-  // Construct the params directly in the map using try_emplace
-  client_params_mutex_.lock();
-  auto [iter, inserted] = client_q_params_.try_emplace(cm_id);
+  rdma_thread_params* params = nullptr;
+  bool queue_exhausted = false;
+  {
+    std::lock_guard<std::mutex> lock(client_params_mutex_);
+    std::vector<detail::RdmaClientQueueAssignment> assignments;
+    assignments.reserve(client_q_params_.size());
+    for (const auto& entry : client_q_params_) {
+      assignments.push_back({entry.second.if_idx, entry.second.queue_idx});
+    }
 
-  if (!inserted) {
-    client_params_mutex_.unlock();
-    DAQIRI_LOG_CRITICAL("Failed to insert client params into map");
-    return Status::CONNECT_FAILURE;
+    // queue_idx addresses the queue vector on one interface, so reserve the
+    // lowest free index on that interface rather than using the global client count.
+    const auto queue_count = cfg_.ifs_[client_port].tx_.queues_.size();
+    const int queue_idx =
+        detail::first_available_rdma_client_queue(client_port, queue_count, assignments);
+    queue_exhausted = queue_idx < 0;
+    if (!queue_exhausted) {
+      auto [iter, inserted] = client_q_params_.try_emplace(cm_id);
+      if (inserted) {
+        params = &iter->second;
+        params->client_id = cm_id;
+        params->pd = pd_map_[cm_id->verbs];
+        params->if_idx = client_port;
+        params->queue_idx = queue_idx;
+      }
+    }
   }
 
-  auto& params = iter->second;
-  params.client_id = cm_id;
-  params.pd = pd_map_[cm_id->verbs];
-  params.if_idx = client_port;
-  params.queue_idx = client_q_params_.size() - 1;
-  client_params_mutex_.unlock();
-  setup_thread_params(&params, false);
+  if (params == nullptr) {
+    if (queue_exhausted) {
+      DAQIRI_LOG_ERROR("No available client TX queue for source address {}", source_addr_str);
+    } else {
+      DAQIRI_LOG_CRITICAL("Failed to insert client params into map");
+    }
+    rdma_destroy_id(cm_id);
+    rdma_destroy_event_channel(ec);
+    return queue_exhausted ? Status::NO_SPACE_AVAILABLE : Status::CONNECT_FAILURE;
+  }
+  setup_thread_params(params, false);
 
   // Set up connection parameters
   memset(&conn_param, 0, sizeof(conn_param));
@@ -1142,7 +1177,7 @@ Status RdmaEngine::rdma_connect_to_server(const std::string& dst_addr, uint16_t 
   // Connect to server
   if (rdma_connect(cm_id, &conn_param) != 0) {
     DAQIRI_LOG_CRITICAL("Failed to connect to server");
-    destroy_thread_params(&params);
+    destroy_thread_params(params);
     rdma_destroy_event_channel(ec);
     return Status::CONNECT_FAILURE;
   } else {
@@ -1152,7 +1187,7 @@ Status RdmaEngine::rdma_connect_to_server(const std::string& dst_addr, uint16_t 
   // Wait for connection established event
   if (rdma_get_cm_event(ec, &event)) {
     DAQIRI_LOG_CRITICAL("Failed to get CM event");
-    destroy_thread_params(&params);
+    destroy_thread_params(params);
     rdma_destroy_event_channel(ec);
     return Status::CONNECT_FAILURE;
   }
@@ -1166,7 +1201,7 @@ Status RdmaEngine::rdma_connect_to_server(const std::string& dst_addr, uint16_t 
     }
     rdma_ack_cm_event(event);
     rdma_destroy_event_channel(ec);
-    destroy_thread_params(&params);
+    destroy_thread_params(params);
     return Status::CONNECT_FAILURE;
   } else {
     DAQIRI_LOG_INFO("Client {} established connection to server", (void*)cm_id);
@@ -1178,7 +1213,7 @@ Status RdmaEngine::rdma_connect_to_server(const std::string& dst_addr, uint16_t 
 
   // Store the connection ID for later use
   threads_mutex_.lock();
-  worker_threads_[cm_id] = std::thread(&RdmaEngine::rdma_thread, this, false, &params);
+  worker_threads_[cm_id] = std::thread(&RdmaEngine::rdma_thread, this, false, params);
   threads_mutex_.unlock();
 
   *conn_id = reinterpret_cast<uintptr_t>(cm_id);

--- a/src/engines/rdma/rdma_queue_index.h
+++ b/src/engines/rdma/rdma_queue_index.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace daqiri::detail {
+
+struct RdmaClientQueueAssignment {
+  int interface_index;
+  int queue_index;
+};
+
+template <typename Assignments>
+constexpr int first_available_rdma_client_queue(int interface_index, std::size_t queue_count,
+                                                const Assignments& assignments) {
+  for (std::size_t candidate = 0; candidate < queue_count; ++candidate) {
+    bool occupied = false;
+    for (const auto& assignment : assignments) {
+      if (assignment.interface_index == interface_index &&
+          assignment.queue_index == static_cast<int>(candidate)) {
+        occupied = true;
+        break;
+      }
+    }
+    if (!occupied) {
+      return static_cast<int>(candidate);
+    }
+  }
+  return -1;
+}
+
+}  // namespace daqiri::detail


### PR DESCRIPTION
Fixes #294.

## Summary

- Allocate RoCE client queue positions independently on each source interface, using the lowest free TX queue position.
- Return `NO_SPACE_AVAILABLE` and release unattached RDMA-CM objects when an interface has no free client TX queue.
- Compile regression assertions for independent interfaces, multiple connections on one interface, gap reuse, and exhaustion.
- Document the per-interface RoCE client queue semantics.

## Scope

This PR fixes only RDMA client queue selection. It does not change the public API or configuration schema, and it does not address multi-role benchmark orchestration, concurrent RDMA-CM setup, or the separate RoCE plus GPU-workload performance investigation.

The configuration reference is the only user-facing documentation affected: engine selection, build options, and tutorial workflows are unchanged.

## Validation

- `git-clang-format --style file` — clean
- Exact queue-selection helper probe built with C++17, `-Wall -Wextra -Werror` — passed
- Release build with `DAQIRI_ENGINE=ibverbs` in the project GPU container, privileged with host hugepages mounted — passed without compiler warnings or errors
- `python3 scripts/check_doc_refs.py` — passed
- MkDocs build — passed; only the pre-existing missing generated WebP warnings remain
- `python3 scripts/check_html_links.py /tmp/daqiri-294-site` — passed
- `git diff --check` — passed

## Review status

Issue #294 still requires DAQIRI engineer approval before code review. Keep this PR in draft until that approval is recorded.
